### PR TITLE
fix(scaffolder): fix duplicate stream logs when switching tabs

### DIFF
--- a/.changeset/fix-scaffolder-sse-teardown.md
+++ b/.changeset/fix-scaffolder-sse-teardown.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-scaffolder-common': patch
+---
+
+Fixed a connection leak in the scaffolder event stream where unsubscribing did not abort the underlying SSE connection. Also changed unexpected server disconnects to signal an error instead of silently completing, enabling consumers to retry.

--- a/.changeset/fix-scaffolder-stream-reconnect.md
+++ b/.changeset/fix-scaffolder-stream-reconnect.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-scaffolder-react': patch
+---
+
+Fixed several issues with scaffolder task event stream reconnection: retry timers are now properly cancelled on cleanup, concurrent reconnect attempts are guarded against, and tab visibility changes reconnect the stream using the last seen event cursor without re-fetching the task.

--- a/plugins/scaffolder-common/src/ScaffolderClient.test.ts
+++ b/plugins/scaffolder-common/src/ScaffolderClient.test.ts
@@ -123,7 +123,9 @@ describe('api', () => {
           {
             fetch: fetchApi.fetch,
             onmessage: expect.any(Function),
+            onclose: expect.any(Function),
             onerror: expect.any(Function),
+            openWhenHidden: true,
             signal: expect.any(AbortSignal),
           },
         );
@@ -143,6 +145,85 @@ describe('api', () => {
           createdAt: '',
           body: { message: 'Finished!' },
         });
+      });
+
+      it('should append the after cursor to the eventstream URL', async () => {
+        mockFetchEventSource.mockImplementation(async (_url, options) => {
+          options.onmessage?.({
+            id: '',
+            event: 'completion',
+            data: '{"id":1,"taskId":"a-random-id","type":"completion","createdAt":"","body":{"message":"Done"}}',
+          });
+        });
+
+        await new Promise<void>(complete => {
+          apiClient
+            .streamLogs({ taskId: 'a-random-task-id', after: 42 })
+            .subscribe({ complete });
+        });
+
+        expect(mockFetchEventSource).toHaveBeenCalledWith(
+          'http://backstage/api/v2/tasks/a-random-task-id/eventstream?after=42',
+          expect.any(Object),
+        );
+      });
+
+      it('should abort the connection when unsubscribing', async () => {
+        let capturedSignal: AbortSignal | undefined;
+
+        mockFetchEventSource.mockImplementation(async (_url, options) => {
+          capturedSignal = options.signal as AbortSignal;
+          // Simulate a long-lived connection that never completes
+          await new Promise(() => {});
+        });
+
+        const subscription = apiClient
+          .streamLogs({ taskId: 'a-random-task-id' })
+          .subscribe({});
+
+        // Wait for fetchEventSource to be called
+        await new Promise(resolve => setTimeout(resolve, 0));
+
+        expect(capturedSignal?.aborted).toBe(false);
+        subscription.unsubscribe();
+        expect(capturedSignal?.aborted).toBe(true);
+      });
+
+      it('should emit an error when the server closes the connection', async () => {
+        mockFetchEventSource.mockImplementation(async (_url, options) => {
+          options.onclose?.();
+        });
+
+        const error = await new Promise<Error>(resolve => {
+          apiClient
+            .streamLogs({ taskId: 'a-random-task-id' })
+            .subscribe({ error: resolve });
+        });
+
+        expect(error.message).toBe('SSE connection closed unexpectedly');
+      });
+
+      it('should emit an error and abort when onerror is called', async () => {
+        let capturedSignal: AbortSignal | undefined;
+        const testError = new Error('connection refused');
+
+        mockFetchEventSource.mockImplementation(async (_url, options) => {
+          capturedSignal = options.signal as AbortSignal;
+          try {
+            options.onerror?.(testError);
+          } catch {
+            // onerror throws to prevent the library's built-in retry
+          }
+        });
+
+        const error = await new Promise<Error>(resolve => {
+          apiClient
+            .streamLogs({ taskId: 'a-random-task-id' })
+            .subscribe({ error: resolve });
+        });
+
+        expect(error).toBe(testError);
+        expect(capturedSignal?.aborted).toBe(true);
       });
     });
 

--- a/plugins/scaffolder-common/src/ScaffolderClient.test.ts
+++ b/plugins/scaffolder-common/src/ScaffolderClient.test.ts
@@ -225,6 +225,34 @@ describe('api', () => {
         expect(error).toBe(testError);
         expect(capturedSignal?.aborted).toBe(true);
       });
+
+      it('should not open SSE connection when unsubscribed before discovery resolves', async () => {
+        mockFetchEventSource.mockClear();
+
+        let resolveDiscovery!: (url: string) => void;
+        const client = new ScaffolderClient({
+          scmIntegrationsApi,
+          discoveryApi: {
+            getBaseUrl: () =>
+              new Promise<string>(resolve => {
+                resolveDiscovery = resolve;
+              }),
+          },
+          fetchApi,
+          identityApi,
+        });
+
+        const subscription = client
+          .streamLogs({ taskId: 'a-random-task-id' })
+          .subscribe({});
+
+        subscription.unsubscribe();
+        resolveDiscovery(mockBaseUrl);
+
+        await new Promise(resolve => setTimeout(resolve, 0));
+
+        expect(mockFetchEventSource).not.toHaveBeenCalled();
+      });
     });
 
     describe('longPolling', () => {

--- a/plugins/scaffolder-common/src/ScaffolderClient.ts
+++ b/plugins/scaffolder-common/src/ScaffolderClient.ts
@@ -247,11 +247,14 @@ export class ScaffolderClient implements ScaffolderApi {
         params.set('after', String(Number(after)));
       }
 
+      const ctrl = new AbortController();
+
       this.discoveryApi.getBaseUrl('scaffolder').then(
         baseUrl => {
+          const query = params.toString();
           const url = `${baseUrl}/v2/tasks/${encodeURIComponent(
             taskId,
-          )}/eventstream`;
+          )}/eventstream${query ? `?${query}` : ''}`;
 
           const processEvent = (event: any) => {
             if (event.data) {
@@ -263,10 +266,10 @@ export class ScaffolderClient implements ScaffolderApi {
             }
           };
 
-          const ctrl = new AbortController();
           void fetchEventSource(url, {
             fetch: this.fetchApi.fetch,
             signal: ctrl.signal,
+            openWhenHidden: true,
             onmessage(e: EventSourceMessage) {
               if (e.event === 'log') {
                 processEvent(e);
@@ -279,8 +282,13 @@ export class ScaffolderClient implements ScaffolderApi {
               }
               processEvent(e);
             },
+            onclose() {
+              subscriber.error(new Error('SSE connection closed unexpectedly'));
+            },
             onerror(err) {
+              ctrl.abort();
               subscriber.error(err);
+              throw err;
             },
           });
         },
@@ -288,6 +296,8 @@ export class ScaffolderClient implements ScaffolderApi {
           subscriber.error(error);
         },
       );
+
+      return () => ctrl.abort();
     });
   }
 

--- a/plugins/scaffolder-common/src/ScaffolderClient.ts
+++ b/plugins/scaffolder-common/src/ScaffolderClient.ts
@@ -270,7 +270,7 @@ export class ScaffolderClient implements ScaffolderApi {
             }
           };
 
-          void fetchEventSource(url, {
+          fetchEventSource(url, {
             fetch: this.fetchApi.fetch,
             signal: ctrl.signal,
             openWhenHidden: true,
@@ -294,6 +294,10 @@ export class ScaffolderClient implements ScaffolderApi {
               subscriber.error(err);
               throw err;
             },
+          }).catch(() => {
+            // The throw in onerror is the documented way to stop fetchEventSource
+            // from retrying, but it also rejects this promise. The error is already
+            // forwarded via subscriber.error above, so we consume the rejection here.
           });
         },
         error => {

--- a/plugins/scaffolder-common/src/ScaffolderClient.ts
+++ b/plugins/scaffolder-common/src/ScaffolderClient.ts
@@ -251,6 +251,10 @@ export class ScaffolderClient implements ScaffolderApi {
 
       this.discoveryApi.getBaseUrl('scaffolder').then(
         baseUrl => {
+          if (ctrl.signal.aborted) {
+            return;
+          }
+
           const query = params.toString();
           const url = `${baseUrl}/v2/tasks/${encodeURIComponent(
             taskId,

--- a/plugins/scaffolder-react/src/hooks/useEventStream.test.tsx
+++ b/plugins/scaffolder-react/src/hooks/useEventStream.test.tsx
@@ -1,0 +1,310 @@
+/*
+ * Copyright 2026 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { ReactNode } from 'react';
+import { renderHook, act } from '@testing-library/react';
+import { TestApiProvider } from '@backstage/test-utils';
+import ObservableImpl from 'zen-observable';
+import { LogEvent, ScaffolderTask } from '@backstage/plugin-scaffolder-common';
+import { scaffolderApiRef } from '../api';
+import { useTaskEventStream } from './useEventStream';
+
+function makeTask(overrides: Partial<ScaffolderTask> = {}): ScaffolderTask {
+  return {
+    id: 'test-task-id',
+    status: 'processing',
+    createdAt: '2026-01-01T00:00:00Z',
+    spec: {
+      apiVersion: 'scaffolder.backstage.io/v1beta3',
+      parameters: {},
+      steps: [{ id: 'step-1', name: 'Step 1', action: 'debug:log' }],
+      output: {},
+      ...overrides.spec,
+    } as ScaffolderTask['spec'],
+    ...overrides,
+  };
+}
+
+function makeLogEvent(id: number, message: string): LogEvent {
+  return {
+    id,
+    taskId: 'test-task-id',
+    type: 'log',
+    createdAt: '2026-01-01T00:00:00Z',
+    body: { message, stepId: 'step-1', status: 'processing' },
+  };
+}
+
+describe('useTaskEventStream', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  function setup(mockApi: { getTask: jest.Mock; streamLogs: jest.Mock }) {
+    const wrapper = ({ children }: { children: ReactNode }) => (
+      <TestApiProvider apis={[[scaffolderApiRef, mockApi]]}>
+        {children}
+      </TestApiProvider>
+    );
+    return renderHook(() => useTaskEventStream('test-task-id'), { wrapper });
+  }
+
+  it('flushes buffered logs before tearing down on visibility hide', async () => {
+    let streamSubscriber: ZenObservable.SubscriptionObserver<LogEvent>;
+
+    const mockApi = {
+      getTask: jest.fn().mockResolvedValue(makeTask()),
+      streamLogs: jest.fn().mockImplementation(
+        () =>
+          new ObservableImpl<LogEvent>(subscriber => {
+            streamSubscriber = subscriber;
+          }),
+      ),
+    };
+
+    const { result } = setup(mockApi);
+
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(mockApi.streamLogs).toHaveBeenCalledTimes(1);
+
+    act(() => {
+      streamSubscriber.next(makeLogEvent(1, 'buffered log'));
+    });
+
+    Object.defineProperty(document, 'hidden', {
+      value: true,
+      writable: true,
+      configurable: true,
+    });
+    act(() => {
+      document.dispatchEvent(new Event('visibilitychange'));
+    });
+
+    expect(result.current.stepLogs['step-1']).toContainEqual(
+      expect.stringContaining('buffered log'),
+    );
+
+    Object.defineProperty(document, 'hidden', {
+      value: false,
+      writable: true,
+      configurable: true,
+    });
+    act(() => {
+      document.dispatchEvent(new Event('visibilitychange'));
+    });
+
+    expect(mockApi.streamLogs).toHaveBeenCalledTimes(2);
+    expect(mockApi.streamLogs).toHaveBeenLastCalledWith(
+      expect.objectContaining({ after: 1 }),
+    );
+  });
+
+  it('clears error state when reconnecting after transport error', async () => {
+    let streamSubscriber: ZenObservable.SubscriptionObserver<LogEvent>;
+    const mockApi = {
+      getTask: jest.fn().mockResolvedValue(makeTask()),
+      streamLogs: jest.fn().mockImplementation(
+        () =>
+          new ObservableImpl<LogEvent>(subscriber => {
+            streamSubscriber = subscriber;
+          }),
+      ),
+    };
+
+    const { result } = setup(mockApi);
+
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    act(() => {
+      streamSubscriber.error(new Error('connection refused'));
+    });
+
+    expect(result.current.error?.message).toBe('connection refused');
+    expect(result.current.completed).toBe(true);
+
+    await act(async () => {
+      jest.advanceTimersByTime(15000);
+    });
+
+    expect(result.current.error).toBeUndefined();
+    expect(result.current.completed).toBe(false);
+    expect(mockApi.streamLogs).toHaveBeenCalledTimes(2);
+  });
+
+  it('cleans up stream on unmount even for recoverable tasks', async () => {
+    const unsubscribeSpy = jest.fn();
+    const mockApi = {
+      getTask: jest.fn().mockResolvedValue(
+        makeTask({
+          spec: {
+            apiVersion: 'scaffolder.backstage.io/v1beta3',
+            parameters: {},
+            steps: [{ id: 'step-1', name: 'Step 1', action: 'debug:log' }],
+            output: {},
+            EXPERIMENTAL_recovery: {
+              EXPERIMENTAL_strategy: 'startOver',
+            },
+          } as ScaffolderTask['spec'],
+        }),
+      ),
+      streamLogs: jest.fn().mockImplementation(
+        () =>
+          new ObservableImpl<LogEvent>(() => {
+            return () => unsubscribeSpy();
+          }),
+      ),
+    };
+
+    const { unmount } = setup(mockApi);
+
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(mockApi.streamLogs).toHaveBeenCalledTimes(1);
+
+    unmount();
+
+    expect(unsubscribeSpy).toHaveBeenCalled();
+  });
+
+  it('re-enables error retry after a recovered event following completion', async () => {
+    let streamSubscriber: ZenObservable.SubscriptionObserver<LogEvent>;
+    const mockApi = {
+      getTask: jest.fn().mockResolvedValue(
+        makeTask({
+          spec: {
+            apiVersion: 'scaffolder.backstage.io/v1beta3',
+            parameters: {},
+            steps: [{ id: 'step-1', name: 'Step 1', action: 'debug:log' }],
+            output: {},
+            EXPERIMENTAL_recovery: {
+              EXPERIMENTAL_strategy: 'startOver',
+            },
+          } as ScaffolderTask['spec'],
+        }),
+      ),
+      streamLogs: jest.fn().mockImplementation(
+        () =>
+          new ObservableImpl<LogEvent>(subscriber => {
+            streamSubscriber = subscriber;
+          }),
+      ),
+    };
+
+    const { result } = setup(mockApi);
+
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    act(() => {
+      streamSubscriber.next({
+        id: 1,
+        taskId: 'test-task-id',
+        type: 'completion',
+        createdAt: '2026-01-01T00:00:00Z',
+        body: { output: {} },
+      } as unknown as LogEvent);
+    });
+
+    expect(result.current.completed).toBe(true);
+
+    act(() => {
+      streamSubscriber.next({
+        id: 2,
+        taskId: 'test-task-id',
+        type: 'recovered',
+        createdAt: '2026-01-01T00:00:00Z',
+        body: { message: 'Task recovered' },
+      } as unknown as LogEvent);
+    });
+
+    expect(result.current.completed).toBe(false);
+
+    act(() => {
+      streamSubscriber.error(new Error('connection lost'));
+    });
+
+    await act(async () => {
+      jest.advanceTimersByTime(15000);
+    });
+
+    expect(mockApi.streamLogs).toHaveBeenCalledTimes(2);
+  });
+
+  it('does not retry after stream completes via cancellation', async () => {
+    let streamSubscriber: ZenObservable.SubscriptionObserver<LogEvent>;
+    const mockApi = {
+      getTask: jest.fn().mockResolvedValue(makeTask()),
+      streamLogs: jest.fn().mockImplementation(
+        () =>
+          new ObservableImpl<LogEvent>(subscriber => {
+            streamSubscriber = subscriber;
+          }),
+      ),
+    };
+
+    const { result } = setup(mockApi);
+
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    act(() => {
+      streamSubscriber.next(makeLogEvent(1, 'before cancel'));
+    });
+
+    act(() => {
+      streamSubscriber.next({
+        id: 2,
+        taskId: 'test-task-id',
+        type: 'cancelled',
+        createdAt: '2026-01-01T00:00:00Z',
+        body: { message: 'Task cancelled' },
+      } as unknown as LogEvent);
+    });
+
+    expect(result.current.cancelled).toBe(true);
+    expect(result.current.stepLogs['step-1']).toContainEqual(
+      expect.stringContaining('before cancel'),
+    );
+
+    act(() => {
+      streamSubscriber.error(new Error('SSE connection closed'));
+    });
+
+    await act(async () => {
+      jest.advanceTimersByTime(15000);
+    });
+
+    expect(mockApi.streamLogs).toHaveBeenCalledTimes(1);
+  });
+});

--- a/plugins/scaffolder-react/src/hooks/useEventStream.test.tsx
+++ b/plugins/scaffolder-react/src/hooks/useEventStream.test.tsx
@@ -259,6 +259,127 @@ describe('useTaskEventStream', () => {
     expect(mockApi.streamLogs).toHaveBeenCalledTimes(2);
   });
 
+  it('retries after transport error following completion on a recoverable task', async () => {
+    let streamSubscriber: ZenObservable.SubscriptionObserver<LogEvent>;
+    const mockApi = {
+      getTask: jest.fn().mockResolvedValue(
+        makeTask({
+          spec: {
+            apiVersion: 'scaffolder.backstage.io/v1beta3',
+            parameters: {},
+            steps: [{ id: 'step-1', name: 'Step 1', action: 'debug:log' }],
+            output: {},
+            EXPERIMENTAL_recovery: {
+              EXPERIMENTAL_strategy: 'startOver',
+            },
+          } as ScaffolderTask['spec'],
+        }),
+      ),
+      streamLogs: jest.fn().mockImplementation(
+        () =>
+          new ObservableImpl<LogEvent>(subscriber => {
+            streamSubscriber = subscriber;
+          }),
+      ),
+    };
+
+    const { result } = setup(mockApi);
+
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    act(() => {
+      streamSubscriber.next({
+        id: 1,
+        taskId: 'test-task-id',
+        type: 'completion',
+        createdAt: '2026-01-01T00:00:00Z',
+        body: { output: {} },
+      } as unknown as LogEvent);
+    });
+
+    expect(result.current.completed).toBe(true);
+
+    act(() => {
+      streamSubscriber.error(new Error('SSE connection closed'));
+    });
+
+    await act(async () => {
+      jest.advanceTimersByTime(15000);
+    });
+
+    expect(mockApi.streamLogs).toHaveBeenCalledTimes(2);
+    expect(result.current.error).toBeUndefined();
+    expect(result.current.completed).toBe(false);
+  });
+
+  it('does not open a stream when getTask resolves after tab was hidden', async () => {
+    let resolveGetTask: (task: ScaffolderTask) => void;
+    const task = makeTask();
+    const mockApi = {
+      getTask: jest
+        .fn()
+        .mockImplementationOnce(
+          () =>
+            new Promise<ScaffolderTask>(resolve => {
+              resolveGetTask = resolve;
+            }),
+        )
+        .mockResolvedValue(task),
+      streamLogs: jest.fn().mockImplementation(
+        () =>
+          new ObservableImpl<LogEvent>(() => {
+            // no-op
+          }),
+      ),
+    };
+
+    setup(mockApi);
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(mockApi.getTask).toHaveBeenCalledTimes(1);
+    expect(mockApi.streamLogs).not.toHaveBeenCalled();
+
+    Object.defineProperty(document, 'hidden', {
+      value: true,
+      writable: true,
+      configurable: true,
+    });
+    act(() => {
+      document.dispatchEvent(new Event('visibilitychange'));
+    });
+
+    await act(async () => {
+      resolveGetTask!(task);
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(mockApi.streamLogs).not.toHaveBeenCalled();
+
+    Object.defineProperty(document, 'hidden', {
+      value: false,
+      writable: true,
+      configurable: true,
+    });
+    act(() => {
+      document.dispatchEvent(new Event('visibilitychange'));
+    });
+
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(mockApi.getTask).toHaveBeenCalledTimes(2);
+    expect(mockApi.streamLogs).toHaveBeenCalledTimes(1);
+  });
+
   it('does not retry after stream completes via cancellation', async () => {
     let streamSubscriber: ZenObservable.SubscriptionObserver<LogEvent>;
     const mockApi = {

--- a/plugins/scaffolder-react/src/hooks/useEventStream.test.tsx
+++ b/plugins/scaffolder-react/src/hooks/useEventStream.test.tsx
@@ -380,14 +380,16 @@ describe('useTaskEventStream', () => {
     expect(mockApi.streamLogs).toHaveBeenCalledTimes(1);
   });
 
-  it('does not retry after stream completes via cancellation', async () => {
+  it('tears down the subscription when a non-recoverable task is cancelled', async () => {
     let streamSubscriber: ZenObservable.SubscriptionObserver<LogEvent>;
+    const unsubscribeSpy = jest.fn();
     const mockApi = {
       getTask: jest.fn().mockResolvedValue(makeTask()),
       streamLogs: jest.fn().mockImplementation(
         () =>
           new ObservableImpl<LogEvent>(subscriber => {
             streamSubscriber = subscriber;
+            return () => unsubscribeSpy();
           }),
       ),
     };
@@ -417,15 +419,43 @@ describe('useTaskEventStream', () => {
     expect(result.current.stepLogs['step-1']).toContainEqual(
       expect.stringContaining('before cancel'),
     );
+    expect(unsubscribeSpy).toHaveBeenCalled();
+    expect(mockApi.streamLogs).toHaveBeenCalledTimes(1);
+  });
 
-    act(() => {
-      streamSubscriber.error(new Error('SSE connection closed'));
-    });
+  it('tears down the subscription when a non-recoverable task completes', async () => {
+    let streamSubscriber: ZenObservable.SubscriptionObserver<LogEvent>;
+    const unsubscribeSpy = jest.fn();
+    const mockApi = {
+      getTask: jest.fn().mockResolvedValue(makeTask()),
+      streamLogs: jest.fn().mockImplementation(
+        () =>
+          new ObservableImpl<LogEvent>(subscriber => {
+            streamSubscriber = subscriber;
+            return () => unsubscribeSpy();
+          }),
+      ),
+    };
+
+    const { result } = setup(mockApi);
 
     await act(async () => {
-      jest.advanceTimersByTime(15000);
+      await Promise.resolve();
+      await Promise.resolve();
     });
 
+    act(() => {
+      streamSubscriber.next({
+        id: 1,
+        taskId: 'test-task-id',
+        type: 'completion',
+        createdAt: '2026-01-01T00:00:00Z',
+        body: { output: {} },
+      } as unknown as LogEvent);
+    });
+
+    expect(result.current.completed).toBe(true);
+    expect(unsubscribeSpy).toHaveBeenCalled();
     expect(mockApi.streamLogs).toHaveBeenCalledTimes(1);
   });
 });

--- a/plugins/scaffolder-react/src/hooks/useEventStream.ts
+++ b/plugins/scaffolder-react/src/hooks/useEventStream.ts
@@ -194,108 +194,147 @@ export const useTaskEventStream = (taskId: string): TaskStream => {
     let didCancel = false;
     let subscription: Subscription | undefined;
     let logPusher: NodeJS.Timeout | undefined;
+    let retryTimer: ReturnType<typeof setTimeout> | undefined;
     let retryCount = 1;
     let isTaskRecoverable = false;
-    const startStreamLogProcess = () =>
-      scaffolderApi.getTask(taskId).then(
+    let lastSeenEventId: number | undefined;
+    let isStreamComplete = false;
+    let hasInitialized = false;
+    let startGeneration = 0;
+
+    const cleanUpStream = () => {
+      if (subscription) {
+        subscription.unsubscribe();
+        subscription = undefined;
+      }
+      if (logPusher) {
+        clearInterval(logPusher);
+        logPusher = undefined;
+      }
+      if (retryTimer) {
+        clearTimeout(retryTimer);
+        retryTimer = undefined;
+      }
+    };
+
+    function reconnectStream() {
+      const generation = ++startGeneration;
+      cleanUpStream();
+      subscribeToStream(generation);
+    }
+
+    function subscribeToStream(generation: number) {
+      const observable = scaffolderApi.streamLogs({
+        isTaskRecoverable,
+        taskId,
+        after: lastSeenEventId,
+      });
+
+      const collectedLogEvents = new Array<LogEvent>();
+
+      function emitLogs() {
+        if (collectedLogEvents.length) {
+          const logs = collectedLogEvents.splice(0, collectedLogEvents.length);
+          dispatch({ type: 'LOGS', data: logs });
+        }
+      }
+
+      logPusher = setInterval(emitLogs, 500);
+
+      subscription = observable.subscribe({
+        next: event => {
+          retryCount = 1;
+          if (event.id !== undefined) {
+            lastSeenEventId = event.id;
+          }
+          switch (event.type) {
+            case 'log':
+              return collectedLogEvents.push(event);
+            case 'cancelled':
+              isStreamComplete = true;
+              dispatch({ type: 'CANCELLED' });
+              return undefined;
+            case 'completion':
+              isStreamComplete = true;
+              emitLogs();
+              dispatch({ type: 'COMPLETED', data: event });
+              return undefined;
+            case 'recovered':
+              dispatch({ type: 'RECOVERED', data: event });
+              return undefined;
+            default:
+              throw new Error(`Unhandled event type ${event.type} in observer`);
+          }
+        },
+        error: error => {
+          emitLogs();
+          cleanUpStream();
+
+          if (generation !== startGeneration || didCancel) return;
+
+          const maxRetries = 3;
+
+          if (!error.message) {
+            error.message = `We cannot connect at the moment, trying again in some seconds... Retrying (${
+              retryCount > maxRetries ? maxRetries : retryCount
+            }/${maxRetries} retries)`;
+          }
+
+          retryTimer = setTimeout(() => {
+            retryTimer = undefined;
+            retryCount += 1;
+            reconnectStream();
+          }, 15000);
+
+          dispatch({ type: 'ERROR', data: error });
+        },
+      });
+    }
+
+    const startStreamLogProcess = () => {
+      const generation = ++startGeneration;
+      cleanUpStream();
+
+      return scaffolderApi.getTask(taskId).then(
         task => {
-          if (didCancel) {
+          if (didCancel || generation !== startGeneration) {
             return;
           }
           isTaskRecoverable =
             task.spec.EXPERIMENTAL_recovery?.EXPERIMENTAL_strategy ===
             'startOver';
+
+          hasInitialized = true;
           dispatch({ type: 'INIT', data: task });
-
-          // TODO(blam): Use a normal fetch to fetch the current log for the event stream
-          // and use that for an INIT_EVENTs dispatch event, and then
-          // use the last event ID to subscribe using after option to
-          // stream logs. Without this, if you have a lot of logs, it can look like the
-          // task is being rebuilt on load as it progresses through the steps at a slower
-          // rate whilst it builds the status from the event logs
-          const observable = scaffolderApi.streamLogs({
-            isTaskRecoverable,
-            taskId,
-          });
-
-          const collectedLogEvents = new Array<LogEvent>();
-
-          function emitLogs() {
-            if (collectedLogEvents.length) {
-              const logs = collectedLogEvents.splice(
-                0,
-                collectedLogEvents.length,
-              );
-              dispatch({ type: 'LOGS', data: logs });
-            }
-          }
-
-          logPusher = setInterval(emitLogs, 500);
-
-          subscription = observable.subscribe({
-            next: event => {
-              retryCount = 1;
-              switch (event.type) {
-                case 'log':
-                  return collectedLogEvents.push(event);
-                case 'cancelled':
-                  dispatch({ type: 'CANCELLED' });
-                  return undefined;
-                case 'completion':
-                  emitLogs();
-                  dispatch({ type: 'COMPLETED', data: event });
-                  return undefined;
-                case 'recovered':
-                  dispatch({ type: 'RECOVERED', data: event });
-                  return undefined;
-                default:
-                  throw new Error(
-                    `Unhandled event type ${event.type} in observer`,
-                  );
-              }
-            },
-            error: error => {
-              emitLogs();
-              // in some cases the error is a refused connection from backend
-              // this can happen from internet issues or proxy problems
-              // so we try to reconnect again after some time
-              // just to restart the fetch process
-              // details here https://github.com/backstage/backstage/issues/15002
-
-              const maxRetries = 3;
-
-              if (!error.message) {
-                error.message = `We cannot connect at the moment, trying again in some seconds... Retrying (${
-                  retryCount > maxRetries ? maxRetries : retryCount
-                }/${maxRetries} retries)`;
-              }
-
-              setTimeout(() => {
-                retryCount += 1;
-                void startStreamLogProcess();
-              }, 15000);
-
-              dispatch({ type: 'ERROR', data: error });
-            },
-          });
+          subscribeToStream(generation);
         },
         error => {
-          if (!didCancel) {
+          if (!didCancel && generation === startGeneration) {
             dispatch({ type: 'ERROR', data: error });
           }
         },
       );
+    };
     void startStreamLogProcess();
+
+    const onVisibilityChange = () => {
+      if (didCancel || isStreamComplete) return;
+      if (document.hidden) {
+        cleanUpStream();
+      } else if (hasInitialized) {
+        reconnectStream();
+      } else {
+        void startStreamLogProcess();
+      }
+    };
+    document.addEventListener('visibilitychange', onVisibilityChange);
+
     return () => {
       if (!isTaskRecoverable) {
         didCancel = true;
-        if (subscription) {
-          subscription.unsubscribe();
-        }
-        if (logPusher) {
-          clearInterval(logPusher);
-        }
+        cleanUpStream();
       }
+      document.removeEventListener('visibilitychange', onVisibilityChange);
     };
   }, [scaffolderApi, dispatch, taskId]);
 

--- a/plugins/scaffolder-react/src/hooks/useEventStream.ts
+++ b/plugins/scaffolder-react/src/hooks/useEventStream.ts
@@ -268,6 +268,9 @@ export const useTaskEventStream = (taskId: string): TaskStream => {
               }
               emitLogs();
               dispatch({ type: 'CANCELLED' });
+              if (isStreamComplete) {
+                cleanUpStream();
+              }
               return undefined;
             case 'completion':
               if (!isTaskRecoverable) {
@@ -275,6 +278,9 @@ export const useTaskEventStream = (taskId: string): TaskStream => {
               }
               emitLogs();
               dispatch({ type: 'COMPLETED', data: event });
+              if (isStreamComplete) {
+                cleanUpStream();
+              }
               return undefined;
             case 'recovered':
               isStreamComplete = false;

--- a/plugins/scaffolder-react/src/hooks/useEventStream.ts
+++ b/plugins/scaffolder-react/src/hooks/useEventStream.ts
@@ -72,6 +72,7 @@ type ReducerAction =
   | { type: 'RECOVERED'; data: ReducerLogEntry }
   | { type: 'LOGS'; data: ReducerLogEntry[] }
   | { type: 'COMPLETED'; data: ReducerLogEntry }
+  | { type: 'RECONNECTING' }
   | { type: 'ERROR'; data: Error };
 
 function reducer(draft: TaskStream, action: ReducerAction) {
@@ -163,6 +164,12 @@ function reducer(draft: TaskStream, action: ReducerAction) {
       return;
     }
 
+    case 'RECONNECTING': {
+      draft.error = undefined;
+      draft.completed = false;
+      return;
+    }
+
     case 'ERROR': {
       draft.error = action.data;
       draft.loading = false;
@@ -201,8 +208,11 @@ export const useTaskEventStream = (taskId: string): TaskStream => {
     let isStreamComplete = false;
     let hasInitialized = false;
     let startGeneration = 0;
+    let currentEmitLogs: (() => void) | undefined;
 
     const cleanUpStream = () => {
+      currentEmitLogs?.();
+      currentEmitLogs = undefined;
       if (subscription) {
         subscription.unsubscribe();
         subscription = undefined;
@@ -218,6 +228,7 @@ export const useTaskEventStream = (taskId: string): TaskStream => {
     };
 
     function reconnectStream() {
+      dispatch({ type: 'RECONNECTING' });
       const generation = ++startGeneration;
       cleanUpStream();
       subscribeToStream(generation);
@@ -239,6 +250,7 @@ export const useTaskEventStream = (taskId: string): TaskStream => {
         }
       }
 
+      currentEmitLogs = emitLogs;
       logPusher = setInterval(emitLogs, 500);
 
       subscription = observable.subscribe({
@@ -252,6 +264,7 @@ export const useTaskEventStream = (taskId: string): TaskStream => {
               return collectedLogEvents.push(event);
             case 'cancelled':
               isStreamComplete = true;
+              emitLogs();
               dispatch({ type: 'CANCELLED' });
               return undefined;
             case 'completion':
@@ -260,6 +273,7 @@ export const useTaskEventStream = (taskId: string): TaskStream => {
               dispatch({ type: 'COMPLETED', data: event });
               return undefined;
             case 'recovered':
+              isStreamComplete = false;
               dispatch({ type: 'RECOVERED', data: event });
               return undefined;
             default:
@@ -267,10 +281,11 @@ export const useTaskEventStream = (taskId: string): TaskStream => {
           }
         },
         error: error => {
-          emitLogs();
           cleanUpStream();
 
-          if (generation !== startGeneration || didCancel) return;
+          if (isStreamComplete || generation !== startGeneration || didCancel) {
+            return;
+          }
 
           const maxRetries = 3;
 
@@ -330,10 +345,8 @@ export const useTaskEventStream = (taskId: string): TaskStream => {
     document.addEventListener('visibilitychange', onVisibilityChange);
 
     return () => {
-      if (!isTaskRecoverable) {
-        didCancel = true;
-        cleanUpStream();
-      }
+      didCancel = true;
+      cleanUpStream();
       document.removeEventListener('visibilitychange', onVisibilityChange);
     };
   }, [scaffolderApi, dispatch, taskId]);

--- a/plugins/scaffolder-react/src/hooks/useEventStream.ts
+++ b/plugins/scaffolder-react/src/hooks/useEventStream.ts
@@ -263,12 +263,16 @@ export const useTaskEventStream = (taskId: string): TaskStream => {
             case 'log':
               return collectedLogEvents.push(event);
             case 'cancelled':
-              isStreamComplete = true;
+              if (!isTaskRecoverable) {
+                isStreamComplete = true;
+              }
               emitLogs();
               dispatch({ type: 'CANCELLED' });
               return undefined;
             case 'completion':
-              isStreamComplete = true;
+              if (!isTaskRecoverable) {
+                isStreamComplete = true;
+              }
               emitLogs();
               dispatch({ type: 'COMPLETED', data: event });
               return undefined;
@@ -335,6 +339,7 @@ export const useTaskEventStream = (taskId: string): TaskStream => {
     const onVisibilityChange = () => {
       if (didCancel || isStreamComplete) return;
       if (document.hidden) {
+        startGeneration++;
         cleanUpStream();
       } else if (hasInitialized) {
         reconnectStream();


### PR DESCRIPTION
## Hey, I just made a Pull Request!

The scaffolder task event stream replayed all log entries when the browser tab
regained focus, causing logs to appear twice. The underlying SSE library
reconnected silently without a cursor, and the Observable never aborted the
connection on unsubscribe.

This fixes connection lifecycle management in `ScaffolderClient` and adds
cursor-based reconnection and visibility-change handling in the event stream
hook so that only new events are fetched on resume.

This would fix: https://github.com/backstage/backstage/issues/25989

## How it worked before

https://github.com/user-attachments/assets/fc45f433-7d79-4a92-a3d9-c44d6640378d

## How it works now

https://github.com/user-attachments/assets/b536d474-9a3a-48a4-b583-33a4051ecad4

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))