### PR TITLE
fix(devtools): migrate ExternalDependenciesContent to BUI Table

### DIFF
--- a/.changeset/tired-buses-tan.md
+++ b/.changeset/tired-buses-tan.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-devtools': patch
+---
+
+Migrate ExternalDependenciesContent to use the Backstage UI (BUI) Table component

--- a/plugins/devtools/package.json
+++ b/plugins/devtools/package.json
@@ -71,6 +71,7 @@
   "devDependencies": {
     "@backstage/cli": "workspace:^",
     "@backstage/dev-utils": "workspace:^",
+    "@backstage/test-utils": "workspace:^",
     "@testing-library/jest-dom": "^6.0.0",
     "@types/lodash": "^4.14.151",
     "@types/react": "^18.0.0",

--- a/plugins/devtools/src/components/Content/ExternalDependenciesContent/ExternalDependenciesContent.test.tsx
+++ b/plugins/devtools/src/components/Content/ExternalDependenciesContent/ExternalDependenciesContent.test.tsx
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2026 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { renderInTestApp } from '@backstage/test-utils';
+import { ExternalDependenciesContent } from './ExternalDependenciesContent';
+import { useExternalDependencies } from '../../../hooks';
+
+jest.mock('../../../hooks', () => ({
+  useExternalDependencies: jest.fn(),
+}));
+
+const mockUseExternalDependencies =
+  useExternalDependencies as jest.MockedFunction<
+    typeof useExternalDependencies
+  >;
+
+describe('ExternalDependenciesContent', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders external dependencies in a table', async () => {
+    mockUseExternalDependencies.mockReturnValue({
+      loading: false,
+      externalDependencies: [
+        {
+          name: 'GitHub',
+          type: 'rest',
+          target: 'https://api.github.com',
+          status: 'Healthy',
+        },
+        {
+          name: 'Postgres',
+          type: 'tcp',
+          target: 'db.internal:5432',
+          status: 'Unhealthy',
+          error: 'connection refused',
+        },
+      ],
+    });
+
+    const { findByText } = await renderInTestApp(
+      <ExternalDependenciesContent />,
+    );
+
+    expect(await findByText('GitHub')).toBeInTheDocument();
+    expect(await findByText('https://api.github.com')).toBeInTheDocument();
+    expect(await findByText('Postgres')).toBeInTheDocument();
+    expect(await findByText('connection refused')).toBeInTheDocument();
+  });
+
+  it('renders an empty state when there are no dependencies', async () => {
+    mockUseExternalDependencies.mockReturnValue({
+      loading: false,
+      externalDependencies: [],
+    });
+
+    const { getByText } = await renderInTestApp(
+      <ExternalDependenciesContent />,
+    );
+
+    expect(getByText('No external dependencies found')).toBeInTheDocument();
+  });
+
+  it('renders an error state', async () => {
+    mockUseExternalDependencies.mockReturnValue({
+      loading: false,
+      error: new Error('failed to fetch'),
+    });
+
+    const { queryByText } = await renderInTestApp(
+      <ExternalDependenciesContent />,
+    );
+
+    expect(queryByText('GitHub')).not.toBeInTheDocument();
+  });
+});

--- a/plugins/devtools/src/components/Content/ExternalDependenciesContent/ExternalDependenciesContent.tsx
+++ b/plugins/devtools/src/components/Content/ExternalDependenciesContent/ExternalDependenciesContent.tsx
@@ -15,121 +15,88 @@
  */
 
 import {
-  Progress,
   StatusError,
   StatusOK,
   StatusWarning,
-  Table,
-  TableColumn,
 } from '@backstage/core-components';
 import { ExternalDependency } from '@backstage/plugin-devtools-common';
-import Box from '@material-ui/core/Box';
-import Grid from '@material-ui/core/Grid';
-import Paper from '@material-ui/core/Paper';
 import Typography from '@material-ui/core/Typography';
-import { createStyles, makeStyles, Theme } from '@material-ui/core/styles';
-import Alert from '@material-ui/lab/Alert';
+import { Table, useTable, CellText, type ColumnConfig } from '@backstage/ui';
 import { useExternalDependencies } from '../../../hooks';
 
-const useStyles = makeStyles((theme: Theme) =>
-  createStyles({
-    paperStyle: {
-      padding: theme.spacing(2),
-    },
-  }),
-);
+type ExternalDependencyRow = ExternalDependency & { id: string };
 
-export const getExternalDependencyStatus = (
-  result: Partial<ExternalDependency> | undefined,
-) => {
+const getStatusIcon = (result: Partial<ExternalDependency> | undefined) => {
   switch (result?.status) {
     case 'Healthy':
-      return (
-        <Typography component="span">
-          <StatusOK /> {result.status}
-        </Typography>
-      );
+      return <StatusOK />;
     case 'Unhealthy':
-      return (
-        <Typography component="span">
-          <StatusError /> {`${result.status}`}
-        </Typography>
-      );
+      return <StatusError />;
     case undefined:
     default:
-      return (
-        <Typography component="span">
-          <StatusWarning /> Unknown
-        </Typography>
-      );
+      return <StatusWarning />;
   }
 };
 
-const columns: TableColumn[] = [
+export const getExternalDependencyStatus = (
+  result: Partial<ExternalDependency> | undefined,
+): string => {
+  switch (result?.status) {
+    case 'Healthy':
+    case 'Unhealthy':
+      return result.status;
+    case undefined:
+    default:
+      return 'Unknown';
+  }
+};
+
+const columns: ColumnConfig<ExternalDependencyRow>[] = [
   {
-    title: 'Name',
-    width: 'auto',
-    field: 'name',
+    id: 'name',
+    label: 'Name',
+    isRowHeader: true,
+    cell: item => <CellText title={item.name} />,
   },
   {
-    title: 'Target',
-    width: 'auto',
-    field: 'target',
+    id: 'target',
+    label: 'Target',
+    cell: item => <CellText title={item.target} />,
   },
   {
-    title: 'Type',
-    width: 'auto',
-    field: 'type',
+    id: 'type',
+    label: 'Type',
+    cell: item => <CellText title={item.type} />,
   },
   {
-    title: 'Status',
-    width: 'auto',
-    render: (row: Partial<ExternalDependency>) => (
-      <Grid container direction="column">
-        <Grid item>
-          <Typography variant="button">
-            {getExternalDependencyStatus(row)}
-          </Typography>
-        </Grid>
-        <Grid item>{row.error && <Typography>{row.error}</Typography>}</Grid>
-      </Grid>
+    id: 'status',
+    label: 'Status',
+    cell: item => (
+      <CellText
+        title={getExternalDependencyStatus(item)}
+        description={item.error}
+        leadingIcon={getStatusIcon(item)}
+      />
     ),
   },
 ];
 
 /** @public */
 export const ExternalDependenciesContent = () => {
-  const classes = useStyles();
   const { externalDependencies, loading, error } = useExternalDependencies();
-
-  if (loading) {
-    return <Progress />;
-  } else if (error) {
-    return <Alert severity="error">{error.message}</Alert>;
-  }
-
-  if (!externalDependencies || externalDependencies.length === 0) {
-    return (
-      <Box>
-        <Paper className={classes.paperStyle}>
-          <Typography>No external dependencies found</Typography>
-        </Paper>
-      </Box>
-    );
-  }
+  const { tableProps } = useTable({
+    mode: 'complete',
+    data: (externalDependencies ?? []).map(dep => ({ ...dep, id: dep.name })),
+    paginationOptions: { pageSize: 20, pageSizeOptions: [20, 50, 100] },
+  });
 
   return (
     <Table
-      title="Status"
-      options={{
-        paging: true,
-        pageSize: 20,
-        pageSizeOptions: [20, 50, 100],
-        loadingType: 'linear',
-        showEmptyDataSourceMessage: !loading,
-      }}
-      columns={columns}
-      data={externalDependencies || []}
+      columnConfig={columns}
+      {...tableProps}
+      isPending={loading}
+      error={error}
+      emptyState={<Typography>No external dependencies found</Typography>}
     />
   );
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -5125,6 +5125,7 @@ __metadata:
     "@backstage/frontend-plugin-api": "workspace:^"
     "@backstage/plugin-devtools-common": "workspace:^"
     "@backstage/plugin-permission-react": "workspace:^"
+    "@backstage/test-utils": "workspace:^"
     "@backstage/ui": "workspace:^"
     "@material-ui/core": "npm:^4.9.13"
     "@material-ui/icons": "npm:^4.9.1"


### PR DESCRIPTION
## Summary
  Migrates the DevTools `ExternalDependenciesContent` component from Material UI's `Table` (via `@backstage/core-components`) to the Backstage UI `Table` component
  (`@backstage/ui`).
  
 Note: this component isn't currently wired into the New Frontend System's devtools plugin registration (`plugins/devtools/src/alpha/plugin.tsx` only registers
  Info/Config/Scheduled Tasks), so it's unreachable in the example app regardless of this change — that looks like a separate, pre-existing gap worth its own issue.
  Verified via a new isolated unit test instead.

 ## Test plan
  - [x] Added `ExternalDependenciesContent.test.tsx` covering populated table, empty state, and error state
  - [x] `yarn tsc` passes
  - [x] `yarn lint:all` passes
  - [x] Added changeset

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
