### PR TITLE
fix(config): return a consistent zero value for all-zero ISO durations

### DIFF
--- a/.changeset/config-zero-iso-duration.md
+++ b/.changeset/config-zero-iso-duration.md
@@ -1,0 +1,5 @@
+---
+'@backstage/config': patch
+---
+
+Fixed reading a duration from configuration so that an all-zero ISO 8601 duration (such as `PT0S`) now yields a consistent zero value instead of an empty result.

--- a/packages/config/src/readDurationFromConfig.test.ts
+++ b/packages/config/src/readDurationFromConfig.test.ts
@@ -53,6 +53,35 @@ describe('readDurationFromConfig', () => {
       });
     });
 
+    it('parses whole-zero durations consistently', () => {
+      const config = new ConfigReader({
+        z1: 'PT0S',
+        z2: 'P0D',
+        z3: 'PT0H0M0S',
+      });
+
+      expect(readDurationFromConfig(config, { key: 'z1' })).toEqual({
+        milliseconds: 0,
+      });
+      expect(readDurationFromConfig(config, { key: 'z2' })).toEqual({
+        milliseconds: 0,
+      });
+      expect(readDurationFromConfig(config, { key: 'z3' })).toEqual({
+        milliseconds: 0,
+      });
+    });
+
+    it('omits zero units within a non-zero duration', () => {
+      const config = new ConfigReader({
+        d1: 'P2DT0H30M',
+      });
+
+      expect(readDurationFromConfig(config, { key: 'd1' })).toEqual({
+        days: 2,
+        minutes: 30,
+      });
+    });
+
     it('throws on errors', () => {
       const config = new ConfigReader({
         d1: 'P 1Y',

--- a/packages/config/src/readDurationFromConfig.ts
+++ b/packages/config/src/readDurationFromConfig.ts
@@ -297,7 +297,7 @@ export function parseIsoDuration(input: string): HumanDuration {
     throw new Error('Invalid ISO format, no values given');
   }
 
-  return {
+  const result: HumanDuration = {
     ...(years ? { years } : {}),
     ...(months ? { months } : {}),
     ...(weeks ? { weeks } : {}),
@@ -307,4 +307,13 @@ export function parseIsoDuration(input: string): HumanDuration {
     ...(seconds ? { seconds } : {}),
     ...(milliseconds ? { milliseconds } : {}),
   };
+
+  // A valid but entirely-zero duration (such as 'PT0S') would otherwise yield
+  // an empty object here, since the spreads above drop zero-valued units. Match
+  // the ms-string form, which represents a zero duration as { milliseconds: 0 }.
+  if (Object.keys(result).length === 0) {
+    return { milliseconds: 0 };
+  }
+
+  return result;
 }


### PR DESCRIPTION
## Summary

`readDurationFromConfig` accepts durations in two string forms, and they disagreed on the value returned for a **whole-zero** duration:

- **ms form** `"0 seconds"` -> `{ milliseconds: 0 }`
- **ISO 8601 form** `"PT0S"` -> `{}` (bug)

`parseIsoDuration` builds its result from truthiness spreads (`...(seconds ? { seconds } : {})`), which is correct for dropping *intermediate* zero units (e.g. `P2DT0H30M` -> `{ days: 2, minutes: 30 }`). But for a valid all-zero input like `PT0S` / `P0D` / `PT0H0M0S`, every spread evaluates to nothing, so the function silently returned an empty object instead of a zero duration inconsistent with the ms parser. The input isn't invalid (the units are `0`, not `undefined`), so it slips past the existing "no values given" guard and fails silently.

## Fix

In `parseIsoDuration`, collect the spread result and, if it is empty, return `{ milliseconds: 0 }` to match `parseMsDuration`. The check is placed **after** the existing "no values given" throw, so genuinely invalid input (e.g. `P`) still throws. Non-zero and mixed-zero behavior is unchanged.

## Changes

- `packages/config/src/readDurationFromConfig.ts`  the fix (minimal, ~11 lines).
- `packages/config/src/readDurationFromConfig.test.ts` a whole-zero consistency test (`PT0S` / `P0D` / `PT0H0M0S` -> `{ milliseconds: 0 }`) and a mixed-zero regression test (`P2DT0H30M` -> `{ days: 2, minutes: 30 }`).
- `.changeset/config-zero-iso-duration.md`  required `patch` changeset for the published `@backstage/config` package.

## Testing

Verified locally (Node 22, yarn 4.8.1):

- `yarn tsc` -> clean
- `backstage-cli repo test packages/config` -> **172 passed / 18 suites** (baseline 170 + 2 new)
- `yarn lint` (packages/config) -> clean
- `yarn prettier:check` on touched files -> clean
- Mutation check: reverting the source makes exactly the new whole-zero test fail (`Received {}` vs `Expected { milliseconds: 0 }`), confirming the test guards the fix.

No exported signatures changed, so no API report update is needed. Commit is DCO signed-off.