### PR TITLE
workflows: validate pull request context artifacts

### DIFF
--- a/.github/workflows/sync_pull-requests.yml
+++ b/.github/workflows/sync_pull-requests.yml
@@ -6,6 +6,10 @@ on:
     types:
       - completed
 
+permissions:
+  actions: read
+  pull-requests: read
+
 jobs:
   run:
     runs-on: ubuntu-latest
@@ -36,15 +40,53 @@ jobs:
         with:
           script: |
             const fs = require('fs');
-            function read(path, fallback) {
+
+            function read(path, fallback = '') {
               try { return fs.readFileSync(path, 'utf8').trim(); }
               catch { return fallback; }
             }
-            core.setOutput('pr-number', read('./context/pr-number', ''));
-            core.setOutput('label-added', read('./context/label-added', ''));
-            core.setOutput('review-state', read('./context/review-state', ''));
-            core.setOutput('actor', read('./context/actor', ''));
-            core.setOutput('action', read('./context/action', 'synchronize'));
+
+            const workflowRun = context.payload.workflow_run;
+            const rawPrNumber = read('./context/pr-number');
+            const prNumber = Number(rawPrNumber);
+
+            if (
+              !/^[1-9]\d*$/.test(rawPrNumber) ||
+              !Number.isSafeInteger(prNumber)
+            ) {
+              core.setFailed('Invalid PR number in workflow artifact');
+              return;
+            }
+
+            if (workflowRun.event === 'pull_request') {
+              const { data: pullRequest } = await github.rest.pulls.get({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                pull_number: prNumber,
+              });
+
+              if (
+                pullRequest.head.sha !== workflowRun.head_sha ||
+                pullRequest.head.repo?.id !== workflowRun.head_repository?.id
+              ) {
+                core.setFailed(
+                  'PR context does not match the triggering workflow run',
+                );
+                return;
+              }
+
+              core.setOutput('label-added', '');
+              core.setOutput('review-state', '');
+              core.setOutput('actor', workflowRun.actor.login);
+              core.setOutput('action', 'synchronize');
+            } else {
+              core.setOutput('label-added', read('./context/label-added'));
+              core.setOutput('review-state', read('./context/review-state'));
+              core.setOutput('actor', read('./context/actor'));
+              core.setOutput('action', read('./context/action', 'synchronize'));
+            }
+
+            core.setOutput('pr-number', prNumber);
 
       - name: Backstage PR automation
         if: steps.context.outputs.pr-number


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This changes the pull request automation to verify that context artifacts from pull request workflows match the triggering workflow's head commit and repository before invoking the privileged automation. Event details from these artifacts are ignored, while the trusted trigger workflow retains its existing behavior.

This prevents pull request workflows from directing the automation at unrelated pull requests or supplying fabricated event context.

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
