### PR TITLE
fix(ci): repair Snyk synchronization workflows

### DIFF
--- a/.github/workflows/sync_snyk-github-issues.yml
+++ b/.github/workflows/sync_snyk-github-issues.yml
@@ -44,6 +44,6 @@ jobs:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
           NODE_OPTIONS: --max-old-space-size=7168
       - name: Update Github issues
-        run: ./scripts/snyk-github-issue-sync.ts
+        run: node --require @backstage/cli/config/nodeTransform.cjs ./scripts/snyk-github-issue-sync.ts
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/sync_snyk-monitor.yml
+++ b/.github/workflows/sync_snyk-monitor.yml
@@ -21,7 +21,6 @@ jobs:
   sync:
     permissions:
       contents: read # for actions/checkout to fetch code
-      security-events: write # for github/codeql-action/upload-sarif to upload SARIF results
     runs-on: ubuntu-latest
     steps:
       - name: Harden Runner
@@ -42,22 +41,3 @@ jobs:
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
           NODE_OPTIONS: --max-old-space-size=7168
-
-      # Above we run the `monitor` command, this runs the `test` command which is
-      # the one that generates the SARIF report that we can upload to GitHub.
-      - name: Create Snyk report
-        uses: snyk/actions/node@12140f4059e244892ae643824a95459a102120dd # master
-        continue-on-error: true # To make sure that SARIF upload gets called
-        with:
-          args: >
-            --yarn-workspaces
-            --org=backstage-dgh
-            --strict-out-of-sync=false
-            --sarif-file-output=snyk.sarif
-        env:
-          SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
-          NODE_OPTIONS: --max-old-space-size=7168
-      - name: Upload Snyk report
-        uses: github/codeql-action/upload-sarif@68bde559dea0fdcac2102bfdf6230c5f70eb485e # v4.35.4
-        with:
-          sarif_file: snyk.sarif


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Fixes two Snyk workflows that have never completed successfully:

- Invokes the issue synchronization script through Node explicitly instead of relying on a shebang that `/usr/bin/env` cannot parse.
- Removes the non-functional SARIF upload from the monitoring workflow. Snyk currently produces 232 workspace runs, while GitHub accepts at most 20 per SARIF upload. The actual Snyk monitoring synchronization remains unchanged.

#### :heavy_check_mark: Checklist

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))