### PR TITLE
fix(ui) : Ensure the document body fills the small viewport height.

### DIFF
--- a/.changeset/sour-boats-marry.md
+++ b/.changeset/sour-boats-marry.md
@@ -1,0 +1,5 @@
+---
+'@backstage/ui': patch
+---
+
+Improve layout rendering by ensuring the document body fills the small viewport height.

--- a/packages/ui/src/css/core.css
+++ b/packages/ui/src/css/core.css
@@ -28,6 +28,7 @@
 
   body {
     background-color: var(--bui-bg-app);
+    min-height: 100svh;
 
     /* Text defaults */
     color: var(--bui-fg-primary);


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

When i added argocd plugin, the background of the content margins appeared white.
(I reported this issue on cummunity-plugins repo https://github.com/backstage/backstage/issues/35577

<img width="1243" height="894" alt="644746752-6a634f87-b0a2-4cac-86f2-18b0c4cdb801" src="https://github.com/user-attachments/assets/e5ff1e7a-ea55-40b4-b803-cc32e38eb1fc" />


Specifying the height in the HTML body ensures that this issue does not occur.

<img width="1350" height="933" alt="Screenshot 2026-09-07 at 13 54 16" src="https://github.com/user-attachments/assets/e4a042ff-6a37-4495-9118-bfca22ba22dc" />

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [X] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
