### PR TITLE
fix(ci): serialize BUI docs synchronization

### DIFF
--- a/.github/workflows/sync_bui-docs.yml
+++ b/.github/workflows/sync_bui-docs.yml
@@ -3,6 +3,10 @@ on:
   push:
     branches: [master]
 
+concurrency:
+  group: sync-bui-docs
+  cancel-in-progress: false
+
 jobs:
   sync-docs-ui:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Prevents concurrent `master` pushes from racing to update `backstage/docs-ui`.

A burst on September 1 produced eight non-fast-forward failures within four minutes. The workflow now uses a single concurrency group, allowing the current run to finish while GitHub retains the newest pending synchronization.

#### :heavy_check_mark: Checklist

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))