### PR TITLE
Use official changesets action for release PRs

### DIFF
--- a/.github/workflows/sync_version-packages.yml
+++ b/.github/workflows/sync_version-packages.yml
@@ -40,13 +40,43 @@ jobs:
         run: yarn --immutable
 
       - name: Create Release Pull Request
-        uses: backstage/changesets-action@a39baf18913e669734ffb00c2fd9900472cfa240 # v2.3.2
+        id: changesets
+        uses: changesets/action@a45c4d594aa4e2c509dc14a9f2b3b67ba3780d0d # v1.9.0
         with:
+          github-token: ${{ secrets.GH_SERVICE_ACCOUNT_TOKEN }}
           # Calls out to `changeset version`, but also runs prettier
           version: yarn release
+          commit: |-
+            Version Packages
+
+            Signed-off-by: github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>
+            Generated-by: changesets/action
         env:
-          GITHUB_TOKEN: ${{ secrets.GH_SERVICE_ACCOUNT_TOKEN }}
           HUSKY: '0'
+
+      - name: Link Next Release Changelog
+        if: ${{ steps.changesets.outputs.pullRequestNumber != '' }}
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
+        with:
+          github-token: ${{ secrets.GH_SERVICE_ACCOUNT_TOKEN }}
+          script: |
+            const fs = require('node:fs');
+            const { isNextReleaseVersion } = require('./scripts/create-release-changelog');
+            const packageJson = JSON.parse(fs.readFileSync('package.json', 'utf8'));
+            if (!isNextReleaseVersion(packageJson.version)) {
+              core.info(`Keeping the generated pull request body for stable release ${packageJson.version}`);
+              return;
+            }
+            const changelogPath = `docs/releases/v${packageJson.version}-changelog.md`;
+            const pull_number = Number('${{ steps.changesets.outputs.pullRequestNumber }}');
+            const { stdout } = await exec.getExecOutput('git', ['rev-parse', 'HEAD']);
+            const releaseCommit = stdout.trim();
+            const body = `See [${changelogPath}](https://github.com/${context.repo.owner}/${context.repo.repo}/blob/${releaseCommit}/${changelogPath}) for more information.`;
+            await github.rest.pulls.update({
+              ...context.repo,
+              pull_number,
+              body,
+            });
 
       - name: Discord notification
         if: ${{ failure() }}

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "prepare": "husky",
     "prettier:check": "prettier --check .",
     "prettier:fix": "prettier --write .",
-    "release": "node scripts/prepare-release.js && changeset version && yarn prettier --write '{packages,plugins}/*/{package.json,CHANGELOG.md}' '.changeset/*.json' && yarn install --no-immutable",
+    "release": "node scripts/prepare-release.js && changeset version && yarn prettier --write '{packages,plugins}/*/{package.json,CHANGELOG.md}' '.changeset/*.json' && node scripts/create-release-changelog.js && yarn install --no-immutable",
     "snyk:test": "npx snyk test --yarn-workspaces --strict-out-of-sync=false",
     "snyk:test:package": "yarn snyk:test --include",
     "start": "backstage-cli repo start",

--- a/scripts/create-release-changelog.js
+++ b/scripts/create-release-changelog.js
@@ -1,0 +1,154 @@
+#!/usr/bin/env node
+/* eslint-disable @backstage/no-undeclared-imports */
+/*
+ * Copyright 2026 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+const { execFile: execFileCallback } = require('node:child_process');
+const fs = require('node:fs/promises');
+const path = require('node:path');
+const { promisify } = require('node:util');
+const { getPackages } = require('@manypkg/get-packages');
+const prettier = require('prettier');
+
+const execFile = promisify(execFileCallback);
+const bumpLevels = { patch: 1, minor: 2, major: 3 };
+
+function isNextReleaseVersion(version) {
+  return version.includes('-next.');
+}
+
+function getChangelogEntry(changelog, version) {
+  const heading = `## ${version}`;
+  const start = changelog.split(/\r?\n/).findIndex(line => line === heading);
+
+  if (start === -1) {
+    return undefined;
+  }
+
+  const lines = changelog.split(/\r?\n/);
+  let end = lines.findIndex(
+    (line, index) => index > start && /^## /.test(line),
+  );
+  if (end === -1) {
+    end = lines.length;
+  }
+
+  const content = lines
+    .slice(start + 1, end)
+    .join('\n')
+    .trim();
+  const highestLevel = [
+    ...content.matchAll(/^### (Major|Minor|Patch) Changes$/gim),
+  ]
+    .map(match => bumpLevels[match[1].toLowerCase()])
+    .reduce((highest, level) => Math.max(highest, level), 0);
+
+  return { content, highestLevel };
+}
+
+function sortEntries(a, b) {
+  if (a.private !== b.private) {
+    return a.private ? 1 : -1;
+  }
+  return b.highestLevel - a.highestLevel;
+}
+
+async function readVersionAtHead(rootDir, packageDir) {
+  const packagePath = path
+    .relative(rootDir, path.join(packageDir, 'package.json'))
+    .split(path.sep)
+    .join('/');
+  try {
+    const { stdout } = await execFile('git', ['show', `HEAD:${packagePath}`], {
+      cwd: rootDir,
+    });
+    return JSON.parse(stdout).version;
+  } catch (error) {
+    if (error.stderr?.includes('exists on disk, but not in')) {
+      return undefined;
+    }
+    throw error;
+  }
+}
+
+async function createReleaseChangelog(rootDir = process.cwd()) {
+  const { packages } = await getPackages(rootDir);
+  const entries = [];
+
+  for (const pkg of packages) {
+    const previousVersion = await readVersionAtHead(rootDir, pkg.dir);
+    if (previousVersion === pkg.packageJson.version) {
+      continue;
+    }
+
+    const changelog = await fs.readFile(
+      path.join(pkg.dir, 'CHANGELOG.md'),
+      'utf8',
+    );
+    const entry = getChangelogEntry(changelog, pkg.packageJson.version);
+    if (!entry) {
+      throw new Error(
+        `Could not find changelog entry for ${pkg.packageJson.name}@${pkg.packageJson.version}`,
+      );
+    }
+
+    entries.push({
+      ...entry,
+      private: Boolean(pkg.packageJson.private),
+      content: `## ${pkg.packageJson.name}@${pkg.packageJson.version}\n\n${entry.content}`,
+    });
+  }
+
+  entries.sort(sortEntries);
+
+  const rootPackage = JSON.parse(
+    await fs.readFile(path.join(rootDir, 'package.json'), 'utf8'),
+  );
+  const releaseVersion = rootPackage.version;
+  const changelogPath = path.join(
+    rootDir,
+    'docs',
+    'releases',
+    `v${releaseVersion}-changelog.md`,
+  );
+  const upgradeHelper = `https://backstage.github.io/upgrade-helper/?to=${releaseVersion}`;
+  const markdown = `# Release v${releaseVersion}\n\nUpgrade Helper: [${upgradeHelper}](${upgradeHelper})\n\n${entries
+    .map(entry => entry.content)
+    .join('\n\n')}\n`;
+  const prettierConfig = await prettier.resolveConfig(rootDir);
+  const formatted = prettier.format(markdown, {
+    ...prettierConfig,
+    parser: 'markdown',
+  });
+
+  await fs.mkdir(path.dirname(changelogPath), { recursive: true });
+  await fs.writeFile(changelogPath, formatted);
+  console.log(`Created ${path.relative(rootDir, changelogPath)}`);
+}
+
+if (require.main === module) {
+  createReleaseChangelog().catch(error => {
+    console.error(error);
+    process.exitCode = 1;
+  });
+}
+
+module.exports = {
+  createReleaseChangelog,
+  getChangelogEntry,
+  isNextReleaseVersion,
+  sortEntries,
+};

--- a/scripts/create-release-changelog.test.js
+++ b/scripts/create-release-changelog.test.js
@@ -1,0 +1,154 @@
+/*
+ * Copyright 2026 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+const assert = require('node:assert/strict');
+const { execFileSync } = require('node:child_process');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const { test } = require('node:test');
+
+const { isNextReleaseVersion } = require('./create-release-changelog');
+
+const scriptPath = path.resolve(__dirname, 'create-release-changelog.js');
+
+function writeJson(filePath, value) {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.writeFileSync(filePath, `${JSON.stringify(value, null, 2)}\n`);
+}
+
+function writePackage(repoDir, directory, packageJson, changelog) {
+  writeJson(path.join(repoDir, directory, 'package.json'), packageJson);
+  fs.writeFileSync(path.join(repoDir, directory, 'CHANGELOG.md'), changelog);
+}
+
+test('identifies only next-line release versions', () => {
+  assert.equal(isNextReleaseVersion('1.55.0-next.1'), true);
+  assert.equal(isNextReleaseVersion('1.55.0'), false);
+  assert.equal(isNextReleaseVersion('1.55.1'), false);
+});
+
+test('creates a sorted aggregate changelog for changed packages', t => {
+  const repoDir = fs.mkdtempSync(
+    path.join(os.tmpdir(), 'backstage-release-changelog-'),
+  );
+  t.after(() => fs.rmSync(repoDir, { recursive: true, force: true }));
+
+  writeJson(path.join(repoDir, 'package.json'), {
+    name: 'backstage',
+    private: true,
+    version: '1.2.2',
+    workspaces: ['packages/*'],
+  });
+  writePackage(
+    repoDir,
+    'packages/minor',
+    { name: '@backstage/minor', version: '1.0.0' },
+    '# @backstage/minor\n',
+  );
+  writePackage(
+    repoDir,
+    'packages/patch',
+    { name: '@backstage/patch', version: '1.0.0' },
+    '# @backstage/patch\n',
+  );
+  writePackage(
+    repoDir,
+    'packages/private',
+    { name: '@backstage/private', private: true, version: '1.0.0' },
+    '# @backstage/private\n',
+  );
+  writePackage(
+    repoDir,
+    'packages/unchanged',
+    { name: '@backstage/unchanged', version: '1.0.0' },
+    '# @backstage/unchanged\n',
+  );
+
+  execFileSync('git', ['init'], { cwd: repoDir });
+  execFileSync('git', ['add', '.'], { cwd: repoDir });
+  execFileSync(
+    'git',
+    [
+      '-c',
+      'user.name=Test',
+      '-c',
+      'user.email=test@example.com',
+      'commit',
+      '-m',
+      'baseline',
+    ],
+    { cwd: repoDir },
+  );
+
+  writeJson(path.join(repoDir, 'package.json'), {
+    name: 'backstage',
+    private: true,
+    version: '1.2.3',
+    workspaces: ['packages/*'],
+  });
+  writePackage(
+    repoDir,
+    'packages/minor',
+    { name: '@backstage/minor', version: '1.1.0' },
+    '# @backstage/minor\n\n## 1.1.0\n\n### Minor Changes\n\n- Add a feature\n\n## 1.0.0\n\n- Old entry\n',
+  );
+  writePackage(
+    repoDir,
+    'packages/patch',
+    { name: '@backstage/patch', version: '1.0.1' },
+    '# @backstage/patch\n\n## 1.0.1\n\n### Patch Changes\n\n- Fix a bug\n',
+  );
+  writePackage(
+    repoDir,
+    'packages/private',
+    { name: '@backstage/private', private: true, version: '2.0.0' },
+    '# @backstage/private\n\n## 2.0.0\n\n### Major Changes\n\n- Internal rewrite\n',
+  );
+  writePackage(
+    repoDir,
+    'packages/new',
+    { name: '@backstage/new', version: '1.0.0' },
+    '# @backstage/new\n\n## 1.0.0\n\n### Patch Changes\n\n- Initial release\n',
+  );
+
+  execFileSync(process.execPath, [scriptPath], {
+    cwd: repoDir,
+    stdio: 'inherit',
+  });
+
+  const output = fs.readFileSync(
+    path.join(repoDir, 'docs/releases/v1.2.3-changelog.md'),
+    'utf8',
+  );
+
+  assert.match(output, /^# Release v1\.2\.3/m);
+  assert.match(
+    output,
+    /https:\/\/backstage\.github\.io\/upgrade-helper\/\?to=1\.2\.3/,
+  );
+  assert.ok(
+    output.indexOf('## @backstage/minor@1.1.0') <
+      output.indexOf('## @backstage/patch@1.0.1'),
+  );
+  assert.ok(
+    output.indexOf('## @backstage/patch@1.0.1') <
+      output.indexOf('## @backstage/private@2.0.0'),
+  );
+  assert.doesNotMatch(output, /@backstage\/unchanged/);
+  assert.doesNotMatch(output, /Old entry/);
+  assert.match(output, /## @backstage\/new@1\.0\.0/);
+});


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Move the release PR workflow to the official changesets/action v1.9.0. The Backstage-specific aggregate release changelog generation now lives in a focused, tested repository script. A follow-up workflow step keeps the compact changelog link for next-line releases only; stable release PRs retain the official generated body until maintainers replace it with the curated mainline release notes.

The generated version commit includes a valid DCO sign-off in stable and prerelease mode. No changeset is needed because this only changes repository release automation.

Context: backstage/changesets-action#22 narrows the remaining fork to the versionBranch capability used by community-plugins.

Smoke-tested in a disposable private repository using real release PR synchronization:

- Stable release: official detailed PR body, aggregate changelog, and signed generated commit.
- Next release: compact aggregate-changelog link targeting the exact generated commit.
- Nested community workspace: custom `versionBranch`, workspace-only file changes, package summary, and signed generated commit.

The next-release smoke test exposed an eventual-consistency race when reading the PR head immediately after the action force-pushed it. The link step now takes the immutable commit SHA from the generated checkout's `HEAD`, rather than a potentially stale pull-request API response.

#### :heavy_check_mark: Checklist

- [ ] A changeset describing the change and affected packages. (Not applicable: release automation only)
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (not applicable)
- [x] All your commits have a Signed-off-by line in the message.
