### PR TITLE
fix(scaffolder-backend-module-gitlab): ID comparison perf improvment

### DIFF
--- a/.changeset/eight-cases-repeat.md
+++ b/.changeset/eight-cases-repeat.md
@@ -14,4 +14,4 @@ pages.
 For a merge request against a repository of a few hundred files this cuts the number of requests
 from roughly 300 to under ten, taking a step that took 5-15 seconds against a self-hosted GitLab
 down to about 3 seconds. Which files are created, updated or skipped is unchanged, including for
-repositories using git's sha256 object format.
+repositories using git sha256 object format.

--- a/.changeset/eight-cases-repeat.md
+++ b/.changeset/eight-cases-repeat.md
@@ -1,0 +1,17 @@
+---
+'@backstage/plugin-scaffolder-backend-module-gitlab': patch
+---
+
+Sped up `publish:gitlab:merge-request` and `gitlab:repo:push` by drastically reducing the number
+of GitLab API requests they make.
+
+Under the default `commitAction: 'auto'`, both actions previously downloaded the contents of every
+file already present on the target branch in order to work out which ones had actually changed.
+That information is available from the repository listing they already fetch, so the comparison is
+now done locally and those per-file requests are gone. The listing itself is also fetched in larger
+pages.
+
+For a merge request against a repository of a few hundred files this cuts the number of requests
+from roughly 300 to under ten, taking a step that took 5-15 seconds against a self-hosted GitLab
+down to about 3 seconds. Which files are created, updated or skipped is unchanged, including for
+repositories using git's sha256 object format.

--- a/plugins/scaffolder-backend-module-gitlab/src/actions/gitlabMergeRequest.test.ts
+++ b/plugins/scaffolder-backend-module-gitlab/src/actions/gitlabMergeRequest.test.ts
@@ -195,7 +195,9 @@ const mockGitlabClient = {
         else {
           return [
             {
-              id: 'a1e8f8d745cc87e3a9248358d9352bb7f9a0aeba',
+              // `git hash-object` of this entry's contents ('foo-bar-baz'), which is what
+              // GitLab returns here and what getFileAction compares against.
+              id: '6463ca9e2f99a4e9b97e1e9e24e752b52228ccef',
               name: 'auto.txt',
               type: 'blob',
               path: 'source/auto.txt',
@@ -221,7 +223,7 @@ const mockGitlabClient = {
           content_sha256:
             '269dce1a5bb90188b2d9cf542a7c30e410c7d8251e34a97bfea56062df51ae23',
           ref,
-          blob_id: 'a1e8f8d745cc87e3a9248358d9352bb7f9a0aeba',
+          blob_id: '6463ca9e2f99a4e9b97e1e9e24e752b52228ccef',
           commit_id: 'd5a3ff139356ce33e37e73add446f16869741b50',
           last_commit_id: '570e7b2abdd848b95f2f578043fc23bd6f6fd24d',
         };
@@ -1321,7 +1323,7 @@ describe('createGitLabMergeRequest', () => {
         'owner/repo',
         'new-mr',
         'Create my new MR',
-        expect.arrayContaining([
+        [
           {
             action: 'create',
             filePath: 'source/foo.txt',
@@ -1329,8 +1331,10 @@ describe('createGitLabMergeRequest', () => {
             encoding: 'base64',
             execute_filemode: false,
           },
-        ]),
+        ],
       );
+      // The unmodified file is recognised from the tree listing alone.
+      expect(mockGitlabClient.RepositoryFiles.show).not.toHaveBeenCalled();
       expect(mockGitlabClient.MergeRequests.create).toHaveBeenCalledWith(
         'owner/repo',
         'new-mr',

--- a/plugins/scaffolder-backend-module-gitlab/src/actions/gitlabMergeRequest.ts
+++ b/plugins/scaffolder-backend-module-gitlab/src/actions/gitlabMergeRequest.ts
@@ -301,6 +301,8 @@ _deprecated_: \`projectid\` passed as query parameters in the \`repoUrl\``,
             ref: targetBranch,
             recursive: true,
             path: targetPath ?? undefined,
+            // Pages are walked serially via the Link header, and GitLab's default is 20.
+            perPage: 100,
           });
         } catch (e) {
           ctx.logger.warn(

--- a/plugins/scaffolder-backend-module-gitlab/src/actions/gitlabRepoPush.ts
+++ b/plugins/scaffolder-backend-module-gitlab/src/actions/gitlabRepoPush.ts
@@ -148,6 +148,8 @@ export const createGitlabRepoPushAction = (options: {
             ref: branchName,
             recursive: true,
             path: targetPath ?? undefined,
+            // Pages are walked serially via the Link header, and GitLab's default is 20.
+            perPage: 100,
           });
         } catch (e) {
           ctx.logger.warn(

--- a/plugins/scaffolder-backend-module-gitlab/src/util.test.ts
+++ b/plugins/scaffolder-backend-module-gitlab/src/util.test.ts
@@ -15,10 +15,13 @@
  */
 
 import * as util from './util';
-import { Gitlab, GroupSchema } from '@gitbeaker/rest';
+import { Gitlab, GroupSchema, RepositoryTreeSchema } from '@gitbeaker/rest';
 import { InputError } from '@backstage/errors';
 import { ConfigReader } from '@backstage/config';
 import { ScmIntegrations } from '@backstage/integration';
+import { mockServices } from '@backstage/backend-test-utils';
+import { SerializedFile } from '@backstage/plugin-scaffolder-node';
+import { createHash } from 'node:crypto';
 
 // Mock the Gitlab client and its methods
 const mockGitlabClient = {
@@ -425,5 +428,170 @@ describe('convertDate', () => {
 
     // Expecting an InputError to be thrown
     expect(() => util.convertDate(inputDate, defaultDate)).toThrow(InputError);
+  });
+});
+
+describe('getFileAction', () => {
+  // Object ids below are real `git hash-object` output for the contents they sit next to.
+  const BLOB_FOO_BAR_BAZ = '6463ca9e2f99a4e9b97e1e9e24e752b52228ccef';
+  const BLOB_CHANGED_CONTENT = '8a4c7293b2b39d7581915204c5f5f6e3b7023203';
+  const BLOB_EMPTY = 'e69de29bb2d1d6434b8b29ae775ad8c2e48c5391';
+  const BLOB_LINK_TARGET = '567dcc0008aa3e8791fb5bb9781d252fc461075a';
+
+  const logger = mockServices.logger.mock();
+  const show = jest.fn();
+  const api = {
+    RepositoryFiles: { show },
+  } as unknown as InstanceType<typeof Gitlab>;
+  const target = { repoID: 'owner/repo', branch: 'main' };
+
+  const file = (path: string, content: string): SerializedFile => ({
+    path,
+    content: Buffer.from(content),
+    executable: false,
+    symlink: false,
+  });
+
+  const treeEntry = (path: string, id?: string) =>
+    ({ path, id } as RepositoryTreeSchema);
+
+  const getFileAction = (
+    f: SerializedFile,
+    remoteFiles: RepositoryTreeSchema[],
+    opts: {
+      targetPath?: string;
+      commitAction?: 'create' | 'delete' | 'update' | 'skip' | 'auto';
+    } = {},
+  ) =>
+    util.getFileAction(
+      { file: f, targetPath: opts.targetPath },
+      target,
+      api,
+      logger,
+      remoteFiles,
+      opts.commitAction,
+    );
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should skip an unchanged file without requesting its contents', async () => {
+    const f = file('a.txt', 'foo-bar-baz');
+
+    await expect(
+      getFileAction(f, [treeEntry('a.txt', BLOB_FOO_BAR_BAZ)]),
+    ).resolves.toEqual('skip');
+    expect(show).not.toHaveBeenCalled();
+  });
+
+  it('should update a changed file without requesting its contents', async () => {
+    const f = file('a.txt', 'changed content');
+
+    await expect(
+      getFileAction(f, [treeEntry('a.txt', BLOB_FOO_BAR_BAZ)]),
+    ).resolves.toEqual('update');
+    expect(show).not.toHaveBeenCalled();
+  });
+
+  it('should create a file that is absent from the tree', async () => {
+    await expect(
+      getFileAction(file('new.txt', 'x'), [
+        treeEntry('a.txt', BLOB_FOO_BAR_BAZ),
+      ]),
+    ).resolves.toEqual('create');
+    expect(show).not.toHaveBeenCalled();
+  });
+
+  it('should join targetPath before matching against the tree', async () => {
+    const f = file('a.txt', 'changed content');
+
+    await expect(
+      getFileAction(f, [treeEntry('sub/a.txt', BLOB_CHANGED_CONTENT)], {
+        targetPath: 'sub',
+      }),
+    ).resolves.toEqual('skip');
+  });
+
+  it('should hash an empty file correctly', async () => {
+    await expect(
+      getFileAction(file('empty', ''), [treeEntry('empty', BLOB_EMPTY)]),
+    ).resolves.toEqual('skip');
+  });
+
+  it('should hash binary content containing NUL bytes correctly', async () => {
+    const f: SerializedFile = {
+      path: 'b.bin',
+      content: Buffer.from([0, 1, 2, 0, 255, 0]),
+      executable: false,
+      symlink: false,
+    };
+    const id = createHash('sha1')
+      .update(`blob ${f.content.length}\0`)
+      .update(f.content)
+      .digest('hex');
+
+    await expect(getFileAction(f, [treeEntry('b.bin', id)])).resolves.toEqual(
+      'skip',
+    );
+  });
+
+  it('should compare a symlink against the blob of its target path', async () => {
+    // serializeDirectoryContents stores readlink() output as the content, as git does.
+    const f: SerializedFile = {
+      path: 'link',
+      content: Buffer.from('../target/file'),
+      executable: false,
+      symlink: true,
+    };
+
+    await expect(
+      getFileAction(f, [treeEntry('link', BLOB_LINK_TARGET)]),
+    ).resolves.toEqual('skip');
+  });
+
+  it('should compare with sha256 in a repository using the sha256 object format', async () => {
+    const f = file('a.txt', 'foo-bar-baz');
+    const id =
+      '6ae59be0528e3485c1ceabf48c2dfb18a4dae525e55b828a3a2325119c7fe86e';
+
+    await expect(getFileAction(f, [treeEntry('a.txt', id)])).resolves.toEqual(
+      'skip',
+    );
+    expect(show).not.toHaveBeenCalled();
+  });
+
+  it('should fall back to comparing contents when the tree id is unusable', async () => {
+    show.mockResolvedValue({
+      content_sha256:
+        '269dce1a5bb90188b2d9cf542a7c30e410c7d8251e34a97bfea56062df51ae23',
+    });
+
+    await expect(
+      getFileAction(file('a.txt', 'foo-bar-baz'), [
+        treeEntry('a.txt', 'not-a-valid-object-id'),
+      ]),
+    ).resolves.toEqual('skip');
+    expect(show).toHaveBeenCalledWith('owner/repo', 'a.txt', 'main');
+  });
+
+  it('should fall back to comparing contents when the tree id is missing', async () => {
+    show.mockResolvedValue({ content_sha256: 'something-else' });
+
+    await expect(
+      getFileAction(file('a.txt', 'foo-bar-baz'), [treeEntry('a.txt')]),
+    ).resolves.toEqual('update');
+    expect(show).toHaveBeenCalledTimes(1);
+  });
+
+  it('should return an explicit commitAction without inspecting the tree', async () => {
+    await expect(
+      getFileAction(
+        file('a.txt', 'foo-bar-baz'),
+        [treeEntry('a.txt', BLOB_FOO_BAR_BAZ)],
+        { commitAction: 'create' },
+      ),
+    ).resolves.toEqual('create');
+    expect(show).not.toHaveBeenCalled();
   });
 });

--- a/plugins/scaffolder-backend-module-gitlab/src/util.ts
+++ b/plugins/scaffolder-backend-module-gitlab/src/util.ts
@@ -211,6 +211,28 @@ function computeSha256(file: SerializedFile): string {
   return hash.digest('hex');
 }
 
+/**
+ * The hash a repository uses for its object ids, derived from the width of one of them. Git's
+ * default object format is sha1; repositories created with `--object-format=sha256` use sha256.
+ */
+function blobIdAlgorithm(id: unknown): 'sha1' | 'sha256' | undefined {
+  if (typeof id !== 'string') return undefined;
+  if (/^[0-9a-f]{40}$/.test(id)) return 'sha1';
+  if (/^[0-9a-f]{64}$/.test(id)) return 'sha256';
+  return undefined;
+}
+
+/** A file's git object id: hash of `blob <byte length>\0` followed by its contents. */
+function computeGitBlobId(
+  file: SerializedFile,
+  algorithm: 'sha1' | 'sha256',
+): string {
+  const hash = createHash(algorithm);
+  hash.update(`blob ${file.content.length}\0`);
+  hash.update(file.content);
+  return hash.digest('hex');
+}
+
 export async function getFileAction(
   fileInfo: { file: SerializedFile; targetPath?: string },
   target: { repoID: string; branch: string },
@@ -227,7 +249,19 @@ export async function getFileAction(
   if (defaultCommitAction === 'auto') {
     const filePath = path.join(fileInfo.targetPath ?? '', fileInfo.file.path);
 
-    if (remoteFiles?.some(remoteFile => remoteFile.path === filePath)) {
+    const remoteFile = remoteFiles?.find(entry => entry.path === filePath);
+
+    if (remoteFile) {
+      // The tree listing already carries every blob's object id, so an unchanged file can be
+      // recognised without fetching its contents. Fall through to the request below only if
+      // the id isn't one we can compare against.
+      const algorithm = blobIdAlgorithm(remoteFile.id);
+      if (algorithm) {
+        return computeGitBlobId(fileInfo.file, algorithm) === remoteFile.id
+          ? 'skip'
+          : 'update';
+      }
+
       try {
         const targetFile = await api.RepositoryFiles.show(
           target.repoID,


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This PR has been assisted by Claude.

`publish:gitlab:merge-request` was taking 5–15 seconds against a self-hosted GitLab. It turned out
almost all of that was the action asking GitLab for information it already had.

### The short version

Every file stored in git has an ID derived from its contents. When you ask GitLab to list a 
repository, it includes that ID next to every file, for free.

To decide which files a scaffolder template actually changed, the action asks GitLab for exactly
that listing... then ignores the IDs, and downloads the full contents of every file so it can hash
them itself and compare. That's one extra HTTP request per file in the repository, every run, just
to discover that almost nothing changed.

This PR compares the ID that was already sitting in the listing. Same answer, no requests.

### Impact

Measured on a real 273-file repository against a self-hosted GitLab, creating an MR that touched
two files:

|                     | before | after |
| ------------------- | -----: | ----: |
| GitLab API requests |  ~296  |   ~8  |
| Duration            | 5 - 15s|   ~3s |

The ~3s that remains is mostly GitLab's own work creating the commit and the merge request, which
no client-side change can help with.

`gitlab:repo:push` shares the same code path and gets the same improvement.

### Is it safe?

The decision (`create` / `update` / `skip` per file) is unchanged — only how it's reached:

- **Repositories using git's sha256 object format** are handled; the hash is picked from the width
  of the ID GitLab returned rather than assumed.
- **If the ID is missing or isn't one we recognise**, the code falls back to the previous
  download-and-compare path, so an unexpected response can't cause a wrong decision.
- **Symlinks** already worked out correctly, since git stores a symlink's content as its target
  path — which is exactly what the scaffolder had in hand.

There's one unrelated tidy-up bundled in, because the change surfaced it: the merge-request test
fixture claimed a file's ID was `a1e8f8d7…`, which is the example value from GitLab's own API docs,
not the real ID of the fixture's contents. Nothing had noticed, because nothing compared them
before. It's corrected to the real value, and that test now also asserts the unchanged file is
skipped *and* never fetched — so a regression here would fail loudly instead of just getting slow
again.

The tree listing is also fetched 100 entries at a time instead of GitLab's default of 20, since
those pages are walked one after another.

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
