### PR TITLE
fix(ci): pass API change comments as artifacts

### DIFF
--- a/.github/workflows/api-breaking-changes-comment.yml
+++ b/.github/workflows/api-breaking-changes-comment.yml
@@ -15,12 +15,11 @@ jobs:
     permissions:
       # "If you specify the access for any of these scopes, all of those that are not specified are set to none."
       # https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions
-      actions: read # Access cache
+      actions: read # Read artifacts from the trigger workflow
     outputs:
       git-ref: ${{ steps.event.outputs.GIT_REF }}
       pr-number: ${{ steps.event.outputs.PR_NUMBER }}
       action: ${{ steps.event.outputs.ACTION }}
-      comment-cache-key: ${{ steps.hash.outputs.COMMENT_FILE_HASH }}
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@58077d3c7e43986b6b15fba718e8ea69e387dfcc # v2.15.1
@@ -65,24 +64,21 @@ jobs:
           echo ACTION=$(jq --raw-output '.action | tostring | [scan("\\w+")][0]' < event.json) >> $GITHUB_OUTPUT
           echo GIT_REF=$(jq --raw-output '.pull_request.head.sha | tostring | [scan("\\w+")][0]' < event.json) >> $GITHUB_OUTPUT
 
-      - name: Fetch Command and Calculate Hash
-        id: hash
+      - name: Extract comment
         run: |
           unzip preview-spec.zip comment.md
-          ls
-          echo "COMMENT_FILE_HASH=$(md5sum comment.md | awk '{ print $1 }')" >> $GITHUB_OUTPUT
 
-      - name: Cache Comment
+      - name: Upload comment
         if: ${{ steps.event.outputs.ACTION != 'closed' }}
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
+          name: api-breaking-changes-comment
           path: comment.md
-          key: ${{ steps.hash.outputs.COMMENT_FILE_HASH }}
+          retention-days: 1
 
       - name: DEBUG - Print Job Outputs
         env:
           ACTION: ${{ steps.event.outputs.ACTION }}
-          COMMENT_FILE_HASH: ${{ steps.hash.outputs.COMMENT_FILE_HASH }}
           GIT_REF: ${{ steps.event.outputs.GIT_REF }}
           PR_NUMBER: ${{ steps.event.outputs.PR_NUMBER }}
         if: ${{ runner.debug }}
@@ -90,7 +86,6 @@ jobs:
           echo "PR number: $PR_NUMBER"
           echo "Git Ref: $GIT_REF"
           echo "Action: $ACTION"
-          echo "Hash: $COMMENT_FILE_HASH"
           cat event.json
 
   add-comment:
@@ -106,12 +101,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
 
-      - name: Fetch cached Manifests File
-        id: cache
-        uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v5
+      - name: Download comment
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
-          path: comment.md
-          key: ${{ needs.setup.outputs.comment-cache-key }}
+          name: api-breaking-changes-comment
 
       # Identify comment to be updated
       - name: Find comment for API Changes

--- a/.github/workflows/api-breaking-changes-comment.yml
+++ b/.github/workflows/api-breaking-changes-comment.yml
@@ -27,7 +27,9 @@ jobs:
           disable-sudo: true
           egress-policy: block
           allowed-endpoints: >
+            *.blob.core.windows.net:443
             api.github.com:443
+            results-receiver.actions.githubusercontent.com:443
 
       - name: 'Download artifacts'
         # Fetch output (zip archive) from the workflow run that triggered this workflow.


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Fixes the API breaking-changes comment workflow, which has failed every applicable run since early July.

The setup job only has `actions: read`, so GitHub rejects its attempt to save `comment.md` through the Actions cache. This replaces that cache-based cross-job handoff with a short-lived workflow artifact while preserving the existing two-job permission boundary.

#### :heavy_check_mark: Checklist

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))