### PR TITLE
fix(scaffolder): paginate entity picker options

### DIFF
--- a/.changeset/calm-pickers-page.md
+++ b/.changeset/calm-pickers-page.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-scaffolder': patch
+---
+
+Improved the performance of entity picker fields by loading catalog options in pages and filtering them through the catalog API.

--- a/docs/features/software-templates/ui-options-examples.md
+++ b/docs/features/software-templates/ui-options-examples.md
@@ -4,6 +4,13 @@ title: ui:options Examples
 description: The input props that can be specified under ui:options for different pickers
 ---
 
+Entity fields (`EntityPicker`, `OwnerPicker`, `MultiEntityPicker`, and
+`MyGroupsPicker`) load catalog options in pages as you browse. Typing searches
+the catalog after a short delay, matching entity names, kinds, titles, and
+profile display names. Labels supplied by a custom entity presentation API do
+not add searchable fields. Existing selections are loaded separately, so they
+remain available even when they are outside the displayed page.
+
 ## EntityPicker
 
 The input props that can be specified under `ui:options` for the `EntityPicker` field extension.

--- a/plugins/scaffolder/src/components/fields/EntityPicker/EntityPicker.test.tsx
+++ b/plugins/scaffolder/src/components/fields/EntityPicker/EntityPicker.test.tsx
@@ -21,7 +21,7 @@ import {
   entityPresentationApiRef,
 } from '@backstage/plugin-catalog-react';
 import { renderInTestApp, TestApiProvider } from '@backstage/test-utils';
-import { fireEvent, screen } from '@testing-library/react';
+import { fireEvent, screen, waitFor } from '@testing-library/react';
 import { PropsWithChildren, ComponentType, ReactNode } from 'react';
 import { EntityPicker } from './EntityPicker';
 import { EntityPickerProps } from './schema';
@@ -51,15 +51,17 @@ describe('<EntityPicker />', () => {
 
   let props: FieldProps<string>;
 
-  const catalogApi = catalogApiMock.mock({
-    streamEntities: jest.fn(async function* () {
-      yield entities;
-    }),
-  });
+  const catalogApi = catalogApiMock.mock();
 
   let Wrapper: ComponentType<PropsWithChildren<{}>>;
 
   beforeEach(() => {
+    catalogApi.queryEntities.mockResolvedValue({
+      items: entities,
+      totalItems: 0,
+      pageInfo: {},
+    });
+    catalogApi.getEntitiesByRefs.mockResolvedValue({ items: [] });
     Wrapper = ({ children }: { children?: ReactNode }) => (
       <TestApiProvider
         apis={[
@@ -97,7 +99,7 @@ describe('<EntityPicker />', () => {
         </Wrapper>,
       );
 
-      expect(catalogApi.streamEntities).toHaveBeenCalledWith({
+      expect(catalogApi.queryEntities).toHaveBeenCalledWith({
         fields: [
           'kind',
           'metadata.name',
@@ -107,7 +109,28 @@ describe('<EntityPicker />', () => {
           'spec.profile.displayName',
           'spec.type',
         ],
+        limit: 20,
+        orderFields: [{ field: 'metadata.name', order: 'asc' }],
+        totalItems: 'exclude',
       });
+    });
+
+    it('filters entities through the catalog as the user types', async () => {
+      const { getByRole } = await renderInTestApp(
+        <Wrapper>
+          <EntityPicker {...props} />
+        </Wrapper>,
+      );
+
+      fireEvent.change(getByRole('textbox'), { target: { value: 'team' } });
+
+      await waitFor(() =>
+        expect(catalogApi.queryEntities).toHaveBeenLastCalledWith(
+          expect.objectContaining({
+            fullTextFilter: expect.objectContaining({ term: 'team' }),
+          }),
+        ),
+      );
     });
 
     it('updates even if there is not an exact match', async () => {
@@ -150,9 +173,8 @@ describe('<EntityPicker />', () => {
         </Wrapper>,
       );
 
-      expect(catalogApi.streamEntities).toHaveBeenCalledWith(
+      expect(catalogApi.queryEntities).toHaveBeenCalledWith(
         expect.objectContaining({
-          query: {},
           filter: { kind: ['User'] },
         }),
       );
@@ -196,9 +218,8 @@ describe('<EntityPicker />', () => {
         </Wrapper>,
       );
 
-      expect(catalogApi.streamEntities).toHaveBeenCalledWith(
+      expect(catalogApi.queryEntities).toHaveBeenCalledWith(
         expect.objectContaining({
-          query: {},
           filter: [
             {
               kind: ['Group'],
@@ -232,9 +253,8 @@ describe('<EntityPicker />', () => {
         </Wrapper>,
       );
 
-      expect(catalogApi.streamEntities).toHaveBeenCalledWith(
+      expect(catalogApi.queryEntities).toHaveBeenCalledWith(
         expect.objectContaining({
-          query: {},
           filter: {
             kind: ['Group'],
             'metadata.name': 'test-entity',
@@ -261,9 +281,8 @@ describe('<EntityPicker />', () => {
         </Wrapper>,
       );
 
-      expect(catalogApi.streamEntities).toHaveBeenCalledWith(
+      expect(catalogApi.queryEntities).toHaveBeenCalledWith(
         expect.objectContaining({
-          query: {},
           filter: [
             {
               kind: ['User'],
@@ -378,9 +397,8 @@ describe('<EntityPicker />', () => {
         </Wrapper>,
       );
 
-      expect(catalogApi.streamEntities).toHaveBeenCalledWith(
+      expect(catalogApi.queryEntities).toHaveBeenCalledWith(
         expect.objectContaining({
-          query: {},
           filter: [
             {
               kind: ['Group'],
@@ -563,8 +581,10 @@ describe('<EntityPicker />', () => {
           profile: { displayName: item.metadata.name.replace('-', ' ') },
         },
       }));
-      catalogApi.streamEntities.mockImplementation(async function* () {
-        yield items;
+      catalogApi.queryEntities.mockResolvedValue({
+        items,
+        totalItems: 0,
+        pageInfo: {},
       });
 
       const { getByRole, getByText } = await renderInTestApp(
@@ -594,8 +614,10 @@ describe('<EntityPicker />', () => {
           title: item.metadata.name.replace('-', ' ').toUpperCase(),
         },
       }));
-      catalogApi.streamEntities.mockImplementation(async function* () {
-        yield items;
+      catalogApi.queryEntities.mockResolvedValue({
+        items,
+        totalItems: 0,
+        pageInfo: {},
       });
 
       const { getByRole, getByText } = await renderInTestApp(

--- a/plugins/scaffolder/src/components/fields/EntityPicker/EntityPicker.test.tsx
+++ b/plugins/scaffolder/src/components/fields/EntityPicker/EntityPicker.test.tsx
@@ -232,6 +232,97 @@ describe('<EntityPicker />', () => {
       expect(onChange).not.toHaveBeenCalled();
     });
 
+    it('does not clear a BUI selection while its entity is loading', async () => {
+      mockUseScaffolderTheme.mockReturnValue('bui');
+      catalogApi.getEntitiesByRefs.mockReturnValueOnce(new Promise(() => {}));
+      props = {
+        ...props,
+        formData: 'group:default/off-page',
+        uiSchema: {
+          'ui:options': { allowArbitraryValues: false },
+        },
+      } as unknown as FieldProps<any>;
+      await renderInTestApp(
+        <Wrapper>
+          <EntityPicker {...props} />
+        </Wrapper>,
+      );
+      const input = screen.getByRole('combobox');
+
+      fireEvent.focus(input);
+      fireEvent.blur(input);
+
+      expect(onChange).not.toHaveBeenCalled();
+    });
+
+    it.each(['missing', 'failed'] as const)(
+      'does not clear a BUI selection when its entity lookup is %s',
+      async outcome => {
+        mockUseScaffolderTheme.mockReturnValue('bui');
+        if (outcome === 'missing') {
+          catalogApi.getEntitiesByRefs.mockResolvedValueOnce({
+            items: [undefined],
+          });
+        } else {
+          catalogApi.getEntitiesByRefs.mockRejectedValueOnce(
+            new Error('catalog unavailable'),
+          );
+        }
+        props = {
+          ...props,
+          formData: 'group:default/off-page',
+          uiSchema: {
+            'ui:options': { allowArbitraryValues: false },
+          },
+        } as unknown as FieldProps<any>;
+        await renderInTestApp(
+          <Wrapper>
+            <EntityPicker {...props} />
+          </Wrapper>,
+        );
+        const input = screen.getByRole('combobox');
+        await waitFor(() =>
+          expect(catalogApi.getEntitiesByRefs).toHaveBeenCalled(),
+        );
+
+        fireEvent.focus(input);
+        fireEvent.blur(input);
+
+        expect(onChange).not.toHaveBeenCalled();
+      },
+    );
+
+    it('does not commit a BUI presentation title as an arbitrary value on blur', async () => {
+      mockUseScaffolderTheme.mockReturnValue('bui');
+      const selectedEntity = {
+        ...makeEntity('Group', 'default', 'off-page'),
+        metadata: {
+          namespace: 'default',
+          name: 'off-page',
+          title: 'Off Page Group',
+        },
+      };
+      catalogApi.getEntitiesByRefs.mockResolvedValueOnce({
+        items: [selectedEntity],
+      });
+      props = {
+        ...props,
+        formData: 'group:default/off-page',
+      } as unknown as FieldProps<any>;
+      await renderInTestApp(
+        <Wrapper>
+          <EntityPicker {...props} />
+        </Wrapper>,
+      );
+      const input = screen.getByRole('combobox');
+      await waitFor(() => expect(input).toHaveValue('Off Page Group'));
+
+      fireEvent.focus(input);
+      fireEvent.blur(input);
+
+      expect(onChange).not.toHaveBeenCalled();
+    });
+
     it('updates even if there is not an exact match', async () => {
       const { getByRole } = await renderInTestApp(
         <Wrapper>

--- a/plugins/scaffolder/src/components/fields/EntityPicker/EntityPicker.test.tsx
+++ b/plugins/scaffolder/src/components/fields/EntityPicker/EntityPicker.test.tsx
@@ -14,7 +14,10 @@
  * limitations under the License.
  */
 
-import { CATALOG_FILTER_EXISTS } from '@backstage/catalog-client';
+import {
+  type CatalogApi,
+  CATALOG_FILTER_EXISTS,
+} from '@backstage/catalog-client';
 import { Entity } from '@backstage/catalog-model';
 import {
   catalogApiRef,
@@ -39,6 +42,9 @@ jest.mock('@backstage/plugin-scaffolder-react/alpha', () => ({
 
 const mockUseScaffolderTheme = jest.mocked(useScaffolderTheme);
 
+type SpiedCatalogApi = CatalogApi &
+  Pick<jest.Mocked<CatalogApi>, 'getEntitiesByRefs' | 'queryEntities'>;
+
 const makeEntity = (kind: string, namespace: string, name: string): Entity => ({
   apiVersion: 'scaffolder.backstage.io/v1beta3',
   kind,
@@ -59,18 +65,17 @@ describe('<EntityPicker />', () => {
 
   let props: FieldProps<string>;
 
-  const catalogApi = catalogApiMock.mock();
+  let catalogApi: SpiedCatalogApi;
 
   let Wrapper: ComponentType<PropsWithChildren<{}>>;
 
   beforeEach(() => {
     mockUseScaffolderTheme.mockReturnValue('mui');
-    catalogApi.queryEntities.mockResolvedValue({
-      items: entities,
-      totalItems: 0,
-      pageInfo: {},
+    const api = catalogApiMock({ entities });
+    catalogApi = Object.assign(api, {
+      queryEntities: jest.spyOn(api, 'queryEntities'),
+      getEntitiesByRefs: jest.spyOn(api, 'getEntitiesByRefs'),
     });
-    catalogApi.getEntitiesByRefs.mockResolvedValue({ items: [] });
     Wrapper = ({ children }: { children?: ReactNode }) => (
       <TestApiProvider
         apis={[
@@ -368,10 +373,6 @@ describe('<EntityPicker />', () => {
         rawErrors,
         formData,
       } as unknown as FieldProps<any>;
-
-      catalogApi.streamEntities.mockImplementation(async function* () {
-        yield entities;
-      });
     });
 
     it('searches for users and groups', async () => {
@@ -413,10 +414,6 @@ describe('<EntityPicker />', () => {
         rawErrors,
         formData,
       } as unknown as FieldProps<any>;
-
-      catalogApi.streamEntities.mockImplementation(async function* () {
-        yield entities;
-      });
     });
 
     it('searches for a specific group entity', async () => {
@@ -450,10 +447,6 @@ describe('<EntityPicker />', () => {
           },
         },
       };
-
-      catalogApi.streamEntities.mockImplementation(async function* () {
-        yield entities;
-      });
 
       await renderInTestApp(
         <Wrapper>
@@ -526,10 +519,6 @@ describe('<EntityPicker />', () => {
         rawErrors,
         formData,
       } as unknown as FieldProps<any>;
-
-      catalogApi.streamEntities.mockImplementation(async function* () {
-        yield entities;
-      });
     });
     it('Prevents user from modifying input when ui:disabled is true', async () => {
       props.uiSchema = { 'ui:disabled': true };
@@ -592,10 +581,6 @@ describe('<EntityPicker />', () => {
         rawErrors,
         formData,
       } as unknown as FieldProps<any>;
-
-      catalogApi.streamEntities.mockImplementation(async function* () {
-        yield entities;
-      });
     });
 
     it('searches for a Group entity', async () => {
@@ -633,10 +618,6 @@ describe('<EntityPicker />', () => {
         rawErrors,
         formData,
       } as unknown as FieldProps<any>;
-
-      catalogApi.streamEntities.mockImplementation(async function* () {
-        yield entities;
-      });
     });
 
     it('default behavior', async () => {
@@ -729,10 +710,6 @@ describe('<EntityPicker />', () => {
         rawErrors,
         formData,
       } as unknown as FieldProps<any>;
-
-      catalogApi.streamEntities.mockImplementation(async function* () {
-        yield entities;
-      });
     });
 
     it('returns the full entityRef when entity exists in the list', async () => {
@@ -903,10 +880,6 @@ describe('<EntityPicker />', () => {
         rawErrors,
         formData,
       } as unknown as FieldProps<any>;
-
-      catalogApi.streamEntities.mockImplementation(async function* () {
-        yield entities;
-      });
     });
 
     it('User enters clear input', async () => {
@@ -1002,10 +975,6 @@ describe('<EntityPicker />', () => {
         rawErrors,
         formData,
       } as unknown as FieldProps<any>;
-
-      catalogApi.streamEntities.mockImplementation(async function* () {
-        yield entities;
-      });
     });
 
     it('User enters clear input', async () => {
@@ -1102,10 +1071,6 @@ describe('<EntityPicker />', () => {
         rawErrors,
         formData,
       } as unknown as FieldProps<any>;
-
-      catalogApi.streamEntities.mockImplementation(async function* () {
-        yield entities;
-      });
     });
 
     it('User enters clear input', async () => {
@@ -1202,10 +1167,6 @@ describe('<EntityPicker />', () => {
         rawErrors,
         formData,
       } as unknown as FieldProps<any>;
-
-      catalogApi.streamEntities.mockImplementation(async function* () {
-        yield entities;
-      });
     });
 
     it('User enters clear input', async () => {

--- a/plugins/scaffolder/src/components/fields/EntityPicker/EntityPicker.test.tsx
+++ b/plugins/scaffolder/src/components/fields/EntityPicker/EntityPicker.test.tsx
@@ -165,6 +165,73 @@ describe('<EntityPicker />', () => {
       expect(input).toHaveValue('team');
     });
 
+    it('keeps BUI search input when a selected presentation arrives late', async () => {
+      mockUseScaffolderTheme.mockReturnValue('bui');
+      const selectedEntity = {
+        ...makeEntity('Group', 'default', 'off-page'),
+        metadata: {
+          namespace: 'default',
+          name: 'off-page',
+          title: 'Off Page Group',
+        },
+      };
+      let resolveSelectedEntity = () => {};
+      catalogApi.getEntitiesByRefs.mockReturnValueOnce(
+        new Promise(resolve => {
+          resolveSelectedEntity = () => resolve({ items: [selectedEntity] });
+        }),
+      );
+      props = {
+        ...props,
+        formData: 'group:default/off-page',
+        uiSchema: {
+          'ui:options': { allowArbitraryValues: false },
+        },
+      } as unknown as FieldProps<any>;
+      await renderInTestApp(
+        <Wrapper>
+          <EntityPicker {...props} />
+        </Wrapper>,
+      );
+      const input = screen.getByRole('combobox');
+
+      fireEvent.change(input, { target: { value: 'replacement' } });
+      await act(async () => {
+        resolveSelectedEntity();
+        await Promise.resolve();
+        await Promise.resolve();
+      });
+
+      expect(input).toHaveValue('replacement');
+    });
+
+    it('does not clear a BUI selection outside the current page on blur', async () => {
+      mockUseScaffolderTheme.mockReturnValue('bui');
+      const selectedEntity = makeEntity('Group', 'default', 'off-page');
+      catalogApi.getEntitiesByRefs.mockResolvedValueOnce({
+        items: [selectedEntity],
+      });
+      props = {
+        ...props,
+        formData: 'group:default/off-page',
+        uiSchema: {
+          'ui:options': { allowArbitraryValues: false },
+        },
+      } as unknown as FieldProps<any>;
+      await renderInTestApp(
+        <Wrapper>
+          <EntityPicker {...props} />
+        </Wrapper>,
+      );
+      const input = screen.getByRole('combobox');
+      await waitFor(() => expect(input).toHaveValue('off-page'));
+
+      fireEvent.focus(input);
+      fireEvent.blur(input);
+
+      expect(onChange).not.toHaveBeenCalled();
+    });
+
     it('updates even if there is not an exact match', async () => {
       const { getByRole } = await renderInTestApp(
         <Wrapper>
@@ -178,6 +245,24 @@ describe('<EntityPicker />', () => {
       fireEvent.blur(input);
 
       expect(onChange).toHaveBeenCalledWith('squ');
+    });
+
+    it('does not look up an arbitrary value as an entity ref', async () => {
+      props = {
+        ...props,
+        formData: 'arbitrary-value',
+      } as unknown as FieldProps<any>;
+
+      await renderInTestApp(
+        <Wrapper>
+          <EntityPicker {...props} />
+        </Wrapper>,
+      );
+      await waitFor(() =>
+        expect(catalogApi.queryEntities).toHaveBeenCalledTimes(1),
+      );
+
+      expect(catalogApi.getEntitiesByRefs).not.toHaveBeenCalled();
     });
   });
 

--- a/plugins/scaffolder/src/components/fields/EntityPicker/EntityPicker.test.tsx
+++ b/plugins/scaffolder/src/components/fields/EntityPicker/EntityPicker.test.tsx
@@ -93,6 +93,43 @@ describe('<EntityPicker />', () => {
 
   afterEach(() => jest.resetAllMocks());
 
+  it('preserves typed MUI search when the selected entity moves outside the results', async () => {
+    catalogApi.queryEntities
+      .mockResolvedValueOnce({ items: entities, totalItems: 0, pageInfo: {} })
+      .mockResolvedValueOnce({
+        items: [entities[1]],
+        totalItems: 0,
+        pageInfo: {},
+      });
+    // Separate requests return distinct objects, even for the same entity.
+    catalogApi.getEntitiesByRefs.mockResolvedValue({
+      items: [{ ...entities[0] }],
+    });
+    await renderInTestApp(
+      <Wrapper>
+        <EntityPicker
+          {...({
+            onChange,
+            schema,
+            uiSchema: {},
+            formData: 'group:default/team-a',
+          } as unknown as FieldProps<string>)}
+        />
+      </Wrapper>,
+    );
+    const input = screen.getByRole('textbox');
+    expect(input).toHaveValue('group:default/team-a');
+    fireEvent.focus(input);
+    fireEvent.change(input, { target: { value: 'squad' } });
+    await screen.findByRole('option', { name: 'squad-b' });
+    await waitFor(() =>
+      expect(catalogApi.queryEntities).toHaveBeenCalledTimes(2),
+    );
+    expect(input).toHaveValue('squad');
+    fireEvent.click(screen.getByRole('option', { name: 'squad-b' }));
+    expect(onChange).toHaveBeenCalledWith('group:default/squad-b');
+  });
+
   describe('without allowedKinds and catalogFilter', () => {
     beforeEach(() => {
       uiSchema = { 'ui:options': {} };
@@ -170,45 +207,50 @@ describe('<EntityPicker />', () => {
       expect(input).toHaveValue('team');
     });
 
-    it('keeps BUI search input when a selected presentation arrives late', async () => {
-      mockUseScaffolderTheme.mockReturnValue('bui');
-      const selectedEntity = {
-        ...makeEntity('Group', 'default', 'off-page'),
-        metadata: {
-          namespace: 'default',
-          name: 'off-page',
-          title: 'Off Page Group',
-        },
-      };
-      let resolveSelectedEntity = () => {};
-      catalogApi.getEntitiesByRefs.mockReturnValueOnce(
-        new Promise(resolve => {
-          resolveSelectedEntity = () => resolve({ items: [selectedEntity] });
-        }),
-      );
-      props = {
-        ...props,
-        formData: 'group:default/off-page',
-        uiSchema: {
-          'ui:options': { allowArbitraryValues: false },
-        },
-      } as unknown as FieldProps<any>;
-      await renderInTestApp(
-        <Wrapper>
-          <EntityPicker {...props} />
-        </Wrapper>,
-      );
-      const input = screen.getByRole('combobox');
+    it.each(['bui', 'mui'] as const)(
+      'keeps %s search input when a selected presentation arrives late',
+      async theme => {
+        mockUseScaffolderTheme.mockReturnValue(theme);
+        const selectedEntity = {
+          ...makeEntity('Group', 'default', 'off-page'),
+          metadata: {
+            namespace: 'default',
+            name: 'off-page',
+            title: 'Off Page Group',
+          },
+        };
+        let resolveSelectedEntity = () => {};
+        catalogApi.getEntitiesByRefs.mockReturnValueOnce(
+          new Promise(resolve => {
+            resolveSelectedEntity = () => resolve({ items: [selectedEntity] });
+          }),
+        );
+        props = {
+          ...props,
+          formData: 'group:default/off-page',
+          uiSchema: {
+            'ui:options': { allowArbitraryValues: false },
+          },
+        } as unknown as FieldProps<any>;
+        await renderInTestApp(
+          <Wrapper>
+            <EntityPicker {...props} />
+          </Wrapper>,
+        );
+        const input = screen.getByRole(
+          theme === 'bui' ? 'combobox' : 'textbox',
+        );
 
-      fireEvent.change(input, { target: { value: 'replacement' } });
-      await act(async () => {
-        resolveSelectedEntity();
-        await Promise.resolve();
-        await Promise.resolve();
-      });
+        fireEvent.change(input, { target: { value: 'replacement' } });
+        await act(async () => {
+          resolveSelectedEntity();
+          await Promise.resolve();
+          await Promise.resolve();
+        });
 
-      expect(input).toHaveValue('replacement');
-    });
+        expect(input).toHaveValue('replacement');
+      },
+    );
 
     it('does not clear a BUI selection outside the current page on blur', async () => {
       mockUseScaffolderTheme.mockReturnValue('bui');

--- a/plugins/scaffolder/src/components/fields/EntityPicker/EntityPicker.test.tsx
+++ b/plugins/scaffolder/src/components/fields/EntityPicker/EntityPicker.test.tsx
@@ -21,7 +21,7 @@ import {
   entityPresentationApiRef,
 } from '@backstage/plugin-catalog-react';
 import { renderInTestApp, TestApiProvider } from '@backstage/test-utils';
-import { fireEvent, screen, waitFor } from '@testing-library/react';
+import { act, fireEvent, screen, waitFor } from '@testing-library/react';
 import { PropsWithChildren, ComponentType, ReactNode } from 'react';
 import { EntityPicker } from './EntityPicker';
 import { EntityPickerProps } from './schema';
@@ -30,6 +30,14 @@ import { DefaultEntityPresentationApi } from '@backstage/plugin-catalog';
 import { catalogApiMock } from '@backstage/plugin-catalog-react/testUtils';
 import { useTranslationRef } from '@backstage/frontend-plugin-api';
 import { scaffolderTranslationRef } from '../../../translation';
+import { useScaffolderTheme } from '@backstage/plugin-scaffolder-react/alpha';
+
+jest.mock('@backstage/plugin-scaffolder-react/alpha', () => ({
+  ...jest.requireActual('@backstage/plugin-scaffolder-react/alpha'),
+  useScaffolderTheme: jest.fn(),
+}));
+
+const mockUseScaffolderTheme = jest.mocked(useScaffolderTheme);
 
 const makeEntity = (kind: string, namespace: string, name: string): Entity => ({
   apiVersion: 'scaffolder.backstage.io/v1beta3',
@@ -56,6 +64,7 @@ describe('<EntityPicker />', () => {
   let Wrapper: ComponentType<PropsWithChildren<{}>>;
 
   beforeEach(() => {
+    mockUseScaffolderTheme.mockReturnValue('mui');
     catalogApi.queryEntities.mockResolvedValue({
       items: entities,
       totalItems: 0,
@@ -100,15 +109,6 @@ describe('<EntityPicker />', () => {
       );
 
       expect(catalogApi.queryEntities).toHaveBeenCalledWith({
-        fields: [
-          'kind',
-          'metadata.name',
-          'metadata.namespace',
-          'metadata.title',
-          'metadata.description',
-          'spec.profile.displayName',
-          'spec.type',
-        ],
         limit: 20,
         orderFields: [{ field: 'metadata.name', order: 'asc' }],
         totalItems: 'exclude',
@@ -131,6 +131,38 @@ describe('<EntityPicker />', () => {
           }),
         ),
       );
+    });
+
+    it('keeps BUI search input while filtered results arrive', async () => {
+      mockUseScaffolderTheme.mockReturnValue('bui');
+      const filteredEntity = makeEntity('Group', 'default', 'filtered-result');
+      let resolveFilteredResults = () => {};
+      catalogApi.queryEntities
+        .mockResolvedValueOnce({
+          items: entities,
+          totalItems: 0,
+          pageInfo: {},
+        })
+        .mockReturnValueOnce(
+          new Promise(resolve => {
+            resolveFilteredResults = () =>
+              resolve({ items: [filteredEntity], totalItems: 0, pageInfo: {} });
+          }),
+        );
+      await renderInTestApp(
+        <Wrapper>
+          <EntityPicker {...props} />
+        </Wrapper>,
+      );
+      const input = screen.getByRole('combobox');
+
+      fireEvent.change(input, { target: { value: 'team' } });
+      await waitFor(() =>
+        expect(catalogApi.queryEntities).toHaveBeenCalledTimes(2),
+      );
+      await act(async () => resolveFilteredResults());
+
+      expect(input).toHaveValue('team');
     });
 
     it('updates even if there is not an exact match', async () => {
@@ -637,6 +669,37 @@ describe('<EntityPicker />', () => {
       expect(getByText('SQUAD B')).toBeInTheDocument();
 
       fireEvent.blur(input);
+    });
+
+    it('accepts a selected entity that is not on the current page', async () => {
+      const selectedEntity = makeEntity('Group', 'default', 'off-page');
+      catalogApi.getEntitiesByRefs.mockResolvedValue({
+        items: [selectedEntity],
+      });
+      props = {
+        ...props,
+        formData: 'group:default/off-page',
+        uiSchema: {
+          'ui:options': { allowArbitraryValues: false },
+        },
+      } as unknown as FieldProps<any>;
+      const warn = jest.spyOn(console, 'warn').mockImplementation(() => {});
+
+      await renderInTestApp(
+        <Wrapper>
+          <EntityPicker {...props} />
+        </Wrapper>,
+      );
+      await waitFor(() =>
+        expect(screen.getByRole('textbox')).toHaveValue(
+          'group:default/off-page',
+        ),
+      );
+
+      expect(warn).not.toHaveBeenCalledWith(
+        expect.stringContaining('value provided to Autocomplete is invalid'),
+      );
+      warn.mockRestore();
     });
   });
 

--- a/plugins/scaffolder/src/components/fields/EntityPicker/EntityPicker.tsx
+++ b/plugins/scaffolder/src/components/fields/EntityPicker/EntityPicker.tsx
@@ -119,6 +119,7 @@ export const EntityPicker = (props: EntityPickerProps) => {
 
   const onSelect = useCallback(
     (_: any, ref: string | Entity | null, reason: AutocompleteChangeReason) => {
+      setSearchText('');
       // ref can either be a string from free solo entry or
       if (typeof ref !== 'string') {
         // if ref does not exist: pass 'undefined' to trigger validation for required value
@@ -145,15 +146,32 @@ export const EntityPicker = (props: EntityPickerProps) => {
         }
       }
     },
-    [onChange, formData, defaultKind, defaultNamespace, allowArbitraryValues],
+    [
+      onChange,
+      formData,
+      defaultKind,
+      defaultNamespace,
+      allowArbitraryValues,
+      setSearchText,
+    ],
   );
 
   // Since free solo can be enabled, attempt to parse as a full entity ref first, then
   // fall back to the given value.
   const selectedEntity =
-    selectedEntities.find(e => stringifyEntityRef(e) === formData) ??
     entities.find(e => stringifyEntityRef(e) === formData) ??
+    selectedEntities.find(e => stringifyEntityRef(e) === formData) ??
     (allowArbitraryValues && formData ? getLabel(formData) : '');
+  const muiOptions = useMemo(() => {
+    if (
+      typeof selectedEntity !== 'string' &&
+      selectedEntity &&
+      !entities.includes(selectedEntity)
+    ) {
+      return [selectedEntity, ...entities];
+    }
+    return entities;
+  }, [entities, selectedEntity]);
 
   // BUI: options for autocomplete
   const buiOptions = useMemo(
@@ -171,19 +189,17 @@ export const EntityPicker = (props: EntityPickerProps) => {
 
   // BUI: controlled input value
   const [inputValue, setInputValue] = useState(formData || '');
+  const selectedPresentationTitle = formData
+    ? entityRefToPresentation.get(formData)?.primaryTitle
+    : undefined;
 
   useEffect(() => {
     if (formData) {
-      const opt = buiOptions.find(o => o.value === formData);
-      setInputValue(
-        opt?.label ||
-          entityRefToPresentation.get(formData)?.primaryTitle ||
-          formData,
-      );
+      setInputValue(selectedPresentationTitle || formData);
     } else {
       setInputValue('');
     }
-  }, [entityRefToPresentation, formData, buiOptions]);
+  }, [formData, selectedPresentationTitle]);
 
   const selectedKey =
     formData && buiOptions.some(o => o.value === formData) ? formData : null;
@@ -196,6 +212,7 @@ export const EntityPicker = (props: EntityPickerProps) => {
 
   const handleSelectionChange = useCallback(
     (key: Key | null) => {
+      setSearchText('');
       if (key !== null) {
         const value = String(key);
         lastCommittedRef.current = value;
@@ -216,7 +233,14 @@ export const EntityPicker = (props: EntityPickerProps) => {
         onChange(undefined);
       }
     },
-    [onChange, allowArbitraryValues, inputValue, defaultKind, defaultNamespace],
+    [
+      onChange,
+      allowArbitraryValues,
+      inputValue,
+      defaultKind,
+      defaultNamespace,
+      setSearchText,
+    ],
   );
 
   const handleBlur = useCallback(() => {
@@ -231,6 +255,7 @@ export const EntityPicker = (props: EntityPickerProps) => {
       }
       if (lastCommittedRef.current !== entityRef) {
         lastCommittedRef.current = entityRef;
+        setSearchText('');
         onChange(entityRef);
       }
     }
@@ -240,6 +265,7 @@ export const EntityPicker = (props: EntityPickerProps) => {
     defaultKind,
     defaultNamespace,
     onChange,
+    setSearchText,
   ]);
 
   // Auto-select when only one entity and required
@@ -328,7 +354,7 @@ export const EntityPicker = (props: EntityPickerProps) => {
         value={selectedEntity}
         loading={loading}
         onChange={onSelect}
-        options={entities}
+        options={muiOptions}
         onInputChange={(_event, value, reason) => {
           if (reason === 'input' || reason === 'clear') {
             setSearchText(value);
@@ -341,6 +367,11 @@ export const EntityPicker = (props: EntityPickerProps) => {
             : entityRefToPresentation.get(stringifyEntityRef(option))
                 ?.entityRef!
         }
+        getOptionSelected={(option, value) =>
+          typeof value !== 'string' &&
+          stringifyEntityRef(option) === stringifyEntityRef(value)
+        }
+        filterSelectedOptions
         autoSelect={autoSelect}
         freeSolo={allowArbitraryValues}
         renderInput={params => (

--- a/plugins/scaffolder/src/components/fields/EntityPicker/EntityPicker.tsx
+++ b/plugins/scaffolder/src/components/fields/EntityPicker/EntityPicker.tsx
@@ -85,10 +85,22 @@ export const EntityPicker = (props: EntityPickerProps) => {
 
   const allowArbitraryValues =
     uiSchema['ui:options']?.allowArbitraryValues ?? true;
-  const selectedEntityRefs = useMemo(
-    () => (formData ? [formData] : []),
-    [formData],
-  );
+  const selectedEntityRefs = useMemo(() => {
+    if (!formData) {
+      return [];
+    }
+
+    try {
+      return [
+        stringifyEntityRef(
+          parseEntityRef(formData, { defaultKind, defaultNamespace }),
+        ),
+      ];
+    } catch {
+      return [];
+    }
+  }, [formData, defaultKind, defaultNamespace]);
+  const normalizedFormData = selectedEntityRefs[0] ?? formData;
   const {
     entities,
     selectedEntities,
@@ -159,8 +171,8 @@ export const EntityPicker = (props: EntityPickerProps) => {
   // Since free solo can be enabled, attempt to parse as a full entity ref first, then
   // fall back to the given value.
   const selectedEntity =
-    entities.find(e => stringifyEntityRef(e) === formData) ??
-    selectedEntities.find(e => stringifyEntityRef(e) === formData) ??
+    entities.find(e => stringifyEntityRef(e) === normalizedFormData) ??
+    selectedEntities.find(e => stringifyEntityRef(e) === normalizedFormData) ??
     (allowArbitraryValues && formData ? getLabel(formData) : '');
   const muiOptions = useMemo(() => {
     if (
@@ -176,7 +188,7 @@ export const EntityPicker = (props: EntityPickerProps) => {
   // BUI: options for autocomplete
   const buiOptions = useMemo(
     () =>
-      entities.map(entity => {
+      muiOptions.map(entity => {
         const entityRef = stringifyEntityRef(entity);
         const presentation = entityRefToPresentation.get(entityRef);
         return {
@@ -184,25 +196,31 @@ export const EntityPicker = (props: EntityPickerProps) => {
           label: presentation?.primaryTitle || entityRef,
         };
       }),
-    [entities, entityRefToPresentation],
+    [muiOptions, entityRefToPresentation],
   );
 
   // BUI: controlled input value
   const [inputValue, setInputValue] = useState(formData || '');
+  const inputIsDirtyRef = useRef(false);
+  const previousFormDataRef = useRef(formData);
   const selectedPresentationTitle = formData
-    ? entityRefToPresentation.get(formData)?.primaryTitle
+    ? entityRefToPresentation.get(normalizedFormData)?.primaryTitle
     : undefined;
 
   useEffect(() => {
-    if (formData) {
-      setInputValue(selectedPresentationTitle || formData);
-    } else {
-      setInputValue('');
+    if (previousFormDataRef.current !== formData) {
+      previousFormDataRef.current = formData;
+      inputIsDirtyRef.current = false;
+    }
+    if (!inputIsDirtyRef.current) {
+      setInputValue(formData ? selectedPresentationTitle || formData : '');
     }
   }, [formData, selectedPresentationTitle]);
 
   const selectedKey =
-    formData && buiOptions.some(o => o.value === formData) ? formData : null;
+    normalizedFormData && buiOptions.some(o => o.value === normalizedFormData)
+      ? normalizedFormData
+      : null;
 
   const lastCommittedRef = useRef(formData);
 
@@ -212,6 +230,7 @@ export const EntityPicker = (props: EntityPickerProps) => {
 
   const handleSelectionChange = useCallback(
     (key: Key | null) => {
+      inputIsDirtyRef.current = false;
       setSearchText('');
       if (key !== null) {
         const value = String(key);
@@ -255,6 +274,7 @@ export const EntityPicker = (props: EntityPickerProps) => {
       }
       if (lastCommittedRef.current !== entityRef) {
         lastCommittedRef.current = entityRef;
+        inputIsDirtyRef.current = false;
         setSearchText('');
         onChange(entityRef);
       }
@@ -325,6 +345,7 @@ export const EntityPicker = (props: EntityPickerProps) => {
             mode: 'server',
             inputValue,
             onInputChange: value => {
+              inputIsDirtyRef.current = true;
               setInputValue(value);
               setSearchText(value);
             },

--- a/plugins/scaffolder/src/components/fields/EntityPicker/EntityPicker.tsx
+++ b/plugins/scaffolder/src/components/fields/EntityPicker/EntityPicker.tsx
@@ -186,18 +186,30 @@ export const EntityPicker = (props: EntityPickerProps) => {
   }, [entities, selectedEntity]);
 
   // BUI: options for autocomplete
-  const buiOptions = useMemo(
-    () =>
-      muiOptions.map(entity => {
-        const entityRef = stringifyEntityRef(entity);
-        const presentation = entityRefToPresentation.get(entityRef);
-        return {
-          value: entityRef,
-          label: presentation?.primaryTitle || entityRef,
-        };
-      }),
-    [muiOptions, entityRefToPresentation],
-  );
+  const buiOptions = useMemo(() => {
+    const options = muiOptions.map(entity => {
+      const entityRef = stringifyEntityRef(entity);
+      const presentation = entityRefToPresentation.get(entityRef);
+      return {
+        value: entityRef,
+        label: presentation?.primaryTitle || entityRef,
+      };
+    });
+    const selectedEntityRef = selectedEntityRefs[0];
+    if (
+      selectedEntityRef &&
+      !options.some(option => option.value === selectedEntityRef)
+    ) {
+      options.unshift({
+        value: selectedEntityRef,
+        label:
+          entityRefToPresentation.get(selectedEntityRef)?.primaryTitle ||
+          formData ||
+          selectedEntityRef,
+      });
+    }
+    return options;
+  }, [entityRefToPresentation, formData, muiOptions, selectedEntityRefs]);
 
   // BUI: controlled input value
   const [inputValue, setInputValue] = useState(formData || '');
@@ -245,8 +257,10 @@ export const EntityPicker = (props: EntityPickerProps) => {
         } catch {
           // If the input isn't a valid entity ref, use it as-is
         }
-        lastCommittedRef.current = entityRef;
-        onChange(entityRef);
+        if (lastCommittedRef.current !== entityRef) {
+          lastCommittedRef.current = entityRef;
+          onChange(entityRef);
+        }
       } else {
         lastCommittedRef.current = undefined;
         onChange(undefined);
@@ -263,7 +277,7 @@ export const EntityPicker = (props: EntityPickerProps) => {
   );
 
   const handleBlur = useCallback(() => {
-    if (allowArbitraryValues && inputValue) {
+    if (allowArbitraryValues && inputIsDirtyRef.current && inputValue) {
       let entityRef = inputValue;
       try {
         entityRef = stringifyEntityRef(

--- a/plugins/scaffolder/src/components/fields/EntityPicker/EntityPicker.tsx
+++ b/plugins/scaffolder/src/components/fields/EntityPicker/EntityPicker.tsx
@@ -22,27 +22,20 @@ import {
   parseEntityRef,
   stringifyEntityRef,
 } from '@backstage/catalog-model';
-import { useApi } from '@backstage/core-plugin-api';
-import {
-  EntityDisplayName,
-  EntityRefPresentationSnapshot,
-  catalogApiRef,
-  entityPresentationApiRef,
-} from '@backstage/plugin-catalog-react';
+import { EntityDisplayName } from '@backstage/plugin-catalog-react';
 import TextField from '@material-ui/core/TextField';
 import Autocomplete, {
   AutocompleteChangeReason,
-  createFilterOptions,
 } from '@material-ui/lab/Autocomplete';
 import {
   type Key,
+  type MouseEvent,
   useCallback,
   useEffect,
   useMemo,
   useRef,
   useState,
 } from 'react';
-import useAsync from 'react-use/esm/useAsync';
 import {
   EntityPickerFilterQueryValue,
   EntityPickerProps,
@@ -57,6 +50,7 @@ import {
   useScaffolderTheme,
 } from '@backstage/plugin-scaffolder-react/alpha';
 import { Autocomplete as BuiAutocomplete } from '../Autocomplete';
+import { useEntityPickerOptions } from '../useEntityPickerOptions';
 
 export { EntityPickerSchema } from './schema';
 
@@ -82,55 +76,29 @@ export const EntityPicker = (props: EntityPickerProps) => {
     idSchema,
     errors,
   } = props;
-  const catalogFilter = buildCatalogFilter(uiSchema);
+  const catalogFilter = useMemo(() => buildCatalogFilter(uiSchema), [uiSchema]);
   const defaultKind = uiSchema['ui:options']?.defaultKind;
   const defaultNamespace =
     uiSchema['ui:options']?.defaultNamespace || undefined;
   const autoSelect = uiSchema?.['ui:options']?.autoSelect ?? true;
   const isDisabled = uiSchema?.['ui:disabled'] ?? false;
 
-  const catalogApi = useApi(catalogApiRef);
-  const entityPresentationApi = useApi(entityPresentationApiRef);
-
-  const { value: entities, loading } = useAsync(async () => {
-    const fields = [
-      'kind',
-      'metadata.name',
-      'metadata.namespace',
-      'metadata.title',
-      'metadata.description',
-      'spec.profile.displayName',
-      'spec.type',
-    ];
-    const streamRequest = catalogFilter
-      ? { query: {}, filter: catalogFilter, fields }
-      : { fields };
-    const items: Entity[] = [];
-    for await (const batch of catalogApi.streamEntities(streamRequest)) {
-      items.push(...batch);
-    }
-
-    const entityRefToPresentation = new Map<
-      string,
-      EntityRefPresentationSnapshot
-    >(
-      await Promise.all(
-        items.map(async item => {
-          const presentation = await entityPresentationApi.forEntity(item)
-            .promise;
-          return [stringifyEntityRef(item), presentation] as [
-            string,
-            EntityRefPresentationSnapshot,
-          ];
-        }),
-      ),
-    );
-
-    return { catalogEntities: items, entityRefToPresentation };
-  });
-
   const allowArbitraryValues =
     uiSchema['ui:options']?.allowArbitraryValues ?? true;
+  const selectedEntityRefs = useMemo(
+    () => (formData ? [formData] : []),
+    [formData],
+  );
+  const {
+    entities,
+    selectedEntities,
+    entityRefToPresentation,
+    loading,
+    loadingState,
+    setSearchText,
+    loadMore,
+    initialResultIsOnlyOption,
+  } = useEntityPickerOptions({ catalogFilter, selectedEntityRefs });
 
   const getLabel = useCallback(
     (freeSoloValue: string) => {
@@ -183,21 +151,22 @@ export const EntityPicker = (props: EntityPickerProps) => {
   // Since free solo can be enabled, attempt to parse as a full entity ref first, then
   // fall back to the given value.
   const selectedEntity =
-    entities?.catalogEntities.find(e => stringifyEntityRef(e) === formData) ??
+    selectedEntities.find(e => stringifyEntityRef(e) === formData) ??
+    entities.find(e => stringifyEntityRef(e) === formData) ??
     (allowArbitraryValues && formData ? getLabel(formData) : '');
 
   // BUI: options for autocomplete
   const buiOptions = useMemo(
     () =>
-      (entities?.catalogEntities || []).map(entity => {
+      entities.map(entity => {
         const entityRef = stringifyEntityRef(entity);
-        const presentation = entities?.entityRefToPresentation.get(entityRef);
+        const presentation = entityRefToPresentation.get(entityRef);
         return {
           value: entityRef,
           label: presentation?.primaryTitle || entityRef,
         };
       }),
-    [entities],
+    [entities, entityRefToPresentation],
   );
 
   // BUI: controlled input value
@@ -206,11 +175,15 @@ export const EntityPicker = (props: EntityPickerProps) => {
   useEffect(() => {
     if (formData) {
       const opt = buiOptions.find(o => o.value === formData);
-      setInputValue(opt?.label || formData);
+      setInputValue(
+        opt?.label ||
+          entityRefToPresentation.get(formData)?.primaryTitle ||
+          formData,
+      );
     } else {
       setInputValue('');
     }
-  }, [formData, buiOptions]);
+  }, [entityRefToPresentation, formData, buiOptions]);
 
   const selectedKey =
     formData && buiOptions.some(o => o.value === formData) ? formData : null;
@@ -275,23 +248,24 @@ export const EntityPicker = (props: EntityPickerProps) => {
       if (
         required &&
         !allowArbitraryValues &&
-        entities?.catalogEntities.length === 1 &&
+        initialResultIsOnlyOption &&
         !formData
       ) {
-        onChange(stringifyEntityRef(entities.catalogEntities[0]));
+        onChange(stringifyEntityRef(entities[0]));
       }
     } else {
       if (
         required &&
         !allowArbitraryValues &&
-        entities?.catalogEntities.length === 1 &&
+        initialResultIsOnlyOption &&
         selectedEntity === ''
       ) {
-        onChange(stringifyEntityRef(entities.catalogEntities[0]));
+        onChange(stringifyEntityRef(entities[0]));
       }
     }
   }, [
     entities,
+    initialResultIsOnlyOption,
     onChange,
     selectedEntity,
     formData,
@@ -302,9 +276,7 @@ export const EntityPicker = (props: EntityPickerProps) => {
 
   if (theme === 'bui') {
     const isAutoSelected =
-      required &&
-      !allowArbitraryValues &&
-      entities?.catalogEntities.length === 1;
+      required && !allowArbitraryValues && initialResultIsOnlyOption;
 
     return (
       <ScaffolderField
@@ -320,12 +292,18 @@ export const EntityPicker = (props: EntityPickerProps) => {
           isRequired={required}
           isDisabled={isDisabled || isAutoSelected}
           selectedKey={selectedKey}
-          inputValue={inputValue}
-          onInputChange={setInputValue}
           onSelectionChange={handleSelectionChange}
           onBlur={handleBlur}
-          isLoading={loading}
           options={buiOptions}
+          search={{
+            mode: 'server',
+            inputValue,
+            onInputChange: value => {
+              setInputValue(value);
+              setSearchText(value);
+            },
+          }}
+          loading={{ state: loadingState, onLoadMore: loadMore }}
           allowsCustomValue={allowArbitraryValues}
           isInvalid={rawErrors && rawErrors.length > 0}
         />
@@ -344,20 +322,23 @@ export const EntityPicker = (props: EntityPickerProps) => {
       <Autocomplete
         disabled={
           isDisabled ||
-          (required &&
-            !allowArbitraryValues &&
-            entities?.catalogEntities.length === 1)
+          (required && !allowArbitraryValues && initialResultIsOnlyOption)
         }
         id={idSchema?.$id}
         value={selectedEntity}
         loading={loading}
         onChange={onSelect}
-        options={entities?.catalogEntities || []}
+        options={entities}
+        onInputChange={(_event, value, reason) => {
+          if (reason === 'input' || reason === 'clear') {
+            setSearchText(value);
+          }
+        }}
         getOptionLabel={option =>
           // option can be a string due to freeSolo.
           typeof option === 'string'
             ? option
-            : entities?.entityRefToPresentation.get(stringifyEntityRef(option))
+            : entityRefToPresentation.get(stringifyEntityRef(option))
                 ?.entityRef!
         }
         autoSelect={autoSelect}
@@ -374,12 +355,20 @@ export const EntityPicker = (props: EntityPickerProps) => {
           />
         )}
         renderOption={option => <EntityDisplayName entityRef={option} />}
-        filterOptions={createFilterOptions<Entity>({
-          stringify: option =>
-            entities?.entityRefToPresentation.get(stringifyEntityRef(option))
-              ?.primaryTitle!,
-        })}
+        filterOptions={options => options}
         ListboxComponent={VirtualizedListbox}
+        ListboxProps={{
+          onScroll: (event: MouseEvent) => {
+            const element = event.currentTarget;
+            if (
+              Math.abs(
+                element.scrollHeight - element.clientHeight - element.scrollTop,
+              ) < 1
+            ) {
+              loadMore();
+            }
+          },
+        }}
       />
     </ScaffolderField>
   );

--- a/plugins/scaffolder/src/components/fields/EntityPicker/EntityPicker.tsx
+++ b/plugins/scaffolder/src/components/fields/EntityPicker/EntityPicker.tsx
@@ -29,7 +29,6 @@ import Autocomplete, {
 } from '@material-ui/lab/Autocomplete';
 import {
   type Key,
-  type MouseEvent,
   useCallback,
   useEffect,
   useMemo,
@@ -51,6 +50,7 @@ import {
 } from '@backstage/plugin-scaffolder-react/alpha';
 import { Autocomplete as BuiAutocomplete } from '../Autocomplete';
 import { useEntityPickerOptions } from '../useEntityPickerOptions';
+import { useEntityPickerPagination } from '../useEntityPickerPagination';
 
 export { EntityPickerSchema } from './schema';
 
@@ -211,13 +211,21 @@ export const EntityPicker = (props: EntityPickerProps) => {
     return options;
   }, [entityRefToPresentation, formData, muiOptions, selectedEntityRefs]);
 
-  // BUI: controlled input value
+  // Keep input independent of refreshed entity objects in the search results.
   const [inputValue, setInputValue] = useState(formData || '');
   const inputIsDirtyRef = useRef(false);
   const previousFormDataRef = useRef(formData);
   const selectedPresentationTitle = formData
     ? entityRefToPresentation.get(normalizedFormData)?.primaryTitle
     : undefined;
+  const muiInputValue =
+    typeof selectedEntity === 'string'
+      ? selectedEntity
+      : stringifyEntityRef(selectedEntity);
+  const selectedInputValue =
+    theme === 'bui'
+      ? selectedPresentationTitle || formData || ''
+      : muiInputValue;
 
   useEffect(() => {
     if (previousFormDataRef.current !== formData) {
@@ -225,9 +233,9 @@ export const EntityPicker = (props: EntityPickerProps) => {
       inputIsDirtyRef.current = false;
     }
     if (!inputIsDirtyRef.current) {
-      setInputValue(formData ? selectedPresentationTitle || formData : '');
+      setInputValue(selectedInputValue);
     }
-  }, [formData, selectedPresentationTitle]);
+  }, [formData, selectedInputValue]);
 
   const selectedKey =
     normalizedFormData && buiOptions.some(o => o.value === normalizedFormData)
@@ -334,6 +342,13 @@ export const EntityPicker = (props: EntityPickerProps) => {
     theme,
   ]);
 
+  const pagination = useEntityPickerPagination({
+    entities,
+    selectedEntityRefs,
+    loading,
+    loadMore,
+  });
+
   if (theme === 'bui') {
     const isAutoSelected =
       required && !allowArbitraryValues && initialResultIsOnlyOption;
@@ -387,10 +402,16 @@ export const EntityPicker = (props: EntityPickerProps) => {
         }
         id={idSchema?.$id}
         value={selectedEntity}
+        inputValue={inputValue}
         loading={loading}
         onChange={onSelect}
         options={muiOptions}
-        onInputChange={(_event, value, reason) => {
+        onInputChange={(event, value, reason) => {
+          // MUI resets the input when the selected entity object is refreshed.
+          // Only user actions or a changed form value should replace an edit.
+          if (reason === 'reset' && !event && inputIsDirtyRef.current) return;
+          inputIsDirtyRef.current = reason === 'input';
+          setInputValue(value);
           if (reason === 'input' || reason === 'clear') {
             setSearchText(value);
           }
@@ -423,18 +444,7 @@ export const EntityPicker = (props: EntityPickerProps) => {
         renderOption={option => <EntityDisplayName entityRef={option} />}
         filterOptions={options => options}
         ListboxComponent={VirtualizedListbox}
-        ListboxProps={{
-          onScroll: (event: MouseEvent) => {
-            const element = event.currentTarget;
-            if (
-              Math.abs(
-                element.scrollHeight - element.clientHeight - element.scrollTop,
-              ) < 1
-            ) {
-              loadMore();
-            }
-          },
-        }}
+        {...pagination}
       />
     </ScaffolderField>
   );

--- a/plugins/scaffolder/src/components/fields/MultiEntityPicker/MultiEntityPicker.test.tsx
+++ b/plugins/scaffolder/src/components/fields/MultiEntityPicker/MultiEntityPicker.test.tsx
@@ -14,7 +14,10 @@
  * limitations under the License.
  */
 
-import { CATALOG_FILTER_EXISTS } from '@backstage/catalog-client';
+import {
+  type CatalogApi,
+  CATALOG_FILTER_EXISTS,
+} from '@backstage/catalog-client';
 import { Entity } from '@backstage/catalog-model';
 import {
   catalogApiRef,
@@ -42,6 +45,9 @@ jest.mock('@backstage/plugin-scaffolder-react/alpha', () => ({
 const mockUseScaffolderTheme = jest.mocked(useScaffolderTheme);
 const originalIntersectionObserver = globalThis.IntersectionObserver;
 
+type SpiedCatalogApi = CatalogApi &
+  Pick<jest.Mocked<CatalogApi>, 'getEntitiesByRefs' | 'queryEntities'>;
+
 const makeEntity = (kind: string, namespace: string, name: string): Entity => ({
   apiVersion: 'scaffolder.backstage.io/v1beta3',
   kind,
@@ -62,7 +68,7 @@ describe('<MultiEntityPicker />', () => {
 
   let props: FieldProps<string[]>;
 
-  const catalogApi = catalogApiMock.mock();
+  let catalogApi: SpiedCatalogApi;
   let Wrapper: ComponentType<PropsWithChildren<{}>>;
 
   beforeEach(() => {
@@ -81,12 +87,11 @@ describe('<MultiEntityPicker />', () => {
         unobserve() {}
       },
     });
-    catalogApi.queryEntities.mockResolvedValue({
-      items: entities,
-      totalItems: 0,
-      pageInfo: {},
+    const api = catalogApiMock({ entities });
+    catalogApi = Object.assign(api, {
+      queryEntities: jest.spyOn(api, 'queryEntities'),
+      getEntitiesByRefs: jest.spyOn(api, 'getEntitiesByRefs'),
     });
-    catalogApi.getEntitiesByRefs.mockResolvedValue({ items: [] });
     Wrapper = ({ children }: { children?: ReactNode }) => (
       <TestApiProvider
         apis={[
@@ -278,10 +283,6 @@ describe('<MultiEntityPicker />', () => {
         rawErrors,
         formData,
       } as unknown as FieldProps<any>;
-
-      catalogApi.streamEntities.mockImplementation(async function* () {
-        yield entities;
-      });
     });
 
     it('searches for a specific group entity', async () => {
@@ -316,10 +317,6 @@ describe('<MultiEntityPicker />', () => {
           },
         },
       };
-
-      catalogApi.streamEntities.mockImplementation(async function* () {
-        yield entities;
-      });
 
       await renderInTestApp(
         <Wrapper>
@@ -389,10 +386,6 @@ describe('<MultiEntityPicker />', () => {
         rawErrors,
         formData,
       } as unknown as FieldProps<any>;
-
-      catalogApi.streamEntities.mockImplementation(async function* () {
-        yield entities;
-      });
     });
 
     it('searches for a Group entity', async () => {
@@ -459,10 +452,6 @@ describe('<MultiEntityPicker />', () => {
     });
 
     it('preserves existing data on selecting an existing option', async () => {
-      catalogApi.streamEntities.mockImplementation(async function* () {
-        yield entities;
-      });
-
       const { getByRole } = await renderInTestApp(
         <Wrapper>
           <MultiEntityPicker {...props} />
@@ -500,10 +489,6 @@ describe('<MultiEntityPicker />', () => {
         rawErrors,
         formData,
       } as unknown as FieldProps<any>;
-
-      catalogApi.streamEntities.mockImplementation(async function* () {
-        yield entities;
-      });
     });
 
     it('returns the full entityRef when entity exists in the list', async () => {
@@ -561,10 +546,6 @@ describe('<MultiEntityPicker />', () => {
         rawErrors,
         formData,
       } as unknown as FieldProps<any>;
-
-      catalogApi.streamEntities.mockImplementation(async function* () {
-        yield entities;
-      });
     });
 
     it('User enters clear input', async () => {
@@ -652,10 +633,6 @@ describe('<MultiEntityPicker />', () => {
         rawErrors,
         formData,
       } as unknown as FieldProps<any>;
-
-      catalogApi.streamEntities.mockImplementation(async function* () {
-        yield entities;
-      });
     });
     it('Prevents user from modifying input when ui:disabled is true', async () => {
       props.formData = ['component/default:myentity'];
@@ -694,10 +671,6 @@ describe('<MultiEntityPicker />', () => {
         rawErrors,
         formData,
       } as unknown as FieldProps<any>;
-
-      catalogApi.streamEntities.mockImplementation(async function* () {
-        yield entities;
-      });
     });
 
     it('User enters clear input', async () => {
@@ -793,10 +766,6 @@ describe('<MultiEntityPicker />', () => {
         rawErrors,
         formData,
       } as unknown as FieldProps<any>;
-
-      catalogApi.streamEntities.mockImplementation(async function* () {
-        yield entities;
-      });
     });
 
     it('User enters clear input', async () => {
@@ -892,10 +861,6 @@ describe('<MultiEntityPicker />', () => {
         rawErrors,
         formData,
       } as unknown as FieldProps<any>;
-
-      catalogApi.streamEntities.mockImplementation(async function* () {
-        yield entities;
-      });
     });
 
     it('User enters clear input', async () => {

--- a/plugins/scaffolder/src/components/fields/MultiEntityPicker/MultiEntityPicker.test.tsx
+++ b/plugins/scaffolder/src/components/fields/MultiEntityPicker/MultiEntityPicker.test.tsx
@@ -472,6 +472,9 @@ describe('<MultiEntityPicker />', () => {
       const input = getByRole('textbox');
 
       fireEvent.mouseDown(input);
+      expect(
+        screen.queryByRole('option', { name: 'team-a' }),
+      ).not.toBeInTheDocument();
       const optionA = screen.getByText('squad-b');
       await userEvent.click(optionA as HTMLElement);
 

--- a/plugins/scaffolder/src/components/fields/MultiEntityPicker/MultiEntityPicker.test.tsx
+++ b/plugins/scaffolder/src/components/fields/MultiEntityPicker/MultiEntityPicker.test.tsx
@@ -198,6 +198,26 @@ describe('<MultiEntityPicker />', () => {
         expect.not.objectContaining({ fullTextFilter: expect.anything() }),
       );
     });
+
+    it('looks up valid selected refs without arbitrary values', async () => {
+      props = {
+        ...props,
+        formData: ['arbitrary-value', 'group:default/team-a'],
+      } as unknown as FieldProps<string[]>;
+
+      await renderInTestApp(
+        <Wrapper>
+          <MultiEntityPicker {...props} />
+        </Wrapper>,
+      );
+      await waitFor(() =>
+        expect(catalogApi.queryEntities).toHaveBeenCalledTimes(1),
+      );
+
+      expect(catalogApi.getEntitiesByRefs).toHaveBeenCalledWith({
+        entityRefs: ['group:default/team-a'],
+      });
+    });
   });
 
   describe('with catalogFilter', () => {

--- a/plugins/scaffolder/src/components/fields/MultiEntityPicker/MultiEntityPicker.test.tsx
+++ b/plugins/scaffolder/src/components/fields/MultiEntityPicker/MultiEntityPicker.test.tsx
@@ -218,6 +218,40 @@ describe('<MultiEntityPicker />', () => {
         entityRefs: ['group:default/team-a'],
       });
     });
+
+    it('does not offer or add a canonical duplicate of a shorthand BUI value', async () => {
+      mockUseScaffolderTheme.mockReturnValue('bui');
+      catalogApi.getEntitiesByRefs.mockResolvedValueOnce({
+        items: [
+          {
+            ...entities[0],
+            metadata: { ...entities[0].metadata, title: 'Team A' },
+          },
+        ],
+      });
+      props = {
+        ...props,
+        formData: ['team-a'],
+        uiSchema: { 'ui:options': { defaultKind: 'Group' } },
+      } as unknown as FieldProps<string[]>;
+      await renderInTestApp(
+        <Wrapper>
+          <MultiEntityPicker {...props} />
+        </Wrapper>,
+      );
+      const input = screen.getByRole('combobox');
+      await userEvent.click(
+        screen.getByRole('button', { name: /Show suggestions/ }),
+      );
+
+      expect(screen.getByText('Team A')).toBeInTheDocument();
+      expect(
+        screen.queryByRole('option', { name: 'Team A' }),
+      ).not.toBeInTheDocument();
+      fireEvent.change(input, { target: { value: 'team-a' } });
+      fireEvent.blur(input);
+      expect(onChange).not.toHaveBeenCalled();
+    });
   });
 
   describe('with catalogFilter', () => {

--- a/plugins/scaffolder/src/components/fields/MultiEntityPicker/MultiEntityPicker.test.tsx
+++ b/plugins/scaffolder/src/components/fields/MultiEntityPicker/MultiEntityPicker.test.tsx
@@ -22,7 +22,7 @@ import {
 } from '@backstage/plugin-catalog-react';
 import { renderInTestApp, TestApiProvider } from '@backstage/test-utils';
 
-import { fireEvent, screen } from '@testing-library/react';
+import { fireEvent, screen, waitFor } from '@testing-library/react';
 import { userEvent } from '@testing-library/user-event';
 import { PropsWithChildren, ComponentType, ReactNode } from 'react';
 import { MultiEntityPicker } from './MultiEntityPicker';
@@ -53,14 +53,16 @@ describe('<MultiEntityPicker />', () => {
 
   let props: FieldProps<string[]>;
 
-  const catalogApi = catalogApiMock.mock({
-    streamEntities: jest.fn(async function* () {
-      yield entities;
-    }),
-  });
+  const catalogApi = catalogApiMock.mock();
   let Wrapper: ComponentType<PropsWithChildren<{}>>;
 
   beforeEach(() => {
+    catalogApi.queryEntities.mockResolvedValue({
+      items: entities,
+      totalItems: 0,
+      pageInfo: {},
+    });
+    catalogApi.getEntitiesByRefs.mockResolvedValue({ items: [] });
     Wrapper = ({ children }: { children?: ReactNode }) => (
       <TestApiProvider
         apis={[
@@ -98,7 +100,20 @@ describe('<MultiEntityPicker />', () => {
         </Wrapper>,
       );
 
-      expect(catalogApi.streamEntities).toHaveBeenCalledWith({});
+      expect(catalogApi.queryEntities).toHaveBeenCalledWith({
+        fields: [
+          'kind',
+          'metadata.name',
+          'metadata.namespace',
+          'metadata.title',
+          'metadata.description',
+          'spec.profile.displayName',
+          'spec.type',
+        ],
+        limit: 20,
+        orderFields: [{ field: 'metadata.name', order: 'asc' }],
+        totalItems: 'exclude',
+      });
     });
 
     it('updates even if there is not an exact match', async () => {
@@ -114,6 +129,24 @@ describe('<MultiEntityPicker />', () => {
       fireEvent.blur(input);
 
       expect(onChange).toHaveBeenCalledWith(['squ']);
+    });
+
+    it('filters entities through the catalog as the user types', async () => {
+      const { getByRole } = await renderInTestApp(
+        <Wrapper>
+          <MultiEntityPicker {...props} />
+        </Wrapper>,
+      );
+
+      fireEvent.change(getByRole('textbox'), { target: { value: 'team' } });
+
+      await waitFor(() =>
+        expect(catalogApi.queryEntities).toHaveBeenLastCalledWith(
+          expect.objectContaining({
+            fullTextFilter: expect.objectContaining({ term: 'team' }),
+          }),
+        ),
+      );
     });
   });
 
@@ -154,19 +187,20 @@ describe('<MultiEntityPicker />', () => {
         </Wrapper>,
       );
 
-      expect(catalogApi.streamEntities).toHaveBeenCalledWith({
-        query: {},
-        filter: [
-          {
-            kind: ['Group'],
-            'metadata.name': 'test-entity',
-          },
-          {
-            kind: ['User'],
-            'metadata.name': 'test-entity',
-          },
-        ],
-      });
+      expect(catalogApi.queryEntities).toHaveBeenCalledWith(
+        expect.objectContaining({
+          filter: [
+            {
+              kind: ['Group'],
+              'metadata.name': 'test-entity',
+            },
+            {
+              kind: ['User'],
+              'metadata.name': 'test-entity',
+            },
+          ],
+        }),
+      );
     });
 
     it('allow single top level filter', async () => {
@@ -189,13 +223,14 @@ describe('<MultiEntityPicker />', () => {
         </Wrapper>,
       );
 
-      expect(catalogApi.streamEntities).toHaveBeenCalledWith({
-        query: {},
-        filter: {
-          kind: ['Group'],
-          'metadata.name': 'test-entity',
-        },
-      });
+      expect(catalogApi.queryEntities).toHaveBeenCalledWith(
+        expect.objectContaining({
+          filter: {
+            kind: ['Group'],
+            'metadata.name': 'test-entity',
+          },
+        }),
+      );
     });
 
     it('search for entities containing an specific key', async () => {
@@ -216,15 +251,16 @@ describe('<MultiEntityPicker />', () => {
         </Wrapper>,
       );
 
-      expect(catalogApi.streamEntities).toHaveBeenCalledWith({
-        query: {},
-        filter: [
-          {
-            kind: ['User'],
-            'metadata.annotation.some/anotation': CATALOG_FILTER_EXISTS,
-          },
-        ],
-      });
+      expect(catalogApi.queryEntities).toHaveBeenCalledWith(
+        expect.objectContaining({
+          filter: [
+            {
+              kind: ['User'],
+              'metadata.annotation.some/anotation': CATALOG_FILTER_EXISTS,
+            },
+          ],
+        }),
+      );
     });
   });
 
@@ -262,15 +298,16 @@ describe('<MultiEntityPicker />', () => {
         </Wrapper>,
       );
 
-      expect(catalogApi.streamEntities).toHaveBeenCalledWith({
-        query: {},
-        filter: [
-          {
-            kind: ['Group'],
-            'metadata.name': 'test-group',
-          },
-        ],
-      });
+      expect(catalogApi.queryEntities).toHaveBeenCalledWith(
+        expect.objectContaining({
+          filter: [
+            {
+              kind: ['Group'],
+              'metadata.name': 'test-group',
+            },
+          ],
+        }),
+      );
     });
   });
 
@@ -855,8 +892,10 @@ describe('<MultiEntityPicker />', () => {
         formData,
       } as unknown as FieldProps<any>;
 
-      catalogApi.streamEntities.mockImplementation(async function* () {
-        yield testEntities;
+      catalogApi.queryEntities.mockResolvedValue({
+        items: testEntities,
+        totalItems: 0,
+        pageInfo: {},
       });
     });
 
@@ -1065,8 +1104,10 @@ describe('<MultiEntityPicker />', () => {
           profile: { displayName: item.metadata.name.replace('-', ' ') },
         },
       }));
-      catalogApi.streamEntities.mockImplementation(async function* () {
-        yield items;
+      catalogApi.queryEntities.mockResolvedValue({
+        items,
+        totalItems: 0,
+        pageInfo: {},
       });
 
       const { getByRole, getByText } = await renderInTestApp(
@@ -1096,8 +1137,10 @@ describe('<MultiEntityPicker />', () => {
           title: item.metadata.name.replace('-', ' ').toUpperCase(),
         },
       }));
-      catalogApi.streamEntities.mockImplementation(async function* () {
-        yield items;
+      catalogApi.queryEntities.mockResolvedValue({
+        items,
+        totalItems: 0,
+        pageInfo: {},
       });
 
       const { getByRole, getByText } = await renderInTestApp(

--- a/plugins/scaffolder/src/components/fields/MultiEntityPicker/MultiEntityPicker.test.tsx
+++ b/plugins/scaffolder/src/components/fields/MultiEntityPicker/MultiEntityPicker.test.tsx
@@ -25,7 +25,7 @@ import {
 } from '@backstage/plugin-catalog-react';
 import { renderInTestApp, TestApiProvider } from '@backstage/test-utils';
 
-import { fireEvent, screen, waitFor } from '@testing-library/react';
+import { act, fireEvent, screen, waitFor } from '@testing-library/react';
 import { userEvent } from '@testing-library/user-event';
 import { PropsWithChildren, ComponentType, ReactNode } from 'react';
 import { MultiEntityPicker } from './MultiEntityPicker';
@@ -140,6 +140,102 @@ describe('<MultiEntityPicker />', () => {
         orderFields: [{ field: 'metadata.name', order: 'asc' }],
         totalItems: 'exclude',
       });
+    });
+
+    it('loads past a fully selected first page, but only when opened', async () => {
+      catalogApi.queryEntities
+        .mockResolvedValueOnce({
+          items: [entities[0]],
+          totalItems: 0,
+          pageInfo: { nextCursor: 'next-page' },
+        })
+        .mockResolvedValueOnce({
+          items: [entities[1]],
+          totalItems: 0,
+          pageInfo: {},
+        });
+      await renderInTestApp(
+        <Wrapper>
+          <MultiEntityPicker {...props} formData={['group:default/team-a']} />
+        </Wrapper>,
+      );
+      expect(catalogApi.queryEntities).toHaveBeenCalledTimes(1);
+      fireEvent.mouseDown(screen.getByRole('textbox'));
+      fireEvent.click(await screen.findByRole('option', { name: 'squad-b' }));
+      expect(catalogApi.queryEntities).toHaveBeenLastCalledWith({
+        cursor: 'next-page',
+        limit: 20,
+      });
+      expect(onChange).toHaveBeenCalledWith([
+        'group:default/team-a',
+        'group:default/squad-b',
+      ]);
+    });
+
+    it('loads another page when scrolling near the bottom, including keyboard padding', async () => {
+      const page = Array.from({ length: 20 }, (_, i) =>
+        makeEntity('Group', 'default', `team-${i}`),
+      );
+      catalogApi.queryEntities
+        .mockResolvedValueOnce({
+          items: page,
+          totalItems: 0,
+          pageInfo: { nextCursor: 'next-page' },
+        })
+        .mockResolvedValueOnce({
+          items: [entities[1]],
+          totalItems: 0,
+          pageInfo: {},
+        });
+      await renderInTestApp(
+        <Wrapper>
+          <MultiEntityPicker {...props} />
+        </Wrapper>,
+      );
+      fireEvent.mouseDown(screen.getByRole('textbox'));
+      const listbox = await screen.findByRole('listbox');
+      Object.defineProperties(listbox, {
+        scrollHeight: { value: 736 },
+        clientHeight: { value: 378 },
+      });
+      fireEvent.scroll(listbox, { target: { scrollTop: 342 } });
+      await waitFor(() =>
+        expect(catalogApi.queryEntities).toHaveBeenCalledTimes(2),
+      );
+      expect(catalogApi.queryEntities).toHaveBeenLastCalledWith({
+        cursor: 'next-page',
+        limit: 20,
+      });
+    });
+
+    it('does not automatically retry a failed underfilled page until reopened', async () => {
+      catalogApi.queryEntities
+        .mockResolvedValueOnce({
+          items: [entities[0]],
+          totalItems: 0,
+          pageInfo: { nextCursor: 'next-page' },
+        })
+        .mockRejectedValueOnce(new Error('Temporary failure'))
+        .mockResolvedValueOnce({
+          items: [entities[1]],
+          totalItems: 0,
+          pageInfo: {},
+        });
+      await renderInTestApp(
+        <Wrapper>
+          <MultiEntityPicker {...props} formData={['group:default/team-a']} />
+        </Wrapper>,
+      );
+      await act(async () => fireEvent.mouseDown(screen.getByRole('textbox')));
+      expect(catalogApi.queryEntities).toHaveBeenCalledTimes(2);
+      expect(screen.queryByRole('option')).not.toBeInTheDocument();
+
+      fireEvent.keyDown(screen.getByRole('textbox'), { key: 'Escape' });
+      fireEvent.mouseDown(screen.getByRole('textbox'));
+      expect(
+        await screen.findByRole('option', { name: 'squad-b' }),
+      ).toBeInTheDocument();
+      expect(catalogApi.queryEntities).toHaveBeenCalledTimes(3);
     });
 
     it('updates even if there is not an exact match', async () => {

--- a/plugins/scaffolder/src/components/fields/MultiEntityPicker/MultiEntityPicker.test.tsx
+++ b/plugins/scaffolder/src/components/fields/MultiEntityPicker/MultiEntityPicker.test.tsx
@@ -32,6 +32,15 @@ import { DefaultEntityPresentationApi } from '@backstage/plugin-catalog';
 import { catalogApiMock } from '@backstage/plugin-catalog-react/testUtils';
 import { useTranslationRef } from '@backstage/frontend-plugin-api';
 import { scaffolderTranslationRef } from '../../../translation';
+import { useScaffolderTheme } from '@backstage/plugin-scaffolder-react/alpha';
+
+jest.mock('@backstage/plugin-scaffolder-react/alpha', () => ({
+  ...jest.requireActual('@backstage/plugin-scaffolder-react/alpha'),
+  useScaffolderTheme: jest.fn(),
+}));
+
+const mockUseScaffolderTheme = jest.mocked(useScaffolderTheme);
+const originalIntersectionObserver = globalThis.IntersectionObserver;
 
 const makeEntity = (kind: string, namespace: string, name: string): Entity => ({
   apiVersion: 'scaffolder.backstage.io/v1beta3',
@@ -57,6 +66,21 @@ describe('<MultiEntityPicker />', () => {
   let Wrapper: ComponentType<PropsWithChildren<{}>>;
 
   beforeEach(() => {
+    mockUseScaffolderTheme.mockReturnValue('mui');
+    Object.defineProperty(globalThis, 'IntersectionObserver', {
+      configurable: true,
+      value: class {
+        readonly root = null;
+        readonly rootMargin = '';
+        readonly thresholds = [];
+        disconnect() {}
+        observe() {}
+        takeRecords() {
+          return [];
+        }
+        unobserve() {}
+      },
+    });
     catalogApi.queryEntities.mockResolvedValue({
       items: entities,
       totalItems: 0,
@@ -78,7 +102,13 @@ describe('<MultiEntityPicker />', () => {
     );
   });
 
-  afterEach(() => jest.resetAllMocks());
+  afterEach(() => {
+    jest.resetAllMocks();
+    Object.defineProperty(globalThis, 'IntersectionObserver', {
+      configurable: true,
+      value: originalIntersectionObserver,
+    });
+  });
 
   describe('without allowedKinds and catalogFilter', () => {
     beforeEach(() => {
@@ -101,15 +131,6 @@ describe('<MultiEntityPicker />', () => {
       );
 
       expect(catalogApi.queryEntities).toHaveBeenCalledWith({
-        fields: [
-          'kind',
-          'metadata.name',
-          'metadata.namespace',
-          'metadata.title',
-          'metadata.description',
-          'spec.profile.displayName',
-          'spec.type',
-        ],
         limit: 20,
         orderFields: [{ field: 'metadata.name', order: 'asc' }],
         totalItems: 'exclude',
@@ -146,6 +167,35 @@ describe('<MultiEntityPicker />', () => {
             fullTextFilter: expect.objectContaining({ term: 'team' }),
           }),
         ),
+      );
+    });
+
+    it('clears BUI server filtering after selecting an entity', async () => {
+      mockUseScaffolderTheme.mockReturnValue('bui');
+      await renderInTestApp(
+        <Wrapper>
+          <MultiEntityPicker {...props} />
+        </Wrapper>,
+      );
+      const input = screen.getByRole('combobox');
+
+      fireEvent.change(input, { target: { value: 'team' } });
+      await waitFor(() =>
+        expect(catalogApi.queryEntities).toHaveBeenCalledTimes(2),
+      );
+      await userEvent.click(
+        screen.getByRole('button', { name: /Show suggestions/ }),
+      );
+      await userEvent.click(
+        await screen.findByRole('option', { name: 'team-a' }),
+      );
+
+      expect(onChange).toHaveBeenCalledWith(['group:default/team-a']);
+      await waitFor(() =>
+        expect(catalogApi.queryEntities).toHaveBeenCalledTimes(3),
+      );
+      expect(catalogApi.queryEntities).toHaveBeenLastCalledWith(
+        expect.not.objectContaining({ fullTextFilter: expect.anything() }),
       );
     });
   });

--- a/plugins/scaffolder/src/components/fields/MultiEntityPicker/MultiEntityPicker.tsx
+++ b/plugins/scaffolder/src/components/fields/MultiEntityPicker/MultiEntityPicker.tsx
@@ -22,20 +22,19 @@ import {
   parseEntityRef,
   stringifyEntityRef,
 } from '@backstage/catalog-model';
-import { useApi } from '@backstage/core-plugin-api';
-import {
-  catalogApiRef,
-  entityPresentationApiRef,
-  EntityDisplayName,
-  EntityRefPresentationSnapshot,
-} from '@backstage/plugin-catalog-react';
+import { EntityDisplayName } from '@backstage/plugin-catalog-react';
 import TextField from '@material-ui/core/TextField';
 import Autocomplete, {
   AutocompleteChangeReason,
-  createFilterOptions,
 } from '@material-ui/lab/Autocomplete';
-import { type Key, useCallback, useEffect, useMemo, useState } from 'react';
-import useAsync from 'react-use/esm/useAsync';
+import {
+  type Key,
+  type MouseEvent,
+  useCallback,
+  useEffect,
+  useMemo,
+  useState,
+} from 'react';
 import { FieldValidation } from '@rjsf/utils';
 import {
   MultiEntityPickerFilterQueryValue,
@@ -52,6 +51,7 @@ import { useTranslationRef } from '@backstage/frontend-plugin-api';
 import { scaffolderTranslationRef } from '../../../translation';
 import { Autocomplete as BuiAutocomplete } from '../Autocomplete';
 import { chipStyle, chipRemoveStyle } from '../buiChipStyles';
+import { useEntityPickerOptions } from '../useEntityPickerOptions';
 
 export { MultiEntityPickerSchema } from './schema';
 
@@ -82,7 +82,7 @@ export const MultiEntityPicker = (props: MultiEntityPickerProps) => {
     errors,
   } = props;
 
-  const catalogFilter = buildCatalogFilter(uiSchema);
+  const catalogFilter = useMemo(() => buildCatalogFilter(uiSchema), [uiSchema]);
   const defaultKind = uiSchema['ui:options']?.defaultKind;
   const defaultNamespace =
     uiSchema['ui:options']?.defaultNamespace || undefined;
@@ -93,32 +93,18 @@ export const MultiEntityPicker = (props: MultiEntityPickerProps) => {
 
   const [noOfItemsSelected, setNoOfItemsSelected] = useState(0);
 
-  const catalogApi = useApi(catalogApiRef);
-  const entityPresentationApi = useApi(entityPresentationApiRef);
-  const { value: entities, loading } = useAsync(async () => {
-    const streamRequest = catalogFilter
-      ? { query: {}, filter: catalogFilter }
-      : {};
-    const items: Entity[] = [];
-    for await (const batch of catalogApi.streamEntities(streamRequest)) {
-      items.push(...batch);
-    }
-    const entityRefToPresentation = new Map<
-      string,
-      EntityRefPresentationSnapshot
-    >(
-      await Promise.all(
-        items.map(async item => {
-          const presentation = await entityPresentationApi.forEntity(item)
-            .promise;
-          return [stringifyEntityRef(item), presentation] as [
-            string,
-            EntityRefPresentationSnapshot,
-          ];
-        }),
-      ),
-    );
-    return { entities: items, entityRefToPresentation };
+  const selectedValues = useMemo(() => formData || [], [formData]);
+  const {
+    entities,
+    entityRefToPresentation,
+    loading,
+    loadingState,
+    setSearchText,
+    loadMore,
+    initialResultIsOnlyOption,
+  } = useEntityPickerOptions({
+    catalogFilter,
+    selectedEntityRefs: selectedValues,
   });
 
   const onSelect = useCallback(
@@ -168,18 +154,17 @@ export const MultiEntityPicker = (props: MultiEntityPickerProps) => {
   // BUI: options and selection state
   const allOptions = useMemo(
     () =>
-      (entities?.entities || []).map(entity => {
+      entities.map(entity => {
         const entityRef = stringifyEntityRef(entity);
-        const presentation = entities?.entityRefToPresentation.get(entityRef);
+        const presentation = entityRefToPresentation.get(entityRef);
         return {
           value: entityRef,
           label: presentation?.primaryTitle || entityRef,
         };
       }),
-    [entities],
+    [entities, entityRefToPresentation],
   );
 
-  const selectedValues = useMemo(() => formData || [], [formData]);
   const availableOptions = useMemo(
     () => allOptions.filter(o => !selectedValues.includes(o.value)),
     [allOptions, selectedValues],
@@ -233,14 +218,20 @@ export const MultiEntityPicker = (props: MultiEntityPickerProps) => {
   );
 
   useEffect(() => {
-    if (required && !allowArbitraryValues && entities?.entities?.length === 1) {
-      onChange([stringifyEntityRef(entities.entities[0])]);
+    if (required && !allowArbitraryValues && initialResultIsOnlyOption) {
+      onChange([stringifyEntityRef(entities[0])]);
     }
-  }, [entities, onChange, required, allowArbitraryValues]);
+  }, [
+    allowArbitraryValues,
+    entities,
+    initialResultIsOnlyOption,
+    onChange,
+    required,
+  ]);
 
   if (theme === 'bui') {
     const isAutoSelected =
-      required && !allowArbitraryValues && entities?.entities?.length === 1;
+      required && !allowArbitraryValues && initialResultIsOnlyOption;
 
     return (
       <ScaffolderField
@@ -261,16 +252,19 @@ export const MultiEntityPicker = (props: MultiEntityPickerProps) => {
               }}
             >
               {selectedValues.map(value => {
-                const opt = allOptions.find(o => o.value === value);
+                const label =
+                  allOptions.find(o => o.value === value)?.label ||
+                  entityRefToPresentation.get(value)?.primaryTitle ||
+                  value;
                 return (
                   <span key={value} style={chipStyle}>
-                    {opt?.label || value}
+                    {label}
                     {!isDisabled && !isAutoSelected && (
                       <button
                         type="button"
                         onClick={() => handleRemove(value)}
                         style={chipRemoveStyle}
-                        aria-label={`Remove ${opt?.label || value}`}
+                        aria-label={`Remove ${label}`}
                       >
                         &times;
                       </button>
@@ -286,11 +280,17 @@ export const MultiEntityPicker = (props: MultiEntityPickerProps) => {
             isRequired={required}
             isDisabled={isDisabled || isAutoSelected || atMaxItems}
             selectedKey={null}
-            inputValue={inputValue}
-            onInputChange={setInputValue}
             onSelectionChange={handleSelectionChange}
-            isLoading={loading}
             options={availableOptions}
+            search={{
+              mode: 'server',
+              inputValue,
+              onInputChange: value => {
+                setInputValue(value);
+                setSearchText(value);
+              },
+            }}
+            loading={{ state: loadingState, onLoadMore: loadMore }}
             allowsCustomValue={allowArbitraryValues}
             isInvalid={rawErrors && rawErrors.length > 0}
           />
@@ -312,21 +312,24 @@ export const MultiEntityPicker = (props: MultiEntityPickerProps) => {
         filterSelectedOptions
         disabled={
           isDisabled ||
-          (required &&
-            !allowArbitraryValues &&
-            entities?.entities?.length === 1)
+          (required && !allowArbitraryValues && initialResultIsOnlyOption)
         }
         id={idSchema?.$id}
         defaultValue={formData}
         loading={loading}
         onChange={onSelect}
-        options={entities?.entities || []}
+        options={entities}
+        onInputChange={(_event, value, reason) => {
+          if (reason === 'input' || reason === 'clear') {
+            setSearchText(value);
+          }
+        }}
         renderOption={option => <EntityDisplayName entityRef={option} />}
         getOptionLabel={option =>
           // option can be a string due to freeSolo.
           typeof option === 'string'
             ? option
-            : entities?.entityRefToPresentation.get(stringifyEntityRef(option))
+            : entityRefToPresentation.get(stringifyEntityRef(option))
                 ?.entityRef!
         }
         getOptionDisabled={_options =>
@@ -352,12 +355,20 @@ export const MultiEntityPicker = (props: MultiEntityPickerProps) => {
             }}
           />
         )}
-        filterOptions={createFilterOptions<Entity>({
-          stringify: option =>
-            entities?.entityRefToPresentation.get(stringifyEntityRef(option))
-              ?.primaryTitle!,
-        })}
+        filterOptions={options => options}
         ListboxComponent={VirtualizedListbox}
+        ListboxProps={{
+          onScroll: (event: MouseEvent) => {
+            const element = event.currentTarget;
+            if (
+              Math.abs(
+                element.scrollHeight - element.clientHeight - element.scrollTop,
+              ) < 1
+            ) {
+              loadMore();
+            }
+          },
+        }}
       />
     </ScaffolderField>
   );

--- a/plugins/scaffolder/src/components/fields/MultiEntityPicker/MultiEntityPicker.tsx
+++ b/plugins/scaffolder/src/components/fields/MultiEntityPicker/MultiEntityPicker.tsx
@@ -27,14 +27,7 @@ import TextField from '@material-ui/core/TextField';
 import Autocomplete, {
   AutocompleteChangeReason,
 } from '@material-ui/lab/Autocomplete';
-import {
-  type Key,
-  type MouseEvent,
-  useCallback,
-  useEffect,
-  useMemo,
-  useState,
-} from 'react';
+import { type Key, useCallback, useEffect, useMemo, useState } from 'react';
 import { FieldValidation } from '@rjsf/utils';
 import {
   MultiEntityPickerFilterQueryValue,
@@ -52,6 +45,7 @@ import { scaffolderTranslationRef } from '../../../translation';
 import { Autocomplete as BuiAutocomplete } from '../Autocomplete';
 import { chipStyle, chipRemoveStyle } from '../buiChipStyles';
 import { useEntityPickerOptions } from '../useEntityPickerOptions';
+import { useEntityPickerPagination } from '../useEntityPickerPagination';
 
 export { MultiEntityPickerSchema } from './schema';
 
@@ -282,6 +276,13 @@ export const MultiEntityPicker = (props: MultiEntityPickerProps) => {
     required,
   ]);
 
+  const pagination = useEntityPickerPagination({
+    entities,
+    selectedEntityRefs,
+    loading,
+    loadMore,
+  });
+
   if (theme === 'bui') {
     const isAutoSelected =
       required && !allowArbitraryValues && initialResultIsOnlyOption;
@@ -427,18 +428,7 @@ export const MultiEntityPicker = (props: MultiEntityPickerProps) => {
         )}
         filterOptions={options => options}
         ListboxComponent={VirtualizedListbox}
-        ListboxProps={{
-          onScroll: (event: MouseEvent) => {
-            const element = event.currentTarget;
-            if (
-              Math.abs(
-                element.scrollHeight - element.clientHeight - element.scrollTop,
-              ) < 1
-            ) {
-              loadMore();
-            }
-          },
-        }}
+        {...pagination}
       />
     </ScaffolderField>
   );

--- a/plugins/scaffolder/src/components/fields/MultiEntityPicker/MultiEntityPicker.tsx
+++ b/plugins/scaffolder/src/components/fields/MultiEntityPicker/MultiEntityPicker.tsx
@@ -146,9 +146,17 @@ export const MultiEntityPicker = (props: MultiEntityPickerProps) => {
         .filter(ref => ref !== undefined) as string[];
 
       setNoOfItemsSelected(values.length);
+      setSearchText('');
       onChange(values);
     },
-    [onChange, formData, defaultKind, defaultNamespace, allowArbitraryValues],
+    [
+      onChange,
+      formData,
+      defaultKind,
+      defaultNamespace,
+      allowArbitraryValues,
+      setSearchText,
+    ],
   );
 
   // BUI: options and selection state
@@ -198,6 +206,7 @@ export const MultiEntityPicker = (props: MultiEntityPickerProps) => {
         }
       }
       setInputValue('');
+      setSearchText('');
     },
     [
       atMaxItems,
@@ -207,6 +216,7 @@ export const MultiEntityPicker = (props: MultiEntityPickerProps) => {
       inputValue,
       defaultKind,
       defaultNamespace,
+      setSearchText,
     ],
   );
 

--- a/plugins/scaffolder/src/components/fields/MultiEntityPicker/MultiEntityPicker.tsx
+++ b/plugins/scaffolder/src/components/fields/MultiEntityPicker/MultiEntityPicker.tsx
@@ -94,6 +94,21 @@ export const MultiEntityPicker = (props: MultiEntityPickerProps) => {
   const [noOfItemsSelected, setNoOfItemsSelected] = useState(0);
 
   const selectedValues = useMemo(() => formData || [], [formData]);
+  const selectedEntityRefs = useMemo(
+    () =>
+      selectedValues.flatMap(value => {
+        try {
+          return [
+            stringifyEntityRef(
+              parseEntityRef(value, { defaultKind, defaultNamespace }),
+            ),
+          ];
+        } catch {
+          return [];
+        }
+      }),
+    [selectedValues, defaultKind, defaultNamespace],
+  );
   const {
     entities,
     entityRefToPresentation,
@@ -104,7 +119,7 @@ export const MultiEntityPicker = (props: MultiEntityPickerProps) => {
     initialResultIsOnlyOption,
   } = useEntityPickerOptions({
     catalogFilter,
-    selectedEntityRefs: selectedValues,
+    selectedEntityRefs,
   });
 
   const onSelect = useCallback(

--- a/plugins/scaffolder/src/components/fields/MultiEntityPicker/MultiEntityPicker.tsx
+++ b/plugins/scaffolder/src/components/fields/MultiEntityPicker/MultiEntityPicker.tsx
@@ -94,20 +94,29 @@ export const MultiEntityPicker = (props: MultiEntityPickerProps) => {
   const [noOfItemsSelected, setNoOfItemsSelected] = useState(0);
 
   const selectedValues = useMemo(() => formData || [], [formData]);
-  const selectedEntityRefs = useMemo(
+  const selectedValueToEntityRef = useMemo(
     () =>
-      selectedValues.flatMap(value => {
-        try {
-          return [
-            stringifyEntityRef(
-              parseEntityRef(value, { defaultKind, defaultNamespace }),
-            ),
-          ];
-        } catch {
-          return [];
-        }
-      }),
+      new Map(
+        selectedValues.flatMap(value => {
+          try {
+            return [
+              [
+                value,
+                stringifyEntityRef(
+                  parseEntityRef(value, { defaultKind, defaultNamespace }),
+                ),
+              ] as const,
+            ];
+          } catch {
+            return [];
+          }
+        }),
+      ),
     [selectedValues, defaultKind, defaultNamespace],
+  );
+  const selectedEntityRefs = useMemo(
+    () => Array.from(new Set(selectedValueToEntityRef.values())),
+    [selectedValueToEntityRef],
   );
   const {
     entities,
@@ -189,8 +198,8 @@ export const MultiEntityPicker = (props: MultiEntityPickerProps) => {
   );
 
   const availableOptions = useMemo(
-    () => allOptions.filter(o => !selectedValues.includes(o.value)),
-    [allOptions, selectedValues],
+    () => allOptions.filter(o => !selectedEntityRefs.includes(o.value)),
+    [allOptions, selectedEntityRefs],
   );
 
   const [inputValue, setInputValue] = useState('');
@@ -204,7 +213,7 @@ export const MultiEntityPicker = (props: MultiEntityPickerProps) => {
 
       if (key !== null) {
         const newValue = String(key);
-        if (!selectedValues.includes(newValue)) {
+        if (!selectedEntityRefs.includes(newValue)) {
           onChange([...selectedValues, newValue]);
         }
       } else if (allowArbitraryValues && inputValue) {
@@ -216,7 +225,10 @@ export const MultiEntityPicker = (props: MultiEntityPickerProps) => {
         } catch {
           // If the input isn't a valid entity ref, use it as-is
         }
-        if (!selectedValues.includes(entityRef)) {
+        if (
+          !selectedValues.includes(entityRef) &&
+          !selectedEntityRefs.includes(entityRef)
+        ) {
           onChange([...selectedValues, entityRef]);
         }
       }
@@ -225,6 +237,7 @@ export const MultiEntityPicker = (props: MultiEntityPickerProps) => {
     },
     [
       atMaxItems,
+      selectedEntityRefs,
       selectedValues,
       onChange,
       allowArbitraryValues,
@@ -277,9 +290,10 @@ export const MultiEntityPicker = (props: MultiEntityPickerProps) => {
               }}
             >
               {selectedValues.map(value => {
+                const entityRef = selectedValueToEntityRef.get(value) ?? value;
                 const label =
-                  allOptions.find(o => o.value === value)?.label ||
-                  entityRefToPresentation.get(value)?.primaryTitle ||
+                  allOptions.find(o => o.value === entityRef)?.label ||
+                  entityRefToPresentation.get(entityRef)?.primaryTitle ||
                   value;
                 return (
                   <span key={value} style={chipStyle}>

--- a/plugins/scaffolder/src/components/fields/MultiEntityPicker/MultiEntityPicker.tsx
+++ b/plugins/scaffolder/src/components/fields/MultiEntityPicker/MultiEntityPicker.tsx
@@ -120,6 +120,7 @@ export const MultiEntityPicker = (props: MultiEntityPickerProps) => {
   );
   const {
     entities,
+    selectedEntities,
     entityRefToPresentation,
     loading,
     loadingState,
@@ -133,41 +134,45 @@ export const MultiEntityPicker = (props: MultiEntityPickerProps) => {
 
   const onSelect = useCallback(
     (_: any, refs: (string | Entity)[], reason: AutocompleteChangeReason) => {
-      const values = refs
-        .map(ref => {
-          // If the ref is not a string, then it was a selected option in the picker
-          if (typeof ref !== 'string') {
-            // if ref does not exist: pass 'undefined' to trigger validation for required value
-            return ref ? stringifyEntityRef(ref as Entity) : undefined;
-          }
+      const values = Array.from(
+        new Set(
+          refs
+            .map(ref => {
+              // If the ref is not a string, then it was a selected option in the picker
+              if (typeof ref !== 'string') {
+                // if ref does not exist: pass 'undefined' to trigger validation for required value
+                return ref ? stringifyEntityRef(ref as Entity) : undefined;
+              }
 
-          // Add in default namespace, etc.
-          let entityRef = ref;
-          try {
-            // Attempt to parse the entity ref into it's full form.
-            entityRef = stringifyEntityRef(
-              parseEntityRef(ref as string, {
-                defaultKind,
-                defaultNamespace,
-              }),
-            );
-          } catch (err) {
-            // If the passed in value isn't an entity ref, do nothing.
-          }
+              // Add in default namespace, etc.
+              let entityRef = ref;
+              try {
+                // Attempt to parse the entity ref into it's full form.
+                entityRef = stringifyEntityRef(
+                  parseEntityRef(ref as string, {
+                    defaultKind,
+                    defaultNamespace,
+                  }),
+                );
+              } catch (err) {
+                // If the passed in value isn't an entity ref, do nothing.
+              }
 
-          // We need to check against formData here as that's the previous value for this field.
-          if (
-            // If value already matches what exists in form data, allow it
-            formData?.includes(ref) ||
-            // If arbitrary values are allowed and the reason is a free solo event, allow it
-            (allowArbitraryValues && FREE_SOLO_EVENTS.includes(reason))
-          ) {
-            return entityRef;
-          }
+              // We need to check against formData here as that's the previous value for this field.
+              if (
+                // If value already matches what exists in form data, allow it
+                formData?.includes(ref) ||
+                // If arbitrary values are allowed and the reason is a free solo event, allow it
+                (allowArbitraryValues && FREE_SOLO_EVENTS.includes(reason))
+              ) {
+                return entityRef;
+              }
 
-          return undefined;
-        })
-        .filter(ref => ref !== undefined) as string[];
+              return undefined;
+            })
+            .filter(ref => ref !== undefined) as string[],
+        ),
+      );
 
       setNoOfItemsSelected(values.length);
       setSearchText('');
@@ -201,6 +206,16 @@ export const MultiEntityPicker = (props: MultiEntityPickerProps) => {
     () => allOptions.filter(o => !selectedEntityRefs.includes(o.value)),
     [allOptions, selectedEntityRefs],
   );
+
+  const muiOptions = useMemo(() => {
+    const entityRefs = new Set(entities.map(stringifyEntityRef));
+    return [
+      ...selectedEntities.filter(
+        entity => !entityRefs.has(stringifyEntityRef(entity)),
+      ),
+      ...entities,
+    ];
+  }, [entities, selectedEntities]);
 
   const [inputValue, setInputValue] = useState('');
 
@@ -357,7 +372,7 @@ export const MultiEntityPicker = (props: MultiEntityPickerProps) => {
         defaultValue={formData}
         loading={loading}
         onChange={onSelect}
-        options={entities}
+        options={muiOptions}
         onInputChange={(_event, value, reason) => {
           if (reason === 'input' || reason === 'clear') {
             setSearchText(value);
@@ -371,6 +386,22 @@ export const MultiEntityPicker = (props: MultiEntityPickerProps) => {
             : entityRefToPresentation.get(stringifyEntityRef(option))
                 ?.entityRef!
         }
+        getOptionSelected={(option, value) => {
+          const normalizeRef = (item: string | Entity) => {
+            if (typeof item !== 'string') {
+              return stringifyEntityRef(item);
+            }
+            try {
+              return stringifyEntityRef(
+                parseEntityRef(item, { defaultKind, defaultNamespace }),
+              );
+            } catch {
+              return undefined;
+            }
+          };
+          const optionRef = normalizeRef(option);
+          return optionRef !== undefined && optionRef === normalizeRef(value);
+        }}
         getOptionDisabled={_options =>
           maxItems ? noOfItemsSelected >= maxItems : false
         }

--- a/plugins/scaffolder/src/components/fields/MyGroupsPicker/MyGroupsPicker.test.tsx
+++ b/plugins/scaffolder/src/components/fields/MyGroupsPicker/MyGroupsPicker.test.tsx
@@ -26,7 +26,7 @@ import {
   catalogApiRef,
   entityPresentationApiRef,
 } from '@backstage/plugin-catalog-react';
-import { Entity } from '@backstage/catalog-model';
+import { Entity, stringifyEntityRef } from '@backstage/catalog-model';
 import {
   ErrorApi,
   errorApiRef,
@@ -38,6 +38,7 @@ import { DefaultEntityPresentationApi } from '@backstage/plugin-catalog';
 import { ComponentType, PropsWithChildren, ReactNode } from 'react';
 import { useTranslationRef } from '@backstage/frontend-plugin-api';
 import { scaffolderTranslationRef } from '../../../translation';
+import { ENTITY_PICKER_FIELDS } from '../useEntityPickerOptions';
 
 const mockIdentityApi = mockApis.identity({
   userEntityRef: 'user:default/bob',
@@ -50,9 +51,14 @@ describe('<MyGroupsPicker />', () => {
   const required = false;
 
   const catalogApi = catalogApiMock.mock({
-    streamEntities: jest.fn(async function* () {
-      yield entities;
+    queryEntities: jest.fn(async () => {
+      return { items: entities, totalItems: 0, pageInfo: {} };
     }),
+    getEntitiesByRefs: jest.fn(async ({ entityRefs }) => ({
+      items: entityRefs.map((entityRef: string) =>
+        entities.find(entity => stringifyEntityRef(entity) === entityRef),
+      ),
+    })),
   });
 
   const mockErrorApi: jest.Mocked<ErrorApi> = {
@@ -83,7 +89,7 @@ describe('<MyGroupsPicker />', () => {
     ];
 
     onChange.mockClear();
-    catalogApi.streamEntities.mockClear();
+    catalogApi.queryEntities.mockClear();
   });
 
   afterEach(() => {
@@ -98,10 +104,11 @@ describe('<MyGroupsPicker />', () => {
         entity.spec.members.includes('Bob'),
     );
 
-    catalogApi.streamEntities.mockImplementation(async function* () {
-      yield userGroups;
+    catalogApi.queryEntities.mockResolvedValue({
+      items: userGroups,
+      totalItems: 0,
+      pageInfo: {},
     });
-
     const props = {
       onChange,
       schema,
@@ -126,15 +133,18 @@ describe('<MyGroupsPicker />', () => {
     );
 
     await waitFor(() =>
-      expect(catalogApi.streamEntities).toHaveBeenCalledTimes(1),
+      expect(catalogApi.queryEntities).toHaveBeenCalledTimes(1),
     );
 
-    expect(catalogApi.streamEntities).toHaveBeenCalledWith({
-      query: {},
+    expect(catalogApi.queryEntities).toHaveBeenCalledWith({
       filter: {
         kind: 'Group',
         'relations.hasMember': ['user:default/bob'],
       },
+      fields: ENTITY_PICKER_FIELDS,
+      limit: 20,
+      orderFields: [{ field: 'metadata.name', order: 'asc' }],
+      totalItems: 'exclude',
     });
   });
 
@@ -146,8 +156,10 @@ describe('<MyGroupsPicker />', () => {
         entity.spec.members.includes('Bob'),
     );
 
-    catalogApi.streamEntities.mockImplementation(async function* () {
-      yield userGroups;
+    catalogApi.queryEntities.mockResolvedValue({
+      items: userGroups,
+      totalItems: 0,
+      pageInfo: {},
     });
 
     const props = {
@@ -174,7 +186,7 @@ describe('<MyGroupsPicker />', () => {
     );
 
     await waitFor(() =>
-      expect(catalogApi.streamEntities).toHaveBeenCalledTimes(1),
+      expect(catalogApi.queryEntities).toHaveBeenCalledTimes(1),
     );
 
     // Simulate user input
@@ -210,8 +222,10 @@ describe('<MyGroupsPicker />', () => {
       },
     ];
 
-    catalogApi.streamEntities.mockImplementation(async function* () {
-      yield userGroups;
+    catalogApi.queryEntities.mockResolvedValue({
+      items: userGroups,
+      totalItems: 0,
+      pageInfo: {},
     });
 
     const props = {
@@ -238,7 +252,7 @@ describe('<MyGroupsPicker />', () => {
     );
 
     await waitFor(() =>
-      expect(catalogApi.streamEntities).toHaveBeenCalledTimes(1),
+      expect(catalogApi.queryEntities).toHaveBeenCalledTimes(1),
     );
 
     const inputField = getByRole('combobox');
@@ -276,9 +290,12 @@ describe('<MyGroupsPicker />', () => {
       },
     ];
 
-    catalogApi.streamEntities.mockImplementation(async function* () {
-      yield userGroups;
+    catalogApi.queryEntities.mockResolvedValue({
+      items: userGroups,
+      totalItems: 0,
+      pageInfo: {},
     });
+    catalogApi.getEntitiesByRefs.mockResolvedValue({ items: [userGroups[0]] });
 
     const props = {
       onChange,
@@ -305,7 +322,7 @@ describe('<MyGroupsPicker />', () => {
     );
 
     await waitFor(() =>
-      expect(catalogApi.streamEntities).toHaveBeenCalledTimes(1),
+      expect(catalogApi.queryEntities).toHaveBeenCalledTimes(1),
     );
 
     const inputField = getByRole('combobox');

--- a/plugins/scaffolder/src/components/fields/MyGroupsPicker/MyGroupsPicker.test.tsx
+++ b/plugins/scaffolder/src/components/fields/MyGroupsPicker/MyGroupsPicker.test.tsx
@@ -350,6 +350,39 @@ describe('<MyGroupsPicker />', () => {
     expect(onChange).not.toHaveBeenCalled();
   });
 
+  it('does not clear a BUI group while its entity is loading', async () => {
+    mockUseScaffolderTheme.mockReturnValue('bui');
+    catalogApi.getEntitiesByRefs.mockReturnValueOnce(new Promise(() => {}));
+    const props = {
+      onChange,
+      schema,
+      required,
+      uiSchema: {},
+      formData: 'group:default/off-page',
+    } as unknown as FieldProps<string>;
+    await renderInTestApp(
+      <TestApiProvider
+        apis={[
+          [identityApiRef, mockIdentityApi],
+          [catalogApiRef, catalogApi],
+          [errorApiRef, mockErrorApi],
+          [
+            entityPresentationApiRef,
+            DefaultEntityPresentationApi.create({ catalogApi }),
+          ],
+        ]}
+      >
+        <MyGroupsPicker {...props} />
+      </TestApiProvider>,
+    );
+    const input = screen.getByRole('combobox');
+
+    fireEvent.focus(input);
+    fireEvent.blur(input);
+
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
   it('should call the onChange handler with the correct entityRef and and use a nice display name', async () => {
     const userGroups = [
       {

--- a/plugins/scaffolder/src/components/fields/MyGroupsPicker/MyGroupsPicker.test.tsx
+++ b/plugins/scaffolder/src/components/fields/MyGroupsPicker/MyGroupsPicker.test.tsx
@@ -213,100 +213,110 @@ describe('<MyGroupsPicker />', () => {
     expect(queryByText('group3')).not.toBeInTheDocument();
   });
 
-  it('keeps BUI search input while filtered groups arrive', async () => {
-    mockUseScaffolderTheme.mockReturnValue('bui');
-    const userGroups = entities.slice(0, 2);
-    let resolveFilteredResults = () => {};
-    catalogApi.queryEntities
-      .mockResolvedValueOnce({
-        items: userGroups,
-        totalItems: 0,
-        pageInfo: {},
-      })
-      .mockReturnValueOnce(
+  it.each(['bui', 'mui'] as const)(
+    'keeps %s search input when the selected group moves outside the results',
+    async theme => {
+      mockUseScaffolderTheme.mockReturnValue(theme);
+      const userGroups = entities.slice(0, 2);
+      catalogApi.getEntitiesByRefs.mockResolvedValue({
+        items: [{ ...userGroups[1] }],
+      });
+      let resolveFilteredResults = () => {};
+      catalogApi.queryEntities
+        .mockResolvedValueOnce({
+          items: userGroups,
+          totalItems: 0,
+          pageInfo: {},
+        })
+        .mockReturnValueOnce(
+          new Promise(resolve => {
+            resolveFilteredResults = () =>
+              resolve({ items: [userGroups[0]], totalItems: 0, pageInfo: {} });
+          }),
+        );
+      const props = {
+        onChange,
+        schema,
+        required,
+        uiSchema: {},
+        formData: 'group:default/group2',
+      } as unknown as FieldProps<string>;
+      await renderInTestApp(
+        <TestApiProvider
+          apis={[
+            [identityApiRef, mockIdentityApi],
+            [catalogApiRef, catalogApi],
+            [errorApiRef, mockErrorApi],
+            [
+              entityPresentationApiRef,
+              DefaultEntityPresentationApi.create({ catalogApi }),
+            ],
+          ]}
+        >
+          <MyGroupsPicker {...props} />
+        </TestApiProvider>,
+      );
+      const input = screen.getByRole(theme === 'bui' ? 'combobox' : 'textbox');
+
+      fireEvent.change(input, { target: { value: 'group' } });
+      await waitFor(() =>
+        expect(catalogApi.queryEntities).toHaveBeenCalledTimes(2),
+      );
+      await act(async () => resolveFilteredResults());
+
+      expect(input).toHaveValue('group');
+    },
+  );
+
+  it.each(['bui', 'mui'] as const)(
+    'keeps %s search input when a selected group presentation arrives late',
+    async theme => {
+      mockUseScaffolderTheme.mockReturnValue(theme);
+      const selectedGroup: Entity = {
+        apiVersion: 'backstage.io/v1alpha1',
+        kind: 'Group',
+        metadata: { name: 'off-page', title: 'Off Page Group' },
+      };
+      let resolveSelectedGroup = () => {};
+      catalogApi.getEntitiesByRefs.mockReturnValueOnce(
         new Promise(resolve => {
-          resolveFilteredResults = () =>
-            resolve({ items: [userGroups[0]], totalItems: 0, pageInfo: {} });
+          resolveSelectedGroup = () => resolve({ items: [selectedGroup] });
         }),
       );
-    const props = {
-      onChange,
-      schema,
-      required,
-      uiSchema: {},
-    } as unknown as FieldProps<string>;
-    await renderInTestApp(
-      <TestApiProvider
-        apis={[
-          [identityApiRef, mockIdentityApi],
-          [catalogApiRef, catalogApi],
-          [errorApiRef, mockErrorApi],
-          [
-            entityPresentationApiRef,
-            DefaultEntityPresentationApi.create({ catalogApi }),
-          ],
-        ]}
-      >
-        <MyGroupsPicker {...props} />
-      </TestApiProvider>,
-    );
-    const input = screen.getByRole('combobox');
+      const props = {
+        onChange,
+        schema,
+        required,
+        uiSchema: {},
+        formData: 'group:default/off-page',
+      } as unknown as FieldProps<string>;
+      await renderInTestApp(
+        <TestApiProvider
+          apis={[
+            [identityApiRef, mockIdentityApi],
+            [catalogApiRef, catalogApi],
+            [errorApiRef, mockErrorApi],
+            [
+              entityPresentationApiRef,
+              DefaultEntityPresentationApi.create({ catalogApi }),
+            ],
+          ]}
+        >
+          <MyGroupsPicker {...props} />
+        </TestApiProvider>,
+      );
+      const input = screen.getByRole(theme === 'bui' ? 'combobox' : 'textbox');
 
-    fireEvent.change(input, { target: { value: 'group' } });
-    await waitFor(() =>
-      expect(catalogApi.queryEntities).toHaveBeenCalledTimes(2),
-    );
-    await act(async () => resolveFilteredResults());
+      fireEvent.change(input, { target: { value: 'replacement' } });
+      await act(async () => {
+        resolveSelectedGroup();
+        await Promise.resolve();
+        await Promise.resolve();
+      });
 
-    expect(input).toHaveValue('group');
-  });
-
-  it('keeps BUI search input when a selected group presentation arrives late', async () => {
-    mockUseScaffolderTheme.mockReturnValue('bui');
-    const selectedGroup: Entity = {
-      apiVersion: 'backstage.io/v1alpha1',
-      kind: 'Group',
-      metadata: { name: 'off-page', title: 'Off Page Group' },
-    };
-    let resolveSelectedGroup = () => {};
-    catalogApi.getEntitiesByRefs.mockReturnValueOnce(
-      new Promise(resolve => {
-        resolveSelectedGroup = () => resolve({ items: [selectedGroup] });
-      }),
-    );
-    const props = {
-      onChange,
-      schema,
-      required,
-      uiSchema: {},
-      formData: 'group:default/off-page',
-    } as unknown as FieldProps<string>;
-    await renderInTestApp(
-      <TestApiProvider
-        apis={[
-          [identityApiRef, mockIdentityApi],
-          [catalogApiRef, catalogApi],
-          [errorApiRef, mockErrorApi],
-          [
-            entityPresentationApiRef,
-            DefaultEntityPresentationApi.create({ catalogApi }),
-          ],
-        ]}
-      >
-        <MyGroupsPicker {...props} />
-      </TestApiProvider>,
-    );
-    const input = screen.getByRole('combobox');
-
-    fireEvent.change(input, { target: { value: 'replacement' } });
-    await act(async () => {
-      resolveSelectedGroup();
-      await Promise.resolve();
-      await Promise.resolve();
-    });
-
-    expect(input).toHaveValue('replacement');
-  });
+      expect(input).toHaveValue('replacement');
+    },
+  );
 
   it('does not clear a BUI group outside the current page on blur', async () => {
     mockUseScaffolderTheme.mockReturnValue('bui');

--- a/plugins/scaffolder/src/components/fields/MyGroupsPicker/MyGroupsPicker.test.tsx
+++ b/plugins/scaffolder/src/components/fields/MyGroupsPicker/MyGroupsPicker.test.tsx
@@ -15,6 +15,7 @@
  */
 
 import { act, fireEvent, screen, waitFor } from '@testing-library/react';
+import { type CatalogApi } from '@backstage/catalog-client';
 import { catalogApiMock } from '@backstage/plugin-catalog-react/testUtils';
 import { MyGroupsPicker } from './MyGroupsPicker';
 import {
@@ -26,7 +27,7 @@ import {
   catalogApiRef,
   entityPresentationApiRef,
 } from '@backstage/plugin-catalog-react';
-import { Entity, stringifyEntityRef } from '@backstage/catalog-model';
+import { Entity } from '@backstage/catalog-model';
 import {
   ErrorApi,
   errorApiRef,
@@ -47,6 +48,9 @@ jest.mock('@backstage/plugin-scaffolder-react/alpha', () => ({
 
 const mockUseScaffolderTheme = jest.mocked(useScaffolderTheme);
 
+type SpiedCatalogApi = CatalogApi &
+  Pick<jest.Mocked<CatalogApi>, 'getEntitiesByRefs' | 'queryEntities'>;
+
 const mockIdentityApi = mockApis.identity({
   userEntityRef: 'user:default/bob',
 });
@@ -57,16 +61,7 @@ describe('<MyGroupsPicker />', () => {
   const schema = {};
   const required = false;
 
-  const catalogApi = catalogApiMock.mock({
-    queryEntities: jest.fn(async () => {
-      return { items: entities, totalItems: 0, pageInfo: {} };
-    }),
-    getEntitiesByRefs: jest.fn(async ({ entityRefs }) => ({
-      items: entityRefs.map((entityRef: string) =>
-        entities.find(entity => stringifyEntityRef(entity) === entityRef),
-      ),
-    })),
-  });
+  let catalogApi: SpiedCatalogApi;
 
   const mockErrorApi: jest.Mocked<ErrorApi> = {
     post: jest.fn(),
@@ -96,8 +91,13 @@ describe('<MyGroupsPicker />', () => {
       },
     ];
 
+    const api = catalogApiMock({ entities });
+    catalogApi = Object.assign(api, {
+      queryEntities: jest.spyOn(api, 'queryEntities'),
+      getEntitiesByRefs: jest.spyOn(api, 'getEntitiesByRefs'),
+    });
+
     onChange.mockClear();
-    catalogApi.queryEntities.mockClear();
   });
 
   afterEach(() => {

--- a/plugins/scaffolder/src/components/fields/MyGroupsPicker/MyGroupsPicker.test.tsx
+++ b/plugins/scaffolder/src/components/fields/MyGroupsPicker/MyGroupsPicker.test.tsx
@@ -261,6 +261,95 @@ describe('<MyGroupsPicker />', () => {
     expect(input).toHaveValue('group');
   });
 
+  it('keeps BUI search input when a selected group presentation arrives late', async () => {
+    mockUseScaffolderTheme.mockReturnValue('bui');
+    const selectedGroup: Entity = {
+      apiVersion: 'backstage.io/v1alpha1',
+      kind: 'Group',
+      metadata: { name: 'off-page', title: 'Off Page Group' },
+    };
+    let resolveSelectedGroup = () => {};
+    catalogApi.getEntitiesByRefs.mockReturnValueOnce(
+      new Promise(resolve => {
+        resolveSelectedGroup = () => resolve({ items: [selectedGroup] });
+      }),
+    );
+    const props = {
+      onChange,
+      schema,
+      required,
+      uiSchema: {},
+      formData: 'group:default/off-page',
+    } as unknown as FieldProps<string>;
+    await renderInTestApp(
+      <TestApiProvider
+        apis={[
+          [identityApiRef, mockIdentityApi],
+          [catalogApiRef, catalogApi],
+          [errorApiRef, mockErrorApi],
+          [
+            entityPresentationApiRef,
+            DefaultEntityPresentationApi.create({ catalogApi }),
+          ],
+        ]}
+      >
+        <MyGroupsPicker {...props} />
+      </TestApiProvider>,
+    );
+    const input = screen.getByRole('combobox');
+
+    fireEvent.change(input, { target: { value: 'replacement' } });
+    await act(async () => {
+      resolveSelectedGroup();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(input).toHaveValue('replacement');
+  });
+
+  it('does not clear a BUI group outside the current page on blur', async () => {
+    mockUseScaffolderTheme.mockReturnValue('bui');
+    const selectedGroup: Entity = {
+      apiVersion: 'backstage.io/v1alpha1',
+      kind: 'Group',
+      metadata: { name: 'off-page' },
+      spec: { members: ['Bob'] },
+    };
+    catalogApi.getEntitiesByRefs.mockResolvedValueOnce({
+      items: [selectedGroup],
+    });
+    const props = {
+      onChange,
+      schema,
+      required,
+      uiSchema: {},
+      formData: 'group:default/off-page',
+    } as unknown as FieldProps<string>;
+    await renderInTestApp(
+      <TestApiProvider
+        apis={[
+          [identityApiRef, mockIdentityApi],
+          [catalogApiRef, catalogApi],
+          [errorApiRef, mockErrorApi],
+          [
+            entityPresentationApiRef,
+            DefaultEntityPresentationApi.create({ catalogApi }),
+          ],
+        ]}
+      >
+        <MyGroupsPicker {...props} />
+      </TestApiProvider>,
+    );
+    const input = screen.getByRole('combobox');
+    await waitFor(() => expect(input).toHaveValue('off-page'));
+
+    fireEvent.focus(input);
+    fireEvent.blur(input);
+
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
   it('should call the onChange handler with the correct entityRef and and use a nice display name', async () => {
     const userGroups = [
       {

--- a/plugins/scaffolder/src/components/fields/MyGroupsPicker/MyGroupsPicker.test.tsx
+++ b/plugins/scaffolder/src/components/fields/MyGroupsPicker/MyGroupsPicker.test.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { waitFor } from '@testing-library/react';
+import { act, fireEvent, screen, waitFor } from '@testing-library/react';
 import { catalogApiMock } from '@backstage/plugin-catalog-react/testUtils';
 import { MyGroupsPicker } from './MyGroupsPicker';
 import {
@@ -38,7 +38,14 @@ import { DefaultEntityPresentationApi } from '@backstage/plugin-catalog';
 import { ComponentType, PropsWithChildren, ReactNode } from 'react';
 import { useTranslationRef } from '@backstage/frontend-plugin-api';
 import { scaffolderTranslationRef } from '../../../translation';
-import { ENTITY_PICKER_FIELDS } from '../useEntityPickerOptions';
+import { useScaffolderTheme } from '@backstage/plugin-scaffolder-react/alpha';
+
+jest.mock('@backstage/plugin-scaffolder-react/alpha', () => ({
+  ...jest.requireActual('@backstage/plugin-scaffolder-react/alpha'),
+  useScaffolderTheme: jest.fn(),
+}));
+
+const mockUseScaffolderTheme = jest.mocked(useScaffolderTheme);
 
 const mockIdentityApi = mockApis.identity({
   userEntityRef: 'user:default/bob',
@@ -67,6 +74,7 @@ describe('<MyGroupsPicker />', () => {
   };
 
   beforeEach(() => {
+    mockUseScaffolderTheme.mockReturnValue('mui');
     entities = [
       {
         apiVersion: 'backstage.io/v1alpha1',
@@ -141,7 +149,6 @@ describe('<MyGroupsPicker />', () => {
         kind: 'Group',
         'relations.hasMember': ['user:default/bob'],
       },
-      fields: ENTITY_PICKER_FIELDS,
       limit: 20,
       orderFields: [{ field: 'metadata.name', order: 'asc' }],
       totalItems: 'exclude',
@@ -204,6 +211,54 @@ describe('<MyGroupsPicker />', () => {
 
     // Assert that 'group3' is not rendered in the component
     expect(queryByText('group3')).not.toBeInTheDocument();
+  });
+
+  it('keeps BUI search input while filtered groups arrive', async () => {
+    mockUseScaffolderTheme.mockReturnValue('bui');
+    const userGroups = entities.slice(0, 2);
+    let resolveFilteredResults = () => {};
+    catalogApi.queryEntities
+      .mockResolvedValueOnce({
+        items: userGroups,
+        totalItems: 0,
+        pageInfo: {},
+      })
+      .mockReturnValueOnce(
+        new Promise(resolve => {
+          resolveFilteredResults = () =>
+            resolve({ items: [userGroups[0]], totalItems: 0, pageInfo: {} });
+        }),
+      );
+    const props = {
+      onChange,
+      schema,
+      required,
+      uiSchema: {},
+    } as unknown as FieldProps<string>;
+    await renderInTestApp(
+      <TestApiProvider
+        apis={[
+          [identityApiRef, mockIdentityApi],
+          [catalogApiRef, catalogApi],
+          [errorApiRef, mockErrorApi],
+          [
+            entityPresentationApiRef,
+            DefaultEntityPresentationApi.create({ catalogApi }),
+          ],
+        ]}
+      >
+        <MyGroupsPicker {...props} />
+      </TestApiProvider>,
+    );
+    const input = screen.getByRole('combobox');
+
+    fireEvent.change(input, { target: { value: 'group' } });
+    await waitFor(() =>
+      expect(catalogApi.queryEntities).toHaveBeenCalledTimes(2),
+    );
+    await act(async () => resolveFilteredResults());
+
+    expect(input).toHaveValue('group');
   });
 
   it('should call the onChange handler with the correct entityRef and and use a nice display name', async () => {
@@ -329,6 +384,56 @@ describe('<MyGroupsPicker />', () => {
     const inputFieldValue = inputField?.querySelector('input')?.value;
 
     expect(inputFieldValue).toEqual(userGroups[0].metadata.title);
+  });
+
+  it('accepts a selected group that is not on the current page', async () => {
+    const selectedGroup: Entity = {
+      apiVersion: 'backstage.io/v1alpha1',
+      kind: 'Group',
+      metadata: { name: 'off-page' },
+    };
+    catalogApi.queryEntities.mockResolvedValue({
+      items: entities.slice(0, 2),
+      totalItems: 0,
+      pageInfo: {},
+    });
+    catalogApi.getEntitiesByRefs.mockResolvedValue({
+      items: [selectedGroup],
+    });
+    const props = {
+      onChange,
+      schema,
+      required,
+      uiSchema: {},
+      formData: 'group:default/off-page',
+    } as unknown as FieldProps<string>;
+    const warn = jest.spyOn(console, 'warn').mockImplementation(() => {});
+
+    await renderInTestApp(
+      <TestApiProvider
+        apis={[
+          [identityApiRef, mockIdentityApi],
+          [catalogApiRef, catalogApi],
+          [errorApiRef, mockErrorApi],
+          [
+            entityPresentationApiRef,
+            DefaultEntityPresentationApi.create({ catalogApi }),
+          ],
+        ]}
+      >
+        <MyGroupsPicker {...props} />
+      </TestApiProvider>,
+    );
+    await waitFor(() =>
+      expect(screen.getByRole('combobox').querySelector('input')).toHaveValue(
+        'off-page',
+      ),
+    );
+
+    expect(warn).not.toHaveBeenCalledWith(
+      expect.stringContaining('value provided to Autocomplete is invalid'),
+    );
+    warn.mockRestore();
   });
 
   describe('MyGroupsPicker description', () => {

--- a/plugins/scaffolder/src/components/fields/MyGroupsPicker/MyGroupsPicker.tsx
+++ b/plugins/scaffolder/src/components/fields/MyGroupsPicker/MyGroupsPicker.tsx
@@ -17,6 +17,7 @@
 import {
   type Key,
   ChangeEvent,
+  type MouseEvent,
   useCallback,
   useEffect,
   useMemo,
@@ -29,15 +30,8 @@ import {
 } from '@backstage/core-plugin-api';
 import TextField from '@material-ui/core/TextField';
 import { MyGroupsPickerProps, MyGroupsPickerSchema } from './schema';
-import Autocomplete, {
-  createFilterOptions,
-} from '@material-ui/lab/Autocomplete';
-import {
-  catalogApiRef,
-  EntityDisplayName,
-  entityPresentationApiRef,
-  EntityRefPresentationSnapshot,
-} from '@backstage/plugin-catalog-react';
+import Autocomplete from '@material-ui/lab/Autocomplete';
+import { EntityDisplayName } from '@backstage/plugin-catalog-react';
 import { NotFoundError } from '@backstage/errors';
 import useAsync from 'react-use/esm/useAsync';
 import { Entity, stringifyEntityRef } from '@backstage/catalog-model';
@@ -49,6 +43,7 @@ import {
   useScaffolderTheme,
 } from '@backstage/plugin-scaffolder-react/alpha';
 import { Autocomplete as BuiAutocomplete } from '../Autocomplete';
+import { useEntityPickerOptions } from '../useEntityPickerOptions';
 
 export { MyGroupsPickerSchema };
 
@@ -70,47 +65,49 @@ export const MyGroupsPicker = (props: MyGroupsPickerProps) => {
   } = props;
 
   const identityApi = useApi(identityApiRef);
-  const catalogApi = useApi(catalogApiRef);
   const errorApi = useApi(errorApiRef);
-  const entityPresentationApi = useApi(entityPresentationApiRef);
   const isDisabled = uiSchema?.['ui:disabled'] ?? false;
 
-  const { value: groups, loading } = useAsync(async () => {
-    const { userEntityRef } = await identityApi.getBackstageIdentity();
+  const { value: userEntityRef, loading: identityLoading } = useAsync(
+    async () => {
+      const { userEntityRef: identityEntityRef } =
+        await identityApi.getBackstageIdentity();
 
-    if (!userEntityRef) {
-      errorApi.post(new NotFoundError('No user entity ref found'));
-      return { catalogEntities: [], entityRefToPresentation: new Map() };
-    }
+      if (!identityEntityRef) {
+        errorApi.post(new NotFoundError('No user entity ref found'));
+        return undefined;
+      }
 
-    const items: Entity[] = [];
-    for await (const batch of catalogApi.streamEntities({
-      query: {},
-      filter: {
-        kind: 'Group',
-        ['relations.hasMember']: [userEntityRef],
-      },
-    })) {
-      items.push(...batch);
-    }
-
-    const entityRefToPresentation = new Map<
-      string,
-      EntityRefPresentationSnapshot
-    >(
-      await Promise.all(
-        items.map(async item => {
-          const presentation = await entityPresentationApi.forEntity(item)
-            .promise;
-          return [stringifyEntityRef(item), presentation] as [
-            string,
-            EntityRefPresentationSnapshot,
-          ];
-        }),
-      ),
-    );
-
-    return { catalogEntities: items, entityRefToPresentation };
+      return identityEntityRef;
+    },
+  );
+  const catalogFilter = useMemo(
+    () =>
+      userEntityRef
+        ? {
+            kind: 'Group',
+            ['relations.hasMember']: [userEntityRef],
+          }
+        : undefined,
+    [userEntityRef],
+  );
+  const selectedEntityRefs = useMemo(
+    () => (formData ? [formData] : []),
+    [formData],
+  );
+  const {
+    entities,
+    selectedEntities,
+    entityRefToPresentation,
+    loading,
+    loadingState,
+    setSearchText,
+    loadMore,
+    initialResultIsOnlyOption,
+  } = useEntityPickerOptions({
+    catalogFilter,
+    enabled: !identityLoading && Boolean(userEntityRef),
+    selectedEntityRefs,
   });
 
   // MUI: update handler
@@ -119,33 +116,37 @@ export const MyGroupsPicker = (props: MyGroupsPickerProps) => {
   };
 
   const selectedEntity =
-    groups?.catalogEntities.find(e => stringifyEntityRef(e) === formData) ||
+    selectedEntities.find(e => stringifyEntityRef(e) === formData) ??
+    entities.find(e => stringifyEntityRef(e) === formData) ??
     null;
 
   // BUI: options
   const buiOptions = useMemo(
     () =>
-      (groups?.catalogEntities || []).map(entity => {
+      entities.map(entity => {
         const entityRef = stringifyEntityRef(entity);
-        const presentation = groups?.entityRefToPresentation.get(entityRef);
+        const presentation = entityRefToPresentation.get(entityRef);
         return {
           value: entityRef,
           label: presentation?.primaryTitle || entityRef,
         };
       }),
-    [groups],
+    [entities, entityRefToPresentation],
   );
 
   const [inputValue, setInputValue] = useState('');
 
   useEffect(() => {
     if (formData) {
-      const opt = buiOptions.find(o => o.value === formData);
-      setInputValue(opt?.label || formData);
+      setInputValue(
+        buiOptions.find(o => o.value === formData)?.label ||
+          entityRefToPresentation.get(formData)?.primaryTitle ||
+          formData,
+      );
     } else {
       setInputValue('');
     }
-  }, [formData, buiOptions]);
+  }, [entityRefToPresentation, formData, buiOptions]);
 
   const selectedKey =
     formData && buiOptions.some(o => o.value === formData) ? formData : null;
@@ -158,13 +159,13 @@ export const MyGroupsPicker = (props: MyGroupsPickerProps) => {
   );
 
   useEffect(() => {
-    if (required && groups?.catalogEntities.length === 1 && !selectedEntity) {
-      onChange(stringifyEntityRef(groups.catalogEntities[0]));
+    if (required && initialResultIsOnlyOption && !selectedEntity) {
+      onChange(stringifyEntityRef(entities[0]));
     }
-  }, [groups, onChange, selectedEntity, required]);
+  }, [entities, initialResultIsOnlyOption, onChange, selectedEntity, required]);
 
   if (theme === 'bui') {
-    const isAutoSelected = required && groups?.catalogEntities.length === 1;
+    const isAutoSelected = required && initialResultIsOnlyOption;
 
     return (
       <ScaffolderField
@@ -180,11 +181,17 @@ export const MyGroupsPicker = (props: MyGroupsPickerProps) => {
           isRequired={required}
           isDisabled={isDisabled || isAutoSelected}
           selectedKey={selectedKey}
-          inputValue={inputValue}
-          onInputChange={setInputValue}
           onSelectionChange={handleSelectionChange}
-          isLoading={loading}
           options={buiOptions}
+          search={{
+            mode: 'server',
+            inputValue,
+            onInputChange: value => {
+              setInputValue(value);
+              setSearchText(value);
+            },
+          }}
+          loading={{ state: loadingState, onLoadMore: loadMore }}
           allowsCustomValue={false}
           isInvalid={rawErrors && rawErrors.length > 0}
         />
@@ -201,15 +208,19 @@ export const MyGroupsPicker = (props: MyGroupsPickerProps) => {
       errors={errors}
     >
       <Autocomplete
-        disabled={required && groups?.catalogEntities.length === 1}
+        disabled={isDisabled || (required && initialResultIsOnlyOption)}
         id="OwnershipEntityRefPicker-dropdown"
-        options={groups?.catalogEntities || []}
+        options={entities}
         value={selectedEntity}
-        loading={loading}
+        loading={identityLoading || loading}
         onChange={updateChange}
+        onInputChange={(_event, value, reason) => {
+          if (reason === 'input' || reason === 'clear') {
+            setSearchText(value);
+          }
+        }}
         getOptionLabel={option =>
-          groups?.entityRefToPresentation.get(stringifyEntityRef(option))
-            ?.primaryTitle!
+          entityRefToPresentation.get(stringifyEntityRef(option))?.primaryTitle!
         }
         autoSelect
         renderInput={params => (
@@ -224,12 +235,20 @@ export const MyGroupsPicker = (props: MyGroupsPickerProps) => {
           />
         )}
         renderOption={option => <EntityDisplayName entityRef={option} />}
-        filterOptions={createFilterOptions<Entity>({
-          stringify: option =>
-            groups?.entityRefToPresentation.get(stringifyEntityRef(option))
-              ?.primaryTitle!,
-        })}
+        filterOptions={options => options}
         ListboxComponent={VirtualizedListbox}
+        ListboxProps={{
+          onScroll: (event: MouseEvent) => {
+            const element = event.currentTarget;
+            if (
+              Math.abs(
+                element.scrollHeight - element.clientHeight - element.scrollTop,
+              ) < 1
+            ) {
+              loadMore();
+            }
+          },
+        }}
       />
     </ScaffolderField>
   );

--- a/plugins/scaffolder/src/components/fields/MyGroupsPicker/MyGroupsPicker.tsx
+++ b/plugins/scaffolder/src/components/fields/MyGroupsPicker/MyGroupsPicker.tsx
@@ -21,6 +21,7 @@ import {
   useCallback,
   useEffect,
   useMemo,
+  useRef,
   useState,
 } from 'react';
 import {
@@ -131,7 +132,7 @@ export const MyGroupsPicker = (props: MyGroupsPickerProps) => {
   // BUI: options
   const buiOptions = useMemo(
     () =>
-      entities.map(entity => {
+      muiOptions.map(entity => {
         const entityRef = stringifyEntityRef(entity);
         const presentation = entityRefToPresentation.get(entityRef);
         return {
@@ -139,19 +140,23 @@ export const MyGroupsPicker = (props: MyGroupsPickerProps) => {
           label: presentation?.primaryTitle || entityRef,
         };
       }),
-    [entities, entityRefToPresentation],
+    [muiOptions, entityRefToPresentation],
   );
 
   const [inputValue, setInputValue] = useState('');
+  const inputIsDirtyRef = useRef(false);
+  const previousFormDataRef = useRef(formData);
   const selectedPresentationTitle = formData
     ? entityRefToPresentation.get(formData)?.primaryTitle
     : undefined;
 
   useEffect(() => {
-    if (formData) {
-      setInputValue(selectedPresentationTitle || formData);
-    } else {
-      setInputValue('');
+    if (previousFormDataRef.current !== formData) {
+      previousFormDataRef.current = formData;
+      inputIsDirtyRef.current = false;
+    }
+    if (!inputIsDirtyRef.current) {
+      setInputValue(formData ? selectedPresentationTitle || formData : '');
     }
   }, [formData, selectedPresentationTitle]);
 
@@ -160,6 +165,7 @@ export const MyGroupsPicker = (props: MyGroupsPickerProps) => {
 
   const handleSelectionChange = useCallback(
     (key: Key | null) => {
+      inputIsDirtyRef.current = false;
       setSearchText('');
       onChange(key !== null ? String(key) : '');
     },
@@ -195,6 +201,7 @@ export const MyGroupsPicker = (props: MyGroupsPickerProps) => {
             mode: 'server',
             inputValue,
             onInputChange: value => {
+              inputIsDirtyRef.current = true;
               setInputValue(value);
               setSearchText(value);
             },

--- a/plugins/scaffolder/src/components/fields/MyGroupsPicker/MyGroupsPicker.tsx
+++ b/plugins/scaffolder/src/components/fields/MyGroupsPicker/MyGroupsPicker.tsx
@@ -35,7 +35,11 @@ import Autocomplete from '@material-ui/lab/Autocomplete';
 import { EntityDisplayName } from '@backstage/plugin-catalog-react';
 import { NotFoundError } from '@backstage/errors';
 import useAsync from 'react-use/esm/useAsync';
-import { Entity, stringifyEntityRef } from '@backstage/catalog-model';
+import {
+  Entity,
+  parseEntityRef,
+  stringifyEntityRef,
+} from '@backstage/catalog-model';
 import { VirtualizedListbox } from '../VirtualizedListbox';
 import { useTranslationRef } from '@backstage/core-plugin-api/alpha';
 import { scaffolderTranslationRef } from '../../../translation';
@@ -92,9 +96,19 @@ export const MyGroupsPicker = (props: MyGroupsPickerProps) => {
         : undefined,
     [userEntityRef],
   );
+  const selectedEntityRef = useMemo(() => {
+    if (!formData) {
+      return undefined;
+    }
+    try {
+      return stringifyEntityRef(parseEntityRef(formData));
+    } catch {
+      return undefined;
+    }
+  }, [formData]);
   const selectedEntityRefs = useMemo(
-    () => (formData ? [formData] : []),
-    [formData],
+    () => (selectedEntityRef ? [selectedEntityRef] : []),
+    [selectedEntityRef],
   );
   const {
     entities,
@@ -118,8 +132,8 @@ export const MyGroupsPicker = (props: MyGroupsPickerProps) => {
   };
 
   const selectedEntity =
-    entities.find(e => stringifyEntityRef(e) === formData) ??
-    selectedEntities.find(e => stringifyEntityRef(e) === formData) ??
+    entities.find(e => stringifyEntityRef(e) === selectedEntityRef) ??
+    selectedEntities.find(e => stringifyEntityRef(e) === selectedEntityRef) ??
     null;
   const muiOptions = useMemo(
     () =>
@@ -130,24 +144,35 @@ export const MyGroupsPicker = (props: MyGroupsPickerProps) => {
   );
 
   // BUI: options
-  const buiOptions = useMemo(
-    () =>
-      muiOptions.map(entity => {
-        const entityRef = stringifyEntityRef(entity);
-        const presentation = entityRefToPresentation.get(entityRef);
-        return {
-          value: entityRef,
-          label: presentation?.primaryTitle || entityRef,
-        };
-      }),
-    [muiOptions, entityRefToPresentation],
-  );
+  const buiOptions = useMemo(() => {
+    const options = muiOptions.map(entity => {
+      const entityRef = stringifyEntityRef(entity);
+      const presentation = entityRefToPresentation.get(entityRef);
+      return {
+        value: entityRef,
+        label: presentation?.primaryTitle || entityRef,
+      };
+    });
+    if (
+      selectedEntityRef &&
+      !options.some(option => option.value === selectedEntityRef)
+    ) {
+      options.unshift({
+        value: selectedEntityRef,
+        label:
+          entityRefToPresentation.get(selectedEntityRef)?.primaryTitle ||
+          formData ||
+          selectedEntityRef,
+      });
+    }
+    return options;
+  }, [entityRefToPresentation, formData, muiOptions, selectedEntityRef]);
 
   const [inputValue, setInputValue] = useState('');
   const inputIsDirtyRef = useRef(false);
   const previousFormDataRef = useRef(formData);
   const selectedPresentationTitle = formData
-    ? entityRefToPresentation.get(formData)?.primaryTitle
+    ? entityRefToPresentation.get(selectedEntityRef ?? formData)?.primaryTitle
     : undefined;
 
   useEffect(() => {
@@ -161,7 +186,9 @@ export const MyGroupsPicker = (props: MyGroupsPickerProps) => {
   }, [formData, selectedPresentationTitle]);
 
   const selectedKey =
-    formData && buiOptions.some(o => o.value === formData) ? formData : null;
+    selectedEntityRef && buiOptions.some(o => o.value === selectedEntityRef)
+      ? selectedEntityRef
+      : null;
 
   const handleSelectionChange = useCallback(
     (key: Key | null) => {

--- a/plugins/scaffolder/src/components/fields/MyGroupsPicker/MyGroupsPicker.tsx
+++ b/plugins/scaffolder/src/components/fields/MyGroupsPicker/MyGroupsPicker.tsx
@@ -112,13 +112,21 @@ export const MyGroupsPicker = (props: MyGroupsPickerProps) => {
 
   // MUI: update handler
   const updateChange = (_: ChangeEvent<{}>, value: Entity | null) => {
+    setSearchText('');
     onChange(value ? stringifyEntityRef(value) : '');
   };
 
   const selectedEntity =
-    selectedEntities.find(e => stringifyEntityRef(e) === formData) ??
     entities.find(e => stringifyEntityRef(e) === formData) ??
+    selectedEntities.find(e => stringifyEntityRef(e) === formData) ??
     null;
+  const muiOptions = useMemo(
+    () =>
+      selectedEntity && !entities.includes(selectedEntity)
+        ? [selectedEntity, ...entities]
+        : entities,
+    [entities, selectedEntity],
+  );
 
   // BUI: options
   const buiOptions = useMemo(
@@ -135,27 +143,27 @@ export const MyGroupsPicker = (props: MyGroupsPickerProps) => {
   );
 
   const [inputValue, setInputValue] = useState('');
+  const selectedPresentationTitle = formData
+    ? entityRefToPresentation.get(formData)?.primaryTitle
+    : undefined;
 
   useEffect(() => {
     if (formData) {
-      setInputValue(
-        buiOptions.find(o => o.value === formData)?.label ||
-          entityRefToPresentation.get(formData)?.primaryTitle ||
-          formData,
-      );
+      setInputValue(selectedPresentationTitle || formData);
     } else {
       setInputValue('');
     }
-  }, [entityRefToPresentation, formData, buiOptions]);
+  }, [formData, selectedPresentationTitle]);
 
   const selectedKey =
     formData && buiOptions.some(o => o.value === formData) ? formData : null;
 
   const handleSelectionChange = useCallback(
     (key: Key | null) => {
+      setSearchText('');
       onChange(key !== null ? String(key) : '');
     },
-    [onChange],
+    [onChange, setSearchText],
   );
 
   useEffect(() => {
@@ -210,7 +218,7 @@ export const MyGroupsPicker = (props: MyGroupsPickerProps) => {
       <Autocomplete
         disabled={isDisabled || (required && initialResultIsOnlyOption)}
         id="OwnershipEntityRefPicker-dropdown"
-        options={entities}
+        options={muiOptions}
         value={selectedEntity}
         loading={identityLoading || loading}
         onChange={updateChange}
@@ -222,6 +230,10 @@ export const MyGroupsPicker = (props: MyGroupsPickerProps) => {
         getOptionLabel={option =>
           entityRefToPresentation.get(stringifyEntityRef(option))?.primaryTitle!
         }
+        getOptionSelected={(option, value) =>
+          stringifyEntityRef(option) === stringifyEntityRef(value)
+        }
+        filterSelectedOptions
         autoSelect
         renderInput={params => (
           <TextField

--- a/plugins/scaffolder/src/components/fields/MyGroupsPicker/MyGroupsPicker.tsx
+++ b/plugins/scaffolder/src/components/fields/MyGroupsPicker/MyGroupsPicker.tsx
@@ -17,7 +17,6 @@
 import {
   type Key,
   ChangeEvent,
-  type MouseEvent,
   useCallback,
   useEffect,
   useMemo,
@@ -49,6 +48,7 @@ import {
 } from '@backstage/plugin-scaffolder-react/alpha';
 import { Autocomplete as BuiAutocomplete } from '../Autocomplete';
 import { useEntityPickerOptions } from '../useEntityPickerOptions';
+import { useEntityPickerPagination } from '../useEntityPickerPagination';
 
 export { MyGroupsPickerSchema };
 
@@ -205,6 +205,13 @@ export const MyGroupsPicker = (props: MyGroupsPickerProps) => {
     }
   }, [entities, initialResultIsOnlyOption, onChange, selectedEntity, required]);
 
+  const pagination = useEntityPickerPagination({
+    entities,
+    selectedEntityRefs,
+    loading,
+    loadMore,
+  });
+
   if (theme === 'bui') {
     const isAutoSelected = required && initialResultIsOnlyOption;
 
@@ -254,9 +261,14 @@ export const MyGroupsPicker = (props: MyGroupsPickerProps) => {
         id="OwnershipEntityRefPicker-dropdown"
         options={muiOptions}
         value={selectedEntity}
+        inputValue={inputValue}
         loading={identityLoading || loading}
         onChange={updateChange}
-        onInputChange={(_event, value, reason) => {
+        onInputChange={(event, value, reason) => {
+          // A new object for the same selection must not replace typed search.
+          if (reason === 'reset' && !event && inputIsDirtyRef.current) return;
+          inputIsDirtyRef.current = reason === 'input';
+          setInputValue(value);
           if (reason === 'input' || reason === 'clear') {
             setSearchText(value);
           }
@@ -283,18 +295,7 @@ export const MyGroupsPicker = (props: MyGroupsPickerProps) => {
         renderOption={option => <EntityDisplayName entityRef={option} />}
         filterOptions={options => options}
         ListboxComponent={VirtualizedListbox}
-        ListboxProps={{
-          onScroll: (event: MouseEvent) => {
-            const element = event.currentTarget;
-            if (
-              Math.abs(
-                element.scrollHeight - element.clientHeight - element.scrollTop,
-              ) < 1
-            ) {
-              loadMore();
-            }
-          },
-        }}
+        {...pagination}
       />
     </ScaffolderField>
   );

--- a/plugins/scaffolder/src/components/fields/OwnerPicker/OwnerPicker.test.tsx
+++ b/plugins/scaffolder/src/components/fields/OwnerPicker/OwnerPicker.test.tsx
@@ -27,6 +27,7 @@ import { PropsWithChildren, ComponentType, ReactNode } from 'react';
 import { OwnerPicker } from './OwnerPicker';
 import { DefaultEntityPresentationApi } from '@backstage/plugin-catalog';
 import { fireEvent, screen } from '@testing-library/react';
+import { ENTITY_PICKER_FIELDS } from '../useEntityPickerOptions';
 
 const makeEntity = (kind: string, namespace: string, name: string): Entity => ({
   apiVersion: 'backstage.io/v1beta1',
@@ -56,14 +57,16 @@ describe('<OwnerPicker />', () => {
 
   let props: FieldProps<string>;
 
-  const catalogApi = catalogApiMock.mock({
-    streamEntities: jest.fn(async function* () {
-      yield entities;
-    }),
-  });
+  const catalogApi = catalogApiMock.mock();
   let Wrapper: ComponentType<PropsWithChildren<{}>>;
 
   beforeEach(() => {
+    catalogApi.queryEntities.mockResolvedValue({
+      items: entities,
+      totalItems: 0,
+      pageInfo: {},
+    });
+    catalogApi.getEntitiesByRefs.mockResolvedValue({ items: [] });
     Wrapper = ({ children }: { children?: ReactNode }) => (
       <TestApiProvider
         apis={[
@@ -101,18 +104,12 @@ describe('<OwnerPicker />', () => {
         </Wrapper>,
       );
 
-      expect(catalogApi.streamEntities).toHaveBeenCalledWith({
-        query: {},
+      expect(catalogApi.queryEntities).toHaveBeenCalledWith({
         filter: { kind: ['Group', 'User'] },
-        fields: [
-          'kind',
-          'metadata.name',
-          'metadata.namespace',
-          'metadata.title',
-          'metadata.description',
-          'spec.profile.displayName',
-          'spec.type',
-        ],
+        fields: ENTITY_PICKER_FIELDS,
+        limit: 20,
+        orderFields: [{ field: 'metadata.name', order: 'asc' }],
+        totalItems: 'exclude',
       });
     });
   });
@@ -141,10 +138,6 @@ describe('<OwnerPicker />', () => {
         rawErrors,
         formData,
       } as unknown as FieldProps<any>;
-
-      catalogApi.streamEntities.mockImplementation(async function* () {
-        yield entities;
-      });
     });
     it('Prevents user from modifying input when ui:disabled is true', async () => {
       props.uiSchema = { 'ui:disabled': true };
@@ -206,18 +199,12 @@ describe('<OwnerPicker />', () => {
         </Wrapper>,
       );
 
-      expect(catalogApi.streamEntities).toHaveBeenCalledWith({
-        query: {},
+      expect(catalogApi.queryEntities).toHaveBeenCalledWith({
         filter: { kind: ['User'] },
-        fields: [
-          'kind',
-          'metadata.name',
-          'metadata.namespace',
-          'metadata.title',
-          'metadata.description',
-          'spec.profile.displayName',
-          'spec.type',
-        ],
+        fields: ENTITY_PICKER_FIELDS,
+        limit: 20,
+        orderFields: [{ field: 'metadata.name', order: 'asc' }],
+        totalItems: 'exclude',
       });
     });
   });
@@ -242,10 +229,6 @@ describe('<OwnerPicker />', () => {
         rawErrors,
         formData,
       } as unknown as FieldProps<any>;
-
-      catalogApi.streamEntities.mockImplementation(async function* () {
-        yield entities;
-      });
     });
 
     it('searches for group entities of type team', async () => {
@@ -255,9 +238,8 @@ describe('<OwnerPicker />', () => {
         </Wrapper>,
       );
 
-      expect(catalogApi.streamEntities).toHaveBeenCalledWith(
+      expect(catalogApi.queryEntities).toHaveBeenCalledWith(
         expect.objectContaining({
-          query: {},
           filter: [
             {
               kind: ['Group'],
@@ -301,9 +283,8 @@ describe('<OwnerPicker />', () => {
         </Wrapper>,
       );
 
-      expect(catalogApi.streamEntities).toHaveBeenCalledWith(
+      expect(catalogApi.queryEntities).toHaveBeenCalledWith(
         expect.objectContaining({
-          query: {},
           filter: [
             {
               kind: ['Group', 'User'],

--- a/plugins/scaffolder/src/components/fields/OwnerPicker/OwnerPicker.test.tsx
+++ b/plugins/scaffolder/src/components/fields/OwnerPicker/OwnerPicker.test.tsx
@@ -27,7 +27,6 @@ import { PropsWithChildren, ComponentType, ReactNode } from 'react';
 import { OwnerPicker } from './OwnerPicker';
 import { DefaultEntityPresentationApi } from '@backstage/plugin-catalog';
 import { fireEvent, screen } from '@testing-library/react';
-import { ENTITY_PICKER_FIELDS } from '../useEntityPickerOptions';
 
 const makeEntity = (kind: string, namespace: string, name: string): Entity => ({
   apiVersion: 'backstage.io/v1beta1',
@@ -106,7 +105,6 @@ describe('<OwnerPicker />', () => {
 
       expect(catalogApi.queryEntities).toHaveBeenCalledWith({
         filter: { kind: ['Group', 'User'] },
-        fields: ENTITY_PICKER_FIELDS,
         limit: 20,
         orderFields: [{ field: 'metadata.name', order: 'asc' }],
         totalItems: 'exclude',
@@ -201,7 +199,6 @@ describe('<OwnerPicker />', () => {
 
       expect(catalogApi.queryEntities).toHaveBeenCalledWith({
         filter: { kind: ['User'] },
-        fields: ENTITY_PICKER_FIELDS,
         limit: 20,
         orderFields: [{ field: 'metadata.name', order: 'asc' }],
         totalItems: 'exclude',

--- a/plugins/scaffolder/src/components/fields/VirtualizedListbox.test.tsx
+++ b/plugins/scaffolder/src/components/fields/VirtualizedListbox.test.tsx
@@ -15,6 +15,7 @@
  */
 import { VirtualizedListbox } from './VirtualizedListbox';
 import { renderInTestApp } from '@backstage/test-utils';
+import { fireEvent, screen } from '@testing-library/react';
 
 describe('<VirtualizedListbox />', () => {
   it('Should forward additional props to the outer div', async () => {
@@ -272,5 +273,28 @@ describe('<VirtualizedListbox />', () => {
         </div>
       </div>
     `);
+  });
+
+  it('keeps virtualizing while forwarding scroll events', async () => {
+    const onScroll = jest.fn();
+    const { baseElement } = await renderInTestApp(
+      <VirtualizedListbox onScroll={onScroll}>
+        {[...new Array(100)].map((_, i) => (
+          <span key={i}>Item {i}</span>
+        ))}
+      </VirtualizedListbox>,
+    );
+    const scrollContainer = baseElement.querySelector(
+      '[style*="overflow: auto"]',
+    )!;
+    Object.defineProperties(scrollContainer, {
+      clientHeight: { configurable: true, value: 378 },
+      scrollHeight: { configurable: true, value: 3600 },
+    });
+
+    fireEvent.scroll(scrollContainer, { target: { scrollTop: 3200 } });
+
+    expect(onScroll).toHaveBeenCalledTimes(1);
+    expect(await screen.findByText('Item 99')).toBeInTheDocument();
   });
 });

--- a/plugins/scaffolder/src/components/fields/VirtualizedListbox.tsx
+++ b/plugins/scaffolder/src/components/fields/VirtualizedListbox.tsx
@@ -16,6 +16,7 @@
 
 import {
   HTMLAttributes,
+  UIEvent,
   cloneElement,
   createContext,
   forwardRef,
@@ -35,9 +36,13 @@ const renderRow = (props: ListChildComponentProps) => {
 const OuterElementContext = createContext<HTMLDivProps>({});
 
 const OuterElementType = forwardRef<HTMLDivElement, HTMLDivProps>(
-  (props, ref) => {
-    const outerProps = useContext(OuterElementContext);
-    return <div ref={ref} {...props} {...outerProps} />;
+  ({ onScroll: reactWindowOnScroll, ...props }, ref) => {
+    const { onScroll, ...outerProps } = useContext(OuterElementContext);
+    const handleScroll = (event: UIEvent<HTMLDivElement>) => {
+      reactWindowOnScroll?.(event);
+      onScroll?.(event);
+    };
+    return <div ref={ref} onScroll={handleScroll} {...props} {...outerProps} />;
   },
 );
 

--- a/plugins/scaffolder/src/components/fields/useEntityPickerOptions.test.tsx
+++ b/plugins/scaffolder/src/components/fields/useEntityPickerOptions.test.tsx
@@ -1,0 +1,250 @@
+/*
+ * Copyright 2026 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Entity } from '@backstage/catalog-model';
+import {
+  catalogApiRef,
+  entityPresentationApiRef,
+} from '@backstage/plugin-catalog-react';
+import { catalogApiMock } from '@backstage/plugin-catalog-react/testUtils';
+import { TestApiProvider } from '@backstage/test-utils';
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { PropsWithChildren } from 'react';
+import {
+  ENTITY_PICKER_FIELDS,
+  useEntityPickerOptions,
+} from './useEntityPickerOptions';
+
+const entity: Entity = {
+  apiVersion: 'backstage.io/v1alpha1',
+  kind: 'Group',
+  metadata: { name: 'team-a', namespace: 'default' },
+};
+
+const otherEntity: Entity = {
+  apiVersion: 'backstage.io/v1alpha1',
+  kind: 'Group',
+  metadata: { name: 'team-b', namespace: 'default' },
+};
+
+function deferred<T>() {
+  let resolve: (value: T) => void = () => {};
+  const promise = new Promise<T>(innerResolve => {
+    resolve = innerResolve;
+  });
+  return { promise, resolve };
+}
+
+describe('useEntityPickerOptions', () => {
+  const catalogApi = catalogApiMock.mock();
+  const forEntity = jest.fn((item: Entity) => ({
+    snapshot: {
+      entityRef: `group:default/${item.metadata.name}`,
+      primaryTitle: item.metadata.name,
+    },
+    promise: Promise.resolve({
+      entityRef: `group:default/${item.metadata.name}`,
+      primaryTitle: item.metadata.name,
+    }),
+  }));
+
+  const wrapper = ({ children }: PropsWithChildren<{}>) => (
+    <TestApiProvider
+      apis={[
+        [catalogApiRef, catalogApi],
+        [entityPresentationApiRef, { forEntity }],
+      ]}
+    >
+      {children}
+    </TestApiProvider>
+  );
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    catalogApi.queryEntities.mockReset();
+    catalogApi.getEntitiesByRefs.mockReset();
+    catalogApi.queryEntities.mockResolvedValue({
+      items: [entity],
+      totalItems: 0,
+      pageInfo: {},
+    });
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('does not query until it is enabled', async () => {
+    const { result, rerender } = renderHook(
+      ({ enabled }) =>
+        useEntityPickerOptions({ enabled, selectedEntityRefs: [] }),
+      { wrapper, initialProps: { enabled: false } },
+    );
+    await act(async () => {});
+
+    expect(catalogApi.queryEntities).not.toHaveBeenCalled();
+    expect(result.current.loading).toBe(false);
+
+    rerender({ enabled: true });
+    await waitFor(() => expect(result.current.entities).toEqual([entity]));
+  });
+
+  it('loads and presents only the first page of matching entities', async () => {
+    const catalogFilter = { kind: ['Group'] };
+    const { result } = renderHook(
+      () => useEntityPickerOptions({ catalogFilter, selectedEntityRefs: [] }),
+      { wrapper },
+    );
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    expect(catalogApi.queryEntities).toHaveBeenCalledWith({
+      filter: catalogFilter,
+      fields: ENTITY_PICKER_FIELDS,
+      limit: 20,
+      orderFields: [{ field: 'metadata.name', order: 'asc' }],
+      totalItems: 'exclude',
+    });
+    expect(result.current.entities).toEqual([entity]);
+    expect(
+      result.current.entityRefToPresentation.get('group:default/team-a'),
+    ).toMatchObject({ primaryTitle: 'team-a' });
+  });
+
+  it('debounces server-side filtering', async () => {
+    jest.useFakeTimers();
+    const { result } = renderHook(
+      () => useEntityPickerOptions({ selectedEntityRefs: [] }),
+      { wrapper },
+    );
+    await act(async () => {});
+
+    act(() => result.current.setSearchText('team'));
+    act(() => jest.advanceTimersByTime(249));
+    expect(catalogApi.queryEntities).toHaveBeenCalledTimes(1);
+
+    await act(async () => jest.advanceTimersByTime(1));
+    expect(catalogApi.queryEntities).toHaveBeenLastCalledWith({
+      fields: ENTITY_PICKER_FIELDS,
+      fullTextFilter: {
+        term: 'team',
+        fields: [
+          'metadata.name',
+          'kind',
+          'spec.profile.displayName',
+          'metadata.title',
+        ],
+      },
+      limit: 20,
+      orderFields: [{ field: 'metadata.name', order: 'asc' }],
+      totalItems: 'exclude',
+    });
+  });
+
+  it('loads and appends the next page on demand', async () => {
+    catalogApi.queryEntities
+      .mockResolvedValueOnce({
+        items: [entity],
+        totalItems: 0,
+        pageInfo: { nextCursor: 'next-page' },
+      })
+      .mockResolvedValueOnce({
+        items: [otherEntity],
+        totalItems: 0,
+        pageInfo: {},
+      });
+    const { result } = renderHook(
+      () => useEntityPickerOptions({ selectedEntityRefs: [] }),
+      { wrapper },
+    );
+    await waitFor(() => expect(result.current.entities).toEqual([entity]));
+
+    act(() => result.current.loadMore());
+    await waitFor(() =>
+      expect(result.current.entities).toEqual([entity, otherEntity]),
+    );
+
+    expect(catalogApi.queryEntities).toHaveBeenLastCalledWith({
+      cursor: 'next-page',
+      fields: ENTITY_PICKER_FIELDS,
+      limit: 20,
+    });
+  });
+
+  it('does not let an obsolete search replace newer results', async () => {
+    jest.useFakeTimers();
+    const firstSearch = deferred<{
+      items: Entity[];
+      totalItems: number;
+      pageInfo: {};
+    }>();
+    const secondSearch = deferred<{
+      items: Entity[];
+      totalItems: number;
+      pageInfo: {};
+    }>();
+    catalogApi.queryEntities
+      .mockResolvedValueOnce({ items: [], totalItems: 0, pageInfo: {} })
+      .mockReturnValueOnce(firstSearch.promise)
+      .mockReturnValueOnce(secondSearch.promise);
+    const { result } = renderHook(
+      () => useEntityPickerOptions({ selectedEntityRefs: [] }),
+      { wrapper },
+    );
+    await act(async () => {});
+
+    act(() => result.current.setSearchText('team-a'));
+    await act(async () => jest.advanceTimersByTime(250));
+    act(() => result.current.setSearchText('team-b'));
+    await act(async () => jest.advanceTimersByTime(250));
+
+    await act(async () => {
+      secondSearch.resolve({
+        items: [otherEntity],
+        totalItems: 0,
+        pageInfo: {},
+      });
+    });
+    await act(async () => {
+      firstSearch.resolve({ items: [entity], totalItems: 0, pageInfo: {} });
+    });
+
+    expect(result.current.entities).toEqual([otherEntity]);
+  });
+
+  it('loads selected entities without adding them to the search results', async () => {
+    catalogApi.getEntitiesByRefs.mockResolvedValue({ items: [otherEntity] });
+    const { result } = renderHook(
+      () =>
+        useEntityPickerOptions({
+          selectedEntityRefs: ['group:default/team-b'],
+        }),
+      { wrapper },
+    );
+
+    await waitFor(() =>
+      expect(result.current.selectedEntities).toEqual([otherEntity]),
+    );
+    expect(catalogApi.getEntitiesByRefs).toHaveBeenCalledWith({
+      entityRefs: ['group:default/team-b'],
+      fields: ENTITY_PICKER_FIELDS,
+    });
+    expect(result.current.entities).toEqual([entity]);
+    expect(
+      result.current.entityRefToPresentation.get('group:default/team-b'),
+    ).toMatchObject({ primaryTitle: 'team-b' });
+  });
+});

--- a/plugins/scaffolder/src/components/fields/useEntityPickerOptions.test.tsx
+++ b/plugins/scaffolder/src/components/fields/useEntityPickerOptions.test.tsx
@@ -22,7 +22,7 @@ import {
 import { catalogApiMock } from '@backstage/plugin-catalog-react/testUtils';
 import { TestApiProvider } from '@backstage/test-utils';
 import { act, renderHook, waitFor } from '@testing-library/react';
-import { PropsWithChildren } from 'react';
+import { PropsWithChildren, useEffect } from 'react';
 import { useEntityPickerOptions } from './useEntityPickerOptions';
 
 const entity: Entity = {
@@ -254,6 +254,37 @@ describe('useEntityPickerOptions', () => {
     });
   });
 
+  it.each(['success', 'error'])(
+    'retains an initial %s received while the input is temporarily different',
+    async outcome => {
+      jest.useFakeTimers();
+      const response = deferred<void>();
+      catalogApi.queryEntities.mockImplementationOnce(async () => {
+        await response.promise;
+        if (outcome === 'error') throw new Error('Search failed');
+        return { items: [entity], totalItems: 0, pageInfo: {} };
+      });
+      const { result } = renderHook(
+        () => useEntityPickerOptions({ selectedEntityRefs: [] }),
+        { wrapper },
+      );
+
+      act(() => result.current.setSearchText('team'));
+      await act(async () => response.resolve());
+      expect(result.current.loadingState).toBe('filtering');
+
+      act(() => result.current.setSearchText(''));
+      await act(async () => jest.advanceTimersByTime(250));
+      expect(result.current.loadingState).toBe(
+        outcome === 'success' ? 'idle' : 'error',
+      );
+      expect(result.current.entities).toEqual(
+        outcome === 'success' ? [entity] : [],
+      );
+      expect(catalogApi.queryEntities).toHaveBeenCalledTimes(1);
+    },
+  );
+
   it('allows retrying a page after it fails to load', async () => {
     catalogApi.queryEntities
       .mockResolvedValueOnce({
@@ -286,7 +317,7 @@ describe('useEntityPickerOptions', () => {
     expect(catalogApi.queryEntities).toHaveBeenCalledTimes(3);
   });
 
-  it('ignores a page that resolves after the search input changes', async () => {
+  it('retains an active page while the input is temporarily different', async () => {
     jest.useFakeTimers();
     const nextPage = deferred<{
       items: Entity[];
@@ -316,8 +347,10 @@ describe('useEntityPickerOptions', () => {
       });
     });
 
-    expect(result.current.entities).toEqual([entity]);
+    expect(result.current.entities).toEqual([entity, otherEntity]);
     expect(result.current.loadingState).toBe('filtering');
+    act(() => result.current.setSearchText(''));
+    expect(result.current.loadingState).toBe('idle');
   });
 
   it('does not let an obsolete search replace newer results', async () => {
@@ -359,6 +392,38 @@ describe('useEntityPickerOptions', () => {
     });
 
     expect(result.current.entities).toEqual([otherEntity]);
+  });
+
+  it('does not reuse the previous cursor while a new catalog filter is starting', async () => {
+    catalogApi.queryEntities
+      .mockResolvedValueOnce({
+        items: [entity],
+        totalItems: 0,
+        pageInfo: { nextCursor: 'group-page' },
+      })
+      .mockReturnValueOnce(new Promise(() => {}));
+    const { result, rerender } = renderHook(
+      ({ catalogFilter }) => {
+        const options = useEntityPickerOptions({
+          catalogFilter,
+          selectedEntityRefs: [],
+        });
+        const { loadMore } = options;
+        // An open menu may try to refill in the same render as a filter change.
+        useEffect(() => {
+          if (catalogFilter.kind === 'User') loadMore();
+        }, [catalogFilter, loadMore]);
+        return options;
+      },
+      { wrapper, initialProps: { catalogFilter: { kind: 'Group' } } },
+    );
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    rerender({ catalogFilter: { kind: 'User' } });
+    expect(catalogApi.queryEntities).toHaveBeenCalledTimes(2);
+    expect(catalogApi.queryEntities).toHaveBeenLastCalledWith(
+      expect.objectContaining({ filter: { kind: 'User' } }),
+    );
   });
 
   it('loads selected entities without adding them to the search results', async () => {

--- a/plugins/scaffolder/src/components/fields/useEntityPickerOptions.test.tsx
+++ b/plugins/scaffolder/src/components/fields/useEntityPickerOptions.test.tsx
@@ -198,8 +198,10 @@ describe('useEntityPickerOptions', () => {
     );
     await act(async () => {});
 
-    act(() => result.current.setSearchText('team'));
-    act(() => result.current.setSearchText(''));
+    act(() => {
+      result.current.setSearchText('team');
+      result.current.setSearchText('');
+    });
     await act(async () => {
       initialSearch.resolve({
         items: [entity],
@@ -237,7 +239,11 @@ describe('useEntityPickerOptions', () => {
     );
     await waitFor(() => expect(result.current.entities).toEqual([entity]));
 
-    act(() => result.current.loadMore());
+    act(() => {
+      result.current.loadMore();
+      result.current.loadMore();
+    });
+    expect(catalogApi.queryEntities).toHaveBeenCalledTimes(2);
     await waitFor(() =>
       expect(result.current.entities).toEqual([entity, otherEntity]),
     );
@@ -278,6 +284,40 @@ describe('useEntityPickerOptions', () => {
       expect(result.current.entities).toEqual([entity, otherEntity]),
     );
     expect(catalogApi.queryEntities).toHaveBeenCalledTimes(3);
+  });
+
+  it('ignores a page that resolves after the search input changes', async () => {
+    jest.useFakeTimers();
+    const nextPage = deferred<{
+      items: Entity[];
+      totalItems: number;
+      pageInfo: {};
+    }>();
+    catalogApi.queryEntities
+      .mockResolvedValueOnce({
+        items: [entity],
+        totalItems: 0,
+        pageInfo: { nextCursor: 'next-page' },
+      })
+      .mockReturnValueOnce(nextPage.promise);
+    const { result } = renderHook(
+      () => useEntityPickerOptions({ selectedEntityRefs: [] }),
+      { wrapper },
+    );
+    await waitFor(() => expect(result.current.entities).toEqual([entity]));
+
+    act(() => result.current.loadMore());
+    act(() => result.current.setSearchText('team'));
+    await act(async () => {
+      nextPage.resolve({
+        items: [otherEntity],
+        totalItems: 0,
+        pageInfo: {},
+      });
+    });
+
+    expect(result.current.entities).toEqual([entity]);
+    expect(result.current.loadingState).toBe('filtering');
   });
 
   it('does not let an obsolete search replace newer results', async () => {

--- a/plugins/scaffolder/src/components/fields/useEntityPickerOptions.test.tsx
+++ b/plugins/scaffolder/src/components/fields/useEntityPickerOptions.test.tsx
@@ -23,10 +23,7 @@ import { catalogApiMock } from '@backstage/plugin-catalog-react/testUtils';
 import { TestApiProvider } from '@backstage/test-utils';
 import { act, renderHook, waitFor } from '@testing-library/react';
 import { PropsWithChildren } from 'react';
-import {
-  ENTITY_PICKER_FIELDS,
-  useEntityPickerOptions,
-} from './useEntityPickerOptions';
+import { useEntityPickerOptions } from './useEntityPickerOptions';
 
 const entity: Entity = {
   apiVersion: 'backstage.io/v1alpha1',
@@ -113,7 +110,6 @@ describe('useEntityPickerOptions', () => {
 
     expect(catalogApi.queryEntities).toHaveBeenCalledWith({
       filter: catalogFilter,
-      fields: ENTITY_PICKER_FIELDS,
       limit: 20,
       orderFields: [{ field: 'metadata.name', order: 'asc' }],
       totalItems: 'exclude',
@@ -122,6 +118,41 @@ describe('useEntityPickerOptions', () => {
     expect(
       result.current.entityRefToPresentation.get('group:default/team-a'),
     ).toMatchObject({ primaryTitle: 'team-a' });
+  });
+
+  it('provides complete entities to custom presentation APIs', async () => {
+    const completeEntity: Entity = {
+      ...entity,
+      spec: { customPresentation: 'Friendly Team A' },
+    };
+    catalogApi.queryEntities.mockImplementationOnce(async request => ({
+      items: request?.fields ? [entity] : [completeEntity],
+      totalItems: 0,
+      pageInfo: {},
+    }));
+    forEntity.mockImplementationOnce(item => {
+      const primaryTitle = String(item.spec?.customPresentation);
+      return {
+        snapshot: {
+          entityRef: 'group:default/team-a',
+          primaryTitle,
+        },
+        promise: Promise.resolve({
+          entityRef: 'group:default/team-a',
+          primaryTitle,
+        }),
+      };
+    });
+    const { result } = renderHook(
+      () => useEntityPickerOptions({ selectedEntityRefs: [] }),
+      { wrapper },
+    );
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    expect(
+      result.current.entityRefToPresentation.get('group:default/team-a'),
+    ).toMatchObject({ primaryTitle: 'Friendly Team A' });
   });
 
   it('debounces server-side filtering', async () => {
@@ -138,7 +169,6 @@ describe('useEntityPickerOptions', () => {
 
     await act(async () => jest.advanceTimersByTime(1));
     expect(catalogApi.queryEntities).toHaveBeenLastCalledWith({
-      fields: ENTITY_PICKER_FIELDS,
       fullTextFilter: {
         term: 'team',
         fields: [
@@ -152,6 +182,41 @@ describe('useEntityPickerOptions', () => {
       orderFields: [{ field: 'metadata.name', order: 'asc' }],
       totalItems: 'exclude',
     });
+  });
+
+  it('recovers when input returns to the active query before the debounce', async () => {
+    jest.useFakeTimers();
+    const initialSearch = deferred<{
+      items: Entity[];
+      totalItems: number;
+      pageInfo: {};
+    }>();
+    catalogApi.queryEntities.mockReturnValueOnce(initialSearch.promise);
+    const { result } = renderHook(
+      () => useEntityPickerOptions({ selectedEntityRefs: [] }),
+      { wrapper },
+    );
+    await act(async () => {});
+
+    act(() => result.current.setSearchText('team'));
+    act(() => result.current.setSearchText(''));
+    await act(async () => {
+      initialSearch.resolve({
+        items: [entity],
+        totalItems: 0,
+        pageInfo: {},
+      });
+    });
+
+    expect(result.current.entities).toEqual([entity]);
+    expect(result.current.loadingState).toBe('idle');
+
+    act(() => result.current.setSearchText('team'));
+    act(() => result.current.setSearchText(''));
+    await act(async () => jest.advanceTimersByTime(250));
+
+    expect(result.current.entities).toEqual([entity]);
+    expect(result.current.loadingState).toBe('idle');
   });
 
   it('loads and appends the next page on demand', async () => {
@@ -179,9 +244,40 @@ describe('useEntityPickerOptions', () => {
 
     expect(catalogApi.queryEntities).toHaveBeenLastCalledWith({
       cursor: 'next-page',
-      fields: ENTITY_PICKER_FIELDS,
       limit: 20,
     });
+  });
+
+  it('allows retrying a page after it fails to load', async () => {
+    catalogApi.queryEntities
+      .mockResolvedValueOnce({
+        items: [entity],
+        totalItems: 0,
+        pageInfo: { nextCursor: 'next-page' },
+      })
+      .mockRejectedValueOnce(new Error('temporary failure'))
+      .mockResolvedValueOnce({
+        items: [otherEntity],
+        totalItems: 0,
+        pageInfo: {},
+      });
+    const { result } = renderHook(
+      () => useEntityPickerOptions({ selectedEntityRefs: [] }),
+      { wrapper },
+    );
+    await waitFor(() => expect(result.current.entities).toEqual([entity]));
+
+    act(() => result.current.loadMore());
+    await waitFor(() =>
+      expect(catalogApi.queryEntities).toHaveBeenCalledTimes(2),
+    );
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    act(() => result.current.loadMore());
+
+    await waitFor(() =>
+      expect(result.current.entities).toEqual([entity, otherEntity]),
+    );
+    expect(catalogApi.queryEntities).toHaveBeenCalledTimes(3);
   });
 
   it('does not let an obsolete search replace newer results', async () => {
@@ -240,7 +336,6 @@ describe('useEntityPickerOptions', () => {
     );
     expect(catalogApi.getEntitiesByRefs).toHaveBeenCalledWith({
       entityRefs: ['group:default/team-b'],
-      fields: ENTITY_PICKER_FIELDS,
     });
     expect(result.current.entities).toEqual([entity]);
     expect(

--- a/plugins/scaffolder/src/components/fields/useEntityPickerOptions.ts
+++ b/plugins/scaffolder/src/components/fields/useEntityPickerOptions.ts
@@ -75,6 +75,8 @@ export function useEntityPickerOptions(options: {
   const selectedRequestGeneration = useRef(0);
   const searchTextRef = useRef('');
   const settledSearchTextRef = useRef<string>();
+  const nextLoadMoreRequest = useRef(0);
+  const activeLoadMoreRequest = useRef<number>();
 
   const presentEntities = useCallback(
     async (entities: Entity[]) =>
@@ -94,7 +96,7 @@ export function useEntityPickerOptions(options: {
 
   const setSearchText = useCallback(
     (value: string) => {
-      if (value === searchText) {
+      if (value === searchTextRef.current) {
         return;
       }
       searchTextRef.current = value;
@@ -107,13 +109,14 @@ export function useEntityPickerOptions(options: {
             : 'idle',
       }));
     },
-    [enabled, searchText],
+    [enabled],
   );
 
   useDebounce(() => setDebouncedSearchText(searchText), 250, [searchText]);
 
   useEffect(() => {
     const generation = ++requestGeneration.current;
+    activeLoadMoreRequest.current = undefined;
     if (!enabled) {
       setState({
         entities: [],
@@ -181,12 +184,19 @@ export function useEntityPickerOptions(options: {
   ]);
 
   const loadMore = useCallback(() => {
-    if (!enabled || !state.nextCursor || state.loadingState !== 'idle') {
+    if (
+      !enabled ||
+      !state.nextCursor ||
+      state.loadingState !== 'idle' ||
+      activeLoadMoreRequest.current !== undefined
+    ) {
       return;
     }
 
     const generation = requestGeneration.current;
     const cursor = state.nextCursor;
+    const loadMoreRequest = ++nextLoadMoreRequest.current;
+    activeLoadMoreRequest.current = loadMoreRequest;
     setState(previous => ({ ...previous, loadingState: 'loadingMore' }));
     catalogApi
       .queryEntities({
@@ -195,7 +205,14 @@ export function useEntityPickerOptions(options: {
       })
       .then(async response => {
         const presentations = await presentEntities(response.items);
-        if (generation === requestGeneration.current) {
+        if (activeLoadMoreRequest.current !== loadMoreRequest) {
+          return;
+        }
+        activeLoadMoreRequest.current = undefined;
+        if (
+          generation === requestGeneration.current &&
+          debouncedSearchText === searchTextRef.current
+        ) {
           setState(previous => ({
             ...previous,
             entities: [...previous.entities, ...response.items],
@@ -209,12 +226,20 @@ export function useEntityPickerOptions(options: {
         }
       })
       .catch(() => {
-        if (generation === requestGeneration.current) {
+        if (activeLoadMoreRequest.current !== loadMoreRequest) {
+          return;
+        }
+        activeLoadMoreRequest.current = undefined;
+        if (
+          generation === requestGeneration.current &&
+          debouncedSearchText === searchTextRef.current
+        ) {
           setState(previous => ({ ...previous, loadingState: 'idle' }));
         }
       });
   }, [
     catalogApi,
+    debouncedSearchText,
     enabled,
     presentEntities,
     state.loadingState,

--- a/plugins/scaffolder/src/components/fields/useEntityPickerOptions.ts
+++ b/plugins/scaffolder/src/components/fields/useEntityPickerOptions.ts
@@ -1,0 +1,277 @@
+/*
+ * Copyright 2026 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { EntityFilterQuery } from '@backstage/catalog-client';
+import { Entity, stringifyEntityRef } from '@backstage/catalog-model';
+import { useApi } from '@backstage/core-plugin-api';
+import {
+  catalogApiRef,
+  entityPresentationApiRef,
+  EntityRefPresentationSnapshot,
+} from '@backstage/plugin-catalog-react';
+import { LoadingState } from '@backstage/ui';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import useDebounce from 'react-use/esm/useDebounce';
+
+export const ENTITY_PICKER_FIELDS = [
+  'kind',
+  'metadata.name',
+  'metadata.namespace',
+  'metadata.title',
+  'metadata.description',
+  'spec.profile.displayName',
+  'spec.type',
+];
+
+const ENTITY_PICKER_SEARCH_FIELDS = [
+  'metadata.name',
+  'kind',
+  'spec.profile.displayName',
+  'metadata.title',
+];
+
+type EntityPickerOptionsState = {
+  entities: Entity[];
+  selectedEntities: Entity[];
+  entityRefToPresentation: Map<string, EntityRefPresentationSnapshot>;
+  loading: boolean;
+  loadingState: LoadingState;
+  searchText: string;
+  setSearchText: (value: string) => void;
+  loadMore: () => void;
+  initialResultIsOnlyOption: boolean;
+};
+
+export function useEntityPickerOptions(options: {
+  catalogFilter?: EntityFilterQuery;
+  enabled?: boolean;
+  selectedEntityRefs: string[];
+}): EntityPickerOptionsState {
+  const { catalogFilter, enabled = true } = options;
+  const catalogApi = useApi(catalogApiRef);
+  const entityPresentationApi = useApi(entityPresentationApiRef);
+  const [searchText, setSearchTextState] = useState('');
+  const [debouncedSearchText, setDebouncedSearchText] = useState('');
+  const [state, setState] = useState<{
+    entities: Entity[];
+    entityRefToPresentation: Map<string, EntityRefPresentationSnapshot>;
+    nextCursor?: string;
+    loadingState: LoadingState;
+    initialResultIsOnlyOption: boolean;
+  }>({
+    entities: [],
+    entityRefToPresentation: new Map(),
+    loadingState: enabled ? 'loading' : 'idle',
+    initialResultIsOnlyOption: false,
+  });
+  const [selectedState, setSelectedState] = useState<{
+    entities: Entity[];
+    entityRefToPresentation: Map<string, EntityRefPresentationSnapshot>;
+  }>({ entities: [], entityRefToPresentation: new Map() });
+  const requestGeneration = useRef(0);
+  const selectedRequestGeneration = useRef(0);
+
+  const presentEntities = useCallback(
+    async (entities: Entity[]) =>
+      new Map<string, EntityRefPresentationSnapshot>(
+        await Promise.all(
+          entities.map(
+            async entity =>
+              [
+                stringifyEntityRef(entity),
+                await entityPresentationApi.forEntity(entity).promise,
+              ] as const,
+          ),
+        ),
+      ),
+    [entityPresentationApi],
+  );
+
+  const setSearchText = useCallback(
+    (value: string) => {
+      if (value === searchText) {
+        return;
+      }
+      requestGeneration.current += 1;
+      setSearchTextState(value);
+      setState(previous => ({
+        ...previous,
+        loadingState: enabled ? 'filtering' : 'idle',
+      }));
+    },
+    [enabled, searchText],
+  );
+
+  useDebounce(() => setDebouncedSearchText(searchText), 250, [searchText]);
+
+  useEffect(() => {
+    const generation = ++requestGeneration.current;
+    if (!enabled) {
+      setState({
+        entities: [],
+        entityRefToPresentation: new Map(),
+        loadingState: 'idle',
+        initialResultIsOnlyOption: false,
+      });
+      return;
+    }
+
+    setState(previous => ({
+      ...previous,
+      loadingState: debouncedSearchText ? 'filtering' : 'loading',
+    }));
+
+    catalogApi
+      .queryEntities({
+        ...(catalogFilter ? { filter: catalogFilter } : {}),
+        fields: ENTITY_PICKER_FIELDS,
+        ...(debouncedSearchText
+          ? {
+              fullTextFilter: {
+                term: debouncedSearchText,
+                fields: ENTITY_PICKER_SEARCH_FIELDS,
+              },
+            }
+          : {}),
+        limit: 20,
+        orderFields: [{ field: 'metadata.name', order: 'asc' }],
+        totalItems: 'exclude',
+      })
+      .then(async response => {
+        const entityRefToPresentation = await presentEntities(response.items);
+
+        if (generation === requestGeneration.current) {
+          setState({
+            entities: response.items,
+            entityRefToPresentation,
+            nextCursor: response.pageInfo.nextCursor,
+            loadingState: 'idle',
+            initialResultIsOnlyOption:
+              debouncedSearchText === '' &&
+              response.items.length === 1 &&
+              !response.pageInfo.nextCursor,
+          });
+        }
+      })
+      .catch(() => {
+        if (generation === requestGeneration.current) {
+          setState(previous => ({ ...previous, loadingState: 'error' }));
+        }
+      });
+  }, [
+    catalogApi,
+    catalogFilter,
+    debouncedSearchText,
+    enabled,
+    presentEntities,
+  ]);
+
+  const loadMore = useCallback(() => {
+    if (!enabled || !state.nextCursor || state.loadingState !== 'idle') {
+      return;
+    }
+
+    const generation = requestGeneration.current;
+    const cursor = state.nextCursor;
+    setState(previous => ({ ...previous, loadingState: 'loadingMore' }));
+    catalogApi
+      .queryEntities({
+        cursor,
+        fields: ENTITY_PICKER_FIELDS,
+        limit: 20,
+      })
+      .then(async response => {
+        const presentations = await presentEntities(response.items);
+        if (generation === requestGeneration.current) {
+          setState(previous => ({
+            ...previous,
+            entities: [...previous.entities, ...response.items],
+            entityRefToPresentation: new Map([
+              ...previous.entityRefToPresentation,
+              ...presentations,
+            ]),
+            nextCursor: response.pageInfo.nextCursor,
+            loadingState: 'idle',
+          }));
+        }
+      })
+      .catch(() => {
+        if (generation === requestGeneration.current) {
+          setState(previous => ({ ...previous, loadingState: 'error' }));
+        }
+      });
+  }, [
+    catalogApi,
+    enabled,
+    presentEntities,
+    state.loadingState,
+    state.nextCursor,
+  ]);
+
+  const selectedEntityRefsKey = JSON.stringify(options.selectedEntityRefs);
+  useEffect(() => {
+    const generation = ++selectedRequestGeneration.current;
+    const entityRefs = JSON.parse(selectedEntityRefsKey) as string[];
+    if (!enabled || entityRefs.length === 0) {
+      setSelectedState({
+        entities: [],
+        entityRefToPresentation: new Map(),
+      });
+      return;
+    }
+
+    catalogApi
+      .getEntitiesByRefs({ entityRefs, fields: ENTITY_PICKER_FIELDS })
+      .then(async response => {
+        const entities = response.items.filter(
+          (item): item is Entity => item !== undefined,
+        );
+        const entityRefToPresentation = await presentEntities(entities);
+        if (generation === selectedRequestGeneration.current) {
+          setSelectedState({ entities, entityRefToPresentation });
+        }
+      })
+      .catch(() => {
+        if (generation === selectedRequestGeneration.current) {
+          setSelectedState({
+            entities: [],
+            entityRefToPresentation: new Map(),
+          });
+        }
+      });
+  }, [catalogApi, enabled, presentEntities, selectedEntityRefsKey]);
+
+  const entityRefToPresentation = useMemo(
+    () =>
+      new Map([
+        ...state.entityRefToPresentation,
+        ...selectedState.entityRefToPresentation,
+      ]),
+    [selectedState.entityRefToPresentation, state.entityRefToPresentation],
+  );
+
+  return {
+    entities: state.entities,
+    selectedEntities: selectedState.entities,
+    entityRefToPresentation,
+    loading: state.loadingState !== 'idle' && state.loadingState !== 'error',
+    loadingState: state.loadingState,
+    searchText,
+    setSearchText,
+    loadMore,
+    initialResultIsOnlyOption: state.initialResultIsOnlyOption,
+  };
+}

--- a/plugins/scaffolder/src/components/fields/useEntityPickerOptions.ts
+++ b/plugins/scaffolder/src/components/fields/useEntityPickerOptions.ts
@@ -26,16 +26,6 @@ import { LoadingState } from '@backstage/ui';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import useDebounce from 'react-use/esm/useDebounce';
 
-export const ENTITY_PICKER_FIELDS = [
-  'kind',
-  'metadata.name',
-  'metadata.namespace',
-  'metadata.title',
-  'metadata.description',
-  'spec.profile.displayName',
-  'spec.type',
-];
-
 const ENTITY_PICKER_SEARCH_FIELDS = [
   'metadata.name',
   'kind',
@@ -83,6 +73,8 @@ export function useEntityPickerOptions(options: {
   }>({ entities: [], entityRefToPresentation: new Map() });
   const requestGeneration = useRef(0);
   const selectedRequestGeneration = useRef(0);
+  const searchTextRef = useRef('');
+  const settledSearchTextRef = useRef<string>();
 
   const presentEntities = useCallback(
     async (entities: Entity[]) =>
@@ -105,11 +97,14 @@ export function useEntityPickerOptions(options: {
       if (value === searchText) {
         return;
       }
-      requestGeneration.current += 1;
+      searchTextRef.current = value;
       setSearchTextState(value);
       setState(previous => ({
         ...previous,
-        loadingState: enabled ? 'filtering' : 'idle',
+        loadingState:
+          enabled && value !== settledSearchTextRef.current
+            ? 'filtering'
+            : 'idle',
       }));
     },
     [enabled, searchText],
@@ -137,7 +132,6 @@ export function useEntityPickerOptions(options: {
     catalogApi
       .queryEntities({
         ...(catalogFilter ? { filter: catalogFilter } : {}),
-        fields: ENTITY_PICKER_FIELDS,
         ...(debouncedSearchText
           ? {
               fullTextFilter: {
@@ -153,7 +147,11 @@ export function useEntityPickerOptions(options: {
       .then(async response => {
         const entityRefToPresentation = await presentEntities(response.items);
 
-        if (generation === requestGeneration.current) {
+        if (
+          generation === requestGeneration.current &&
+          debouncedSearchText === searchTextRef.current
+        ) {
+          settledSearchTextRef.current = debouncedSearchText;
           setState({
             entities: response.items,
             entityRefToPresentation,
@@ -167,7 +165,10 @@ export function useEntityPickerOptions(options: {
         }
       })
       .catch(() => {
-        if (generation === requestGeneration.current) {
+        if (
+          generation === requestGeneration.current &&
+          debouncedSearchText === searchTextRef.current
+        ) {
           setState(previous => ({ ...previous, loadingState: 'error' }));
         }
       });
@@ -190,7 +191,6 @@ export function useEntityPickerOptions(options: {
     catalogApi
       .queryEntities({
         cursor,
-        fields: ENTITY_PICKER_FIELDS,
         limit: 20,
       })
       .then(async response => {
@@ -210,7 +210,7 @@ export function useEntityPickerOptions(options: {
       })
       .catch(() => {
         if (generation === requestGeneration.current) {
-          setState(previous => ({ ...previous, loadingState: 'error' }));
+          setState(previous => ({ ...previous, loadingState: 'idle' }));
         }
       });
   }, [
@@ -234,7 +234,7 @@ export function useEntityPickerOptions(options: {
     }
 
     catalogApi
-      .getEntitiesByRefs({ entityRefs, fields: ENTITY_PICKER_FIELDS })
+      .getEntitiesByRefs({ entityRefs })
       .then(async response => {
         const entities = response.items.filter(
           (item): item is Entity => item !== undefined,

--- a/plugins/scaffolder/src/components/fields/useEntityPickerOptions.ts
+++ b/plugins/scaffolder/src/components/fields/useEntityPickerOptions.ts
@@ -56,6 +56,7 @@ export function useEntityPickerOptions(options: {
   const [searchText, setSearchTextState] = useState('');
   const [debouncedSearchText, setDebouncedSearchText] = useState('');
   const [state, setState] = useState<{
+    generation?: number;
     entities: Entity[];
     entityRefToPresentation: Map<string, EntityRefPresentationSnapshot>;
     nextCursor?: string;
@@ -74,7 +75,6 @@ export function useEntityPickerOptions(options: {
   const requestGeneration = useRef(0);
   const selectedRequestGeneration = useRef(0);
   const searchTextRef = useRef('');
-  const settledSearchTextRef = useRef<string>();
   const nextLoadMoreRequest = useRef(0);
   const activeLoadMoreRequest = useRef<number>();
 
@@ -94,23 +94,10 @@ export function useEntityPickerOptions(options: {
     [entityPresentationApi],
   );
 
-  const setSearchText = useCallback(
-    (value: string) => {
-      if (value === searchTextRef.current) {
-        return;
-      }
-      searchTextRef.current = value;
-      setSearchTextState(value);
-      setState(previous => ({
-        ...previous,
-        loadingState:
-          enabled && value !== settledSearchTextRef.current
-            ? 'filtering'
-            : 'idle',
-      }));
-    },
-    [enabled],
-  );
+  const setSearchText = useCallback((value: string) => {
+    searchTextRef.current = value;
+    setSearchTextState(value);
+  }, []);
 
   useDebounce(() => setDebouncedSearchText(searchText), 250, [searchText]);
 
@@ -150,12 +137,9 @@ export function useEntityPickerOptions(options: {
       .then(async response => {
         const entityRefToPresentation = await presentEntities(response.items);
 
-        if (
-          generation === requestGeneration.current &&
-          debouncedSearchText === searchTextRef.current
-        ) {
-          settledSearchTextRef.current = debouncedSearchText;
+        if (generation === requestGeneration.current) {
           setState({
+            generation,
             entities: response.items,
             entityRefToPresentation,
             nextCursor: response.pageInfo.nextCursor,
@@ -168,10 +152,7 @@ export function useEntityPickerOptions(options: {
         }
       })
       .catch(() => {
-        if (
-          generation === requestGeneration.current &&
-          debouncedSearchText === searchTextRef.current
-        ) {
+        if (generation === requestGeneration.current) {
           setState(previous => ({ ...previous, loadingState: 'error' }));
         }
       });
@@ -186,6 +167,8 @@ export function useEntityPickerOptions(options: {
   const loadMore = useCallback(() => {
     if (
       !enabled ||
+      debouncedSearchText !== searchTextRef.current ||
+      state.generation !== requestGeneration.current ||
       !state.nextCursor ||
       state.loadingState !== 'idle' ||
       activeLoadMoreRequest.current !== undefined
@@ -209,10 +192,7 @@ export function useEntityPickerOptions(options: {
           return;
         }
         activeLoadMoreRequest.current = undefined;
-        if (
-          generation === requestGeneration.current &&
-          debouncedSearchText === searchTextRef.current
-        ) {
+        if (generation === requestGeneration.current) {
           setState(previous => ({
             ...previous,
             entities: [...previous.entities, ...response.items],
@@ -230,10 +210,7 @@ export function useEntityPickerOptions(options: {
           return;
         }
         activeLoadMoreRequest.current = undefined;
-        if (
-          generation === requestGeneration.current &&
-          debouncedSearchText === searchTextRef.current
-        ) {
+        if (generation === requestGeneration.current) {
           setState(previous => ({ ...previous, loadingState: 'idle' }));
         }
       });
@@ -242,6 +219,7 @@ export function useEntityPickerOptions(options: {
     debouncedSearchText,
     enabled,
     presentEntities,
+    state.generation,
     state.loadingState,
     state.nextCursor,
   ]);
@@ -288,15 +266,23 @@ export function useEntityPickerOptions(options: {
     [selectedState.entityRefToPresentation, state.entityRefToPresentation],
   );
 
+  // Input can change and return to the active query before the debounce fires.
+  // Keep that query's result (including errors) independently of the input.
+  const loadingState =
+    enabled && searchText !== debouncedSearchText
+      ? 'filtering'
+      : state.loadingState;
+
   return {
     entities: state.entities,
     selectedEntities: selectedState.entities,
     entityRefToPresentation,
-    loading: state.loadingState !== 'idle' && state.loadingState !== 'error',
-    loadingState: state.loadingState,
+    loading: loadingState !== 'idle' && loadingState !== 'error',
+    loadingState,
     searchText,
     setSearchText,
     loadMore,
-    initialResultIsOnlyOption: state.initialResultIsOnlyOption,
+    initialResultIsOnlyOption:
+      loadingState === 'idle' && !searchText && state.initialResultIsOnlyOption,
   };
 }

--- a/plugins/scaffolder/src/components/fields/useEntityPickerPagination.ts
+++ b/plugins/scaffolder/src/components/fields/useEntityPickerPagination.ts
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2026 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Entity, stringifyEntityRef } from '@backstage/catalog-model';
+import { UIEvent, useEffect, useRef, useState } from 'react';
+
+/** Pagination for MUI's virtualized, selection-filtered listbox. */
+export function useEntityPickerPagination(options: {
+  entities: Entity[];
+  selectedEntityRefs: string[];
+  loading: boolean;
+  loadMore: () => void;
+}) {
+  const { entities, selectedEntityRefs, loading, loadMore } = options;
+  const [open, setOpen] = useState(false);
+  const lastAutomaticRequest = useRef<{
+    entities: Entity[];
+    selectedEntityRefs: string[];
+  }>();
+
+  useEffect(() => {
+    if (!open || loading) return;
+    if (
+      lastAutomaticRequest.current?.entities === entities &&
+      lastAutomaticRequest.current?.selectedEntityRefs === selectedEntityRefs
+    )
+      return;
+
+    const available = entities.filter(
+      entity => !selectedEntityRefs.includes(stringifyEntityRef(entity)),
+    );
+    // The list shows up to 10.5 rows. Selected options may hide a whole page,
+    // in which case MUI doesn't even mount the listbox to receive scroll events.
+    if (available.length <= 10) {
+      // Only try once per page/selection, so failures don't cause a retry loop.
+      // Scrolling or reopening the menu allows the user to retry.
+      lastAutomaticRequest.current = { entities, selectedEntityRefs };
+      loadMore();
+    }
+  }, [entities, selectedEntityRefs, loading, loadMore, open]);
+
+  return {
+    onOpen: () => {
+      lastAutomaticRequest.current = undefined;
+      setOpen(true);
+    },
+    onClose: () => setOpen(false),
+    ListboxProps: {
+      onScroll: (event: UIEvent<HTMLElement>) => {
+        const element = event.currentTarget;
+        // Keyboard navigation leaves some padding below the last visible row.
+        if (
+          element.scrollHeight - element.clientHeight - element.scrollTop <=
+          36
+        ) {
+          loadMore();
+        }
+      },
+    },
+  };
+}


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Fixes #35557.

EntityPicker, MultiEntityPicker, and MyGroupsPicker now load a bounded first page of catalog entities instead of eagerly streaming the full result set. Search input is debounced and sent to the catalog API, additional pages load on demand, and existing selections are resolved separately so they remain presentable even when they are outside the current page.

Input edits survive refreshed search results, request races cannot strand the loading state or reuse an obsolete cursor, and MUI pagination handles keyboard navigation and pages hidden by existing selections. Regression tests cover these cases and page-load retries; the actual components were also exercised in a local browser harness with both MUI and BUI.

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a Signed-off-by line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
