### PR TITLE
fix(integration): cache Bitbucket Cloud OAuth tokens per credential set 

### DIFF
--- a/.changeset/bitbucket-cloud-oauth-token-cache.md
+++ b/.changeset/bitbucket-cloud-oauth-token-cache.md
@@ -1,0 +1,5 @@
+---
+'@backstage/integration': patch
+---
+
+Bitbucket Cloud OAuth access tokens returned by `getBitbucketCloudOAuthToken` are now cached separately for each set of OAuth client credentials. Previously a single token was cached globally, which could cause the wrong token to be used when more than one Bitbucket Cloud integration was configured or when OAuth credentials were rotated.

--- a/packages/integration/src/bitbucketCloud/core.test.ts
+++ b/packages/integration/src/bitbucketCloud/core.test.ts
@@ -119,6 +119,104 @@ describe('bitbucketCloud core', () => {
       expect(result2.headers.Authorization).toEqual('Bearer test-oauth-token');
       expect(callCount).toBe(1); // Still 1, proving cache was used
     });
+
+    it('does not reuse a cached OAuth token across different credentials', async () => {
+      // Return a distinct token per credential set by decoding the incoming
+      // Basic auth header, and count how many token fetches actually happen.
+      // This guards against a single shared cache leaking one integration's
+      // token to another integration with different credentials.
+      let callCount = 0;
+      worker.use(
+        http.post(BITBUCKET_CLOUD_OAUTH_TOKEN_URL, ({ request }) => {
+          callCount++;
+          const authorization = request.headers.get('Authorization') ?? '';
+          const [clientId] = Buffer.from(
+            authorization.replace(/^Basic /, ''),
+            'base64',
+          )
+            .toString('utf8')
+            .split(':');
+          return HttpResponse.json({
+            access_token: `${clientId}-token`,
+            expires_in: 3600,
+          });
+        }),
+      );
+
+      const withOAuthA: BitbucketCloudIntegrationConfig = {
+        host: BITBUCKET_CLOUD_HOST,
+        apiBaseUrl: BITBUCKET_CLOUD_API_BASE_URL,
+        clientId: 'client-a',
+        clientSecret: 'secret-a',
+      };
+      const withOAuthB: BitbucketCloudIntegrationConfig = {
+        host: BITBUCKET_CLOUD_HOST,
+        apiBaseUrl: BITBUCKET_CLOUD_API_BASE_URL,
+        clientId: 'client-b',
+        clientSecret: 'secret-b',
+      };
+
+      // First integration fetches and caches its own token.
+      const resultA1 = await getBitbucketCloudRequestOptions(withOAuthA);
+      expect(resultA1.headers.Authorization).toEqual('Bearer client-a-token');
+      expect(callCount).toBe(1);
+
+      // A second call for the same credentials is served from the cache.
+      const resultA2 = await getBitbucketCloudRequestOptions(withOAuthA);
+      expect(resultA2.headers.Authorization).toEqual('Bearer client-a-token');
+      expect(callCount).toBe(1);
+
+      // A different integration must trigger a fresh fetch and receive its own
+      // token, not the one cached for the first integration.
+      const resultB = await getBitbucketCloudRequestOptions(withOAuthB);
+      expect(callCount).toBe(2);
+      expect(resultB.headers.Authorization).toEqual('Bearer client-b-token');
+    });
+
+    it('fetches distinct tokens for concurrent requests with different credentials', async () => {
+      // Concurrent requests for different credentials must each fetch and
+      // resolve to their own token; a shared in-flight promise keyed only by a
+      // single global would collapse both into one fetch and one token.
+      let callCount = 0;
+      worker.use(
+        http.post(BITBUCKET_CLOUD_OAUTH_TOKEN_URL, ({ request }) => {
+          callCount++;
+          const authorization = request.headers.get('Authorization') ?? '';
+          const [clientId] = Buffer.from(
+            authorization.replace(/^Basic /, ''),
+            'base64',
+          )
+            .toString('utf8')
+            .split(':');
+          return HttpResponse.json({
+            access_token: `${clientId}-token`,
+            expires_in: 3600,
+          });
+        }),
+      );
+
+      const withOAuthC: BitbucketCloudIntegrationConfig = {
+        host: BITBUCKET_CLOUD_HOST,
+        apiBaseUrl: BITBUCKET_CLOUD_API_BASE_URL,
+        clientId: 'client-c',
+        clientSecret: 'secret-c',
+      };
+      const withOAuthD: BitbucketCloudIntegrationConfig = {
+        host: BITBUCKET_CLOUD_HOST,
+        apiBaseUrl: BITBUCKET_CLOUD_API_BASE_URL,
+        clientId: 'client-d',
+        clientSecret: 'secret-d',
+      };
+
+      const [resultC, resultD] = await Promise.all([
+        getBitbucketCloudRequestOptions(withOAuthC),
+        getBitbucketCloudRequestOptions(withOAuthD),
+      ]);
+
+      expect(resultC.headers.Authorization).toEqual('Bearer client-c-token');
+      expect(resultD.headers.Authorization).toEqual('Bearer client-d-token');
+      expect(callCount).toBe(2);
+    });
   });
 
   describe('getBitbucketCloudFileFetchUrl', () => {

--- a/packages/integration/src/bitbucketCloud/core.ts
+++ b/packages/integration/src/bitbucketCloud/core.ts
@@ -25,11 +25,14 @@ type OAuthTokenData = {
   expiresAt: DateTime;
 };
 
-// In-memory token cache (single entry since there's only one Bitbucket Cloud integration)
-let cachedToken: OAuthTokenData | undefined;
+// In-memory token cache keyed by credentials, so each distinct
+// clientId/clientSecret pair (i.e. each Bitbucket Cloud integration) caches
+// its own token independently.
+const tokenCache = new Map<string, OAuthTokenData>();
 
-// Track in-flight token refresh request to prevent concurrent fetches
-let refreshPromise: Promise<string> | undefined;
+// Track in-flight token refresh requests per credential set to prevent
+// concurrent fetches for the same credentials.
+const refreshPromises = new Map<string, Promise<string>>();
 
 /**
  * Fetches an OAuth access token from Bitbucket Cloud using client credentials flow.
@@ -44,18 +47,24 @@ export async function getBitbucketCloudOAuthToken(
   clientId: string,
   clientSecret: string,
 ): Promise<string> {
+  // Derive a cache key from the credentials. Using JSON.stringify of a tuple
+  // avoids ambiguity if a clientId contained a delimiter character.
+  const cacheKey = JSON.stringify([clientId, clientSecret]);
+
   // Check cache
-  if (cachedToken && DateTime.now() < cachedToken.expiresAt) {
-    return cachedToken.token;
+  const cached = tokenCache.get(cacheKey);
+  if (cached && DateTime.now() < cached.expiresAt) {
+    return cached.token;
   }
 
-  // Check if there's already a refresh in progress
-  if (refreshPromise) {
-    return refreshPromise;
+  // Check if there's already a refresh in progress for these credentials
+  const inFlight = refreshPromises.get(cacheKey);
+  if (inFlight) {
+    return inFlight;
   }
 
   // Start a new token fetch and track it
-  refreshPromise = (async () => {
+  const refreshPromise = (async () => {
     try {
       // Fetch new token
       const credentials = Buffer.from(
@@ -94,10 +103,10 @@ export async function getBitbucketCloudOAuthToken(
         .minus({ minutes: 10 });
 
       // Cache the token
-      cachedToken = {
+      tokenCache.set(cacheKey, {
         token: data.access_token,
         expiresAt,
-      };
+      });
 
       return data.access_token;
     } catch (error) {
@@ -105,10 +114,12 @@ export async function getBitbucketCloudOAuthToken(
         `Failed to fetch OAuth token for Bitbucket Cloud: ${error}`,
       );
     } finally {
-      // Clean up the in-flight promise tracking
-      refreshPromise = undefined;
+      // Clean up the in-flight promise tracking for these credentials
+      refreshPromises.delete(cacheKey);
     }
   })();
+
+  refreshPromises.set(cacheKey, refreshPromise);
 
   return refreshPromise;
 }


### PR DESCRIPTION
Fixes credential bleed in the Bitbucket Cloud OAuth token cache in `@backstage/integration`.

Backstage supports multiple Bitbucket Cloud integrations (each with its own `clientId`/`clientSecret`) and credentials can be rotated. The client-credentials token and the in-flight refresh promise were previously held in single module-global variables that were **not keyed by credentials**, so:

- a second integration with different credentials could receive the first integration's token, and
- concurrent refreshes for different credentials collapsed onto one shared in-flight promise, silently ignoring the second credential set.

Both the token cache and the in-flight refresh tracking are now keyed per credential set, so each integration caches and refreshes its own token independently. The public API signature of `getBitbucketCloudOAuthToken` is unchanged (API reports are unaffected).

Commits are atomic: fix, regression tests, changeset.

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
