### PR TITLE
perf(catalog-backend): stabilize predicate array queries

### DIFF
--- a/.changeset/calm-predicate-arrays.md
+++ b/.changeset/calm-predicate-arrays.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-backend': patch
+---
+
+Use stable PostgreSQL array parameters for `$in` filter predicates.

--- a/.changeset/tidy-refresh-state-array-queries.md
+++ b/.changeset/tidy-refresh-state-array-queries.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-backend': patch
+---
+
+Use stable PostgreSQL array parameters for batched refresh state lookups and updates.

--- a/plugins/catalog-backend/src/database/DefaultProcessingDatabase.ts
+++ b/plugins/catalog-backend/src/database/DefaultProcessingDatabase.ts
@@ -231,7 +231,7 @@ export class DefaultProcessingDatabase implements ProcessingDatabase {
 
       if (items.length > 0) {
         await tx('refresh_state')
-          .modify(
+          .where(
             whereInArray(
               'entity_ref',
               items.map(i => i.entity_ref),

--- a/plugins/catalog-backend/src/database/DefaultProcessingDatabase.ts
+++ b/plugins/catalog-backend/src/database/DefaultProcessingDatabase.ts
@@ -40,7 +40,7 @@ import {
 import { checkLocationKeyConflict } from './operations/refreshState/checkLocationKeyConflict';
 import { insertUnprocessedEntity } from './operations/refreshState/insertUnprocessedEntity';
 import { updateUnprocessedEntity } from './operations/refreshState/updateUnprocessedEntity';
-import { generateStableHash, generateTargetKey } from './util';
+import { generateStableHash, generateTargetKey, whereInArray } from './util';
 import {
   syncRelations,
   SyncRelationsResult,
@@ -231,9 +231,11 @@ export class DefaultProcessingDatabase implements ProcessingDatabase {
 
       if (items.length > 0) {
         await tx('refresh_state')
-          .whereIn(
-            'entity_ref',
-            items.map(i => i.entity_ref),
+          .modify(
+            whereInArray(
+              'entity_ref',
+              items.map(i => i.entity_ref),
+            ),
           )
           .update({
             next_update_at: nextUpdateAt(tx, interval),

--- a/plugins/catalog-backend/src/database/DefaultProviderDatabase.ts
+++ b/plugins/catalog-backend/src/database/DefaultProviderDatabase.ts
@@ -32,7 +32,12 @@ import {
   ReplaceUnprocessedEntitiesOptions,
   Transaction,
 } from './types';
-import { generateStableHash, isDeadlockError, retryOnDeadlock } from './util';
+import {
+  generateStableHash,
+  isDeadlockError,
+  retryOnDeadlock,
+  whereInArray,
+} from './util';
 import {
   LoggerService,
   isDatabaseConflictError,
@@ -251,7 +256,9 @@ export class DefaultProviderDatabase implements ProviderDatabase {
         const entityRefs = chunk.map(e => stringifyEntityRef(e.entity));
         const rows = await tx<DbRefreshStateRow>('refresh_state')
           .select(['entity_ref', 'unprocessed_hash', 'location_key'])
-          .whereIn('entity_ref', entityRefs);
+          .modify<DbRefreshStateRow, DbRefreshStateRow[]>(
+            whereInArray('entity_ref', entityRefs),
+          );
         const oldStates = new Map(
           rows.map(row => [
             row.entity_ref,

--- a/plugins/catalog-backend/src/database/DefaultProviderDatabase.ts
+++ b/plugins/catalog-backend/src/database/DefaultProviderDatabase.ts
@@ -256,9 +256,7 @@ export class DefaultProviderDatabase implements ProviderDatabase {
         const entityRefs = chunk.map(e => stringifyEntityRef(e.entity));
         const rows = await tx<DbRefreshStateRow>('refresh_state')
           .select(['entity_ref', 'unprocessed_hash', 'location_key'])
-          .modify<DbRefreshStateRow, DbRefreshStateRow[]>(
-            whereInArray('entity_ref', entityRefs),
-          );
+          .where(whereInArray('entity_ref', entityRefs));
         const oldStates = new Map(
           rows.map(row => [
             row.entity_ref,

--- a/plugins/catalog-backend/src/database/util.test.ts
+++ b/plugins/catalog-backend/src/database/util.test.ts
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-import { Knex } from 'knex';
-import { isDeadlockError, retryOnDeadlock } from './util';
+import knexFactory, { Knex } from 'knex';
+import { isDeadlockError, retryOnDeadlock, whereInArray } from './util';
 
 jest.mock('node:timers/promises', () => ({
   setTimeout: jest.fn(),
@@ -30,6 +30,62 @@ function pgDeadlockError(): Error & { code: string } {
   err.code = '40P01';
   return err;
 }
+
+describe('whereInArray', () => {
+  it('uses one array binding on PostgreSQL', () => {
+    const knex = knexFactory({ client: 'pg' });
+
+    const query = knex('refresh_state')
+      .select('*')
+      .modify(whereInArray('entity_ref', ['a', 'b']))
+      .toSQL();
+
+    expect(query.sql).toBe(
+      'select * from "refresh_state" where "entity_ref" = ANY(?::text[])',
+    );
+    expect(query.bindings).toEqual([['a', 'b']]);
+  });
+
+  it('uses an empty array binding on PostgreSQL', () => {
+    const knex = knexFactory({ client: 'pg' });
+
+    const query = knex('refresh_state')
+      .select('*')
+      .modify(whereInArray('entity_ref', []))
+      .toSQL();
+
+    expect(query.sql).toBe(
+      'select * from "refresh_state" where "entity_ref" = ANY(?::text[])',
+    );
+    expect(query.bindings).toEqual([[]]);
+  });
+
+  it('uses scalar IN bindings on non-PostgreSQL databases', () => {
+    const knex = knexFactory({ client: 'better-sqlite3' });
+
+    const query = knex('refresh_state')
+      .select('*')
+      .modify(whereInArray('entity_ref', ['a', 'b']))
+      .toSQL();
+
+    expect(query.sql).toBe(
+      'select * from `refresh_state` where `entity_ref` in (?, ?)',
+    );
+    expect(query.bindings).toEqual(['a', 'b']);
+  });
+
+  it('uses an always-false predicate for empty arrays on non-PostgreSQL databases', () => {
+    const knex = knexFactory({ client: 'better-sqlite3' });
+
+    const query = knex('refresh_state')
+      .select('*')
+      .modify(whereInArray('entity_ref', []))
+      .toSQL();
+
+    expect(query.sql).toBe('select * from `refresh_state` where 1 = ?');
+    expect(query.bindings).toEqual([0]);
+  });
+});
 
 describe('retryOnDeadlock', () => {
   afterEach(() => {

--- a/plugins/catalog-backend/src/database/util.test.ts
+++ b/plugins/catalog-backend/src/database/util.test.ts
@@ -37,11 +37,11 @@ describe('whereInArray', () => {
 
     const query = knex('refresh_state')
       .select('*')
-      .modify(whereInArray('entity_ref', ['a', 'b']))
+      .where(whereInArray('entity_ref', ['a', 'b']))
       .toSQL();
 
     expect(query.sql).toBe(
-      'select * from "refresh_state" where "entity_ref" = ANY(?::text[])',
+      'select * from "refresh_state" where ("entity_ref" = ANY(?::text[]))',
     );
     expect(query.bindings).toEqual([['a', 'b']]);
   });
@@ -51,11 +51,11 @@ describe('whereInArray', () => {
 
     const query = knex('refresh_state')
       .select('*')
-      .modify(whereInArray('entity_ref', []))
+      .where(whereInArray('entity_ref', []))
       .toSQL();
 
     expect(query.sql).toBe(
-      'select * from "refresh_state" where "entity_ref" = ANY(?::text[])',
+      'select * from "refresh_state" where ("entity_ref" = ANY(?::text[]))',
     );
     expect(query.bindings).toEqual([[]]);
   });
@@ -65,11 +65,11 @@ describe('whereInArray', () => {
 
     const query = knex('refresh_state')
       .select('*')
-      .modify(whereInArray('entity_ref', ['a', 'b']))
+      .where(whereInArray('entity_ref', ['a', 'b']))
       .toSQL();
 
     expect(query.sql).toBe(
-      'select * from `refresh_state` where `entity_ref` in (?, ?)',
+      'select * from `refresh_state` where (`entity_ref` in (?, ?))',
     );
     expect(query.bindings).toEqual(['a', 'b']);
   });
@@ -79,10 +79,10 @@ describe('whereInArray', () => {
 
     const query = knex('refresh_state')
       .select('*')
-      .modify(whereInArray('entity_ref', []))
+      .where(whereInArray('entity_ref', []))
       .toSQL();
 
-    expect(query.sql).toBe('select * from `refresh_state` where 1 = ?');
+    expect(query.sql).toBe('select * from `refresh_state` where (1 = ?)');
     expect(query.bindings).toEqual([0]);
   });
 });

--- a/plugins/catalog-backend/src/database/util.ts
+++ b/plugins/catalog-backend/src/database/util.ts
@@ -35,6 +35,17 @@ export function generateTargetKey(target: string) {
     : target;
 }
 
+/** Applies an array-backed WHERE clause with a stable query shape on PostgreSQL. */
+export function whereInArray(column: string, values: string[]) {
+  return (qb: Knex.QueryBuilder) => {
+    if (qb.client.config.client === 'pg') {
+      qb.whereRaw('?? = ANY(?::text[])', [column, values]);
+    } else {
+      qb.whereIn(column, values);
+    }
+  };
+}
+
 /**
  * Retries an operation on database deadlock errors.
  */

--- a/plugins/catalog-backend/src/service/request/applyPredicateEntityFilterToQuery.test.ts
+++ b/plugins/catalog-backend/src/service/request/applyPredicateEntityFilterToQuery.test.ts
@@ -21,7 +21,7 @@ import {
   DbRefreshStateRow,
   DbSearchRow,
 } from '../../database/tables';
-import { Knex } from 'knex';
+import knexFactory, { Knex } from 'knex';
 import { applyDatabaseMigrations } from '../../database/migrations';
 import { FilterPredicate } from '@backstage/filter-predicates';
 import { Entity, stringifyEntityRef } from '@backstage/catalog-model';
@@ -31,6 +31,50 @@ import { buildEntitySearch } from '../../database/operations/stitcher/buildEntit
 jest.setTimeout(60_000);
 
 const databases = TestDatabases.create();
+
+describe('PostgreSQL query generation', () => {
+  function compile(filter: FilterPredicate) {
+    const knex = knexFactory({ client: 'pg' });
+    const query = knex('final_entities').select('*');
+
+    applyEntityFilterToQuery({
+      filter,
+      targetQuery: query,
+      onEntityIdField: 'final_entities.entity_id',
+      knex,
+    });
+
+    return query.toSQL();
+  }
+
+  it('uses one array binding for $in', () => {
+    const query = compile({
+      'spec.type': { $in: ['Service', 'Website'] },
+    });
+
+    expect(query.sql).toContain('"search_flt"."value" = ANY(?::text[])');
+    expect(query.bindings).toEqual(['spec.type', ['service', 'website']]);
+  });
+
+  it('uses one array binding for relation targetRef $in', () => {
+    const query = compile({
+      relations: {
+        $contains: {
+          type: 'OwnedBy',
+          targetRef: {
+            $in: ['Group:Default/Team-A', 'Group:Default/Team-B'],
+          },
+        },
+      },
+    });
+
+    expect(query.sql).toContain('"search_flt"."value" = ANY(?::text[])');
+    expect(query.bindings).toEqual([
+      'relations.ownedby',
+      ['group:default/team-a', 'group:default/team-b'],
+    ]);
+  });
+});
 
 describe.each(databases.eachSupportedId())(
   'applyEntityFilterToQuery with predicate queries, %p',

--- a/plugins/catalog-backend/src/service/request/applyPredicateEntityFilterToQuery.ts
+++ b/plugins/catalog-backend/src/service/request/applyPredicateEntityFilterToQuery.ts
@@ -21,6 +21,7 @@ import {
 } from '@backstage/filter-predicates';
 import { InputError } from '@backstage/errors';
 import { Knex } from 'knex';
+import { whereInArray } from '../../database/util';
 import { searchExists, SEARCH_FLT_ALIAS as S } from './searchSubquery';
 
 function isPrimitive(value: unknown): value is FilterPredicatePrimitive {
@@ -151,7 +152,7 @@ function applyFieldCondition(options: {
       return targetQuery.whereExists(
         searchExists(knex, onEntityIdField)
           .where(`${S}.key`, key)
-          .whereIn(`${S}.value`, values),
+          .where(whereInArray(`${S}.value`, values)),
       );
     }
 
@@ -322,7 +323,7 @@ function applyContainsRelation(options: {
   );
 
   if (targetRef) {
-    subquery.whereIn(`${S}.value`, targetRef);
+    subquery.where(whereInArray(`${S}.value`, targetRef));
   }
 
   return targetQuery.whereExists(subquery);


### PR DESCRIPTION
## What

Use the PostgreSQL array-backed membership helper from #35535 for both ordinary `$in` filter predicates and relation `targetRef.$in` predicates. MySQL and SQLite continue to use Knex `whereIn`.

This PR is stacked on #35535 and can be retargeted to `master` after that PR lands.

## Why

Variable-length `$in` predicates currently produce a separate query shape for every value count. A single `text[]` binding keeps Query Insights and query statistics stable.

On a PostgreSQL 17 replica, alternating full-result count benchmarks showed equivalent median execution times for explicit `IN` and array `ANY` with both two and five values. PostgreSQL also produced identical custom plans, internally representing explicit `IN` as `ANY` itself.

## Testing

- Added PostgreSQL SQL-generation coverage for both predicate forms
- Existing SQLite integration tests cover both non-PostgreSQL fallback paths
- Ran 75 focused tests, package lint, repository TypeScript compilation, and the catalog-backend build

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages.
- [ ] Added or updated documentation (not applicable)
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (not applicable)
- [x] All commits have a `Signed-off-by` line in the message.