### PR TITLE
chore: update API comment actions to Node 24

### DIFF
--- a/.github/workflows/api-breaking-changes-comment.yml
+++ b/.github/workflows/api-breaking-changes-comment.yml
@@ -110,7 +110,7 @@ jobs:
 
       # Identify comment to be updated
       - name: Find comment for API Changes
-        uses: peter-evans/find-comment@3eae4d37986fb5a8592848f6a574fdf654e61f9e # v3
+        uses: peter-evans/find-comment@b30e6a3c0ed37e7c023ccd3f1db5c6c0b0c23aad # v4.0.0
         id: find-comment
         with:
           issue-number: ${{ needs.setup.outputs.pr-number }}
@@ -119,7 +119,7 @@ jobs:
           direction: last
 
       - name: Create or Update Comment with API Changes
-        uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043 # v4
+        uses: peter-evans/create-or-update-comment@e8674b075228eee787fea43ef493e45ece1004c9 # v5.0.0
         with:
           comment-id: ${{ steps.find-comment.outputs.comment-id }}
           issue-number: ${{ needs.setup.outputs.pr-number }}


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Updates the actions used to find and create API breaking-change comments to their Node 24 releases:

- `peter-evans/find-comment` v4.0.0
- `peter-evans/create-or-update-comment` v5.0.0

Both actions remain pinned to immutable commit SHAs. Their inputs are unchanged, and the workflow runs on GitHub-hosted `ubuntu-latest`, which satisfies the Node 24 runner requirement.

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))