### PR TITLE
fix(catalog): safely handle entity context menu errors

### DIFF
--- a/.changeset/safe-menu-errors.md
+++ b/.changeset/safe-menu-errors.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog': patch
+---
+
+Fixed entity context menus to report errors from contributed items without disrupting the menu.

--- a/plugins/catalog/src/alpha/components/EntityContextMenu/EntityContextMenu.test.tsx
+++ b/plugins/catalog/src/alpha/components/EntityContextMenu/EntityContextMenu.test.tsx
@@ -18,10 +18,12 @@ import {
   createExtensionTester,
   renderInTestApp,
 } from '@backstage/frontend-test-utils';
+import { errorApiRef } from '@backstage/frontend-plugin-api';
 import {
   EntityContextMenuItemBlueprint,
   type EntityContextMenuItemParams,
 } from '@backstage/plugin-catalog-react/alpha';
+import { MockErrorApi, withLogCollector } from '@backstage/test-utils';
 import { screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { useState } from 'react';
@@ -70,6 +72,55 @@ describe('EntityContextMenu', () => {
     await userEvent.click(item);
 
     expect(onClick).toHaveBeenCalledTimes(1);
+  });
+
+  it('reports menu item errors without disrupting the menu collection', async () => {
+    const errorApi = new MockErrorApi({ collect: true });
+    const error = new Error('Failed to render menu item');
+    const onClick = jest.fn();
+
+    await withLogCollector(['error'], async () => {
+      await renderInTestApp(
+        <EntityContextMenu
+          contextMenuItems={[
+            createContextMenuItem({
+              icon: <span />,
+              useProps: () => {
+                throw error;
+              },
+            }),
+            createContextMenuItem({
+              icon: <span />,
+              useProps: () => ({ title: 'Healthy item', onClick }),
+            }),
+          ]}
+        />,
+        { apis: [[errorApiRef, errorApi]] },
+      );
+
+      await userEvent.click(
+        screen.getByRole('button', { name: 'More actions' }),
+      );
+
+      const healthyItem = await screen.findByRole('menuitem', {
+        name: 'Healthy item',
+      });
+      expect(screen.queryByText(error.message)).not.toBeInTheDocument();
+      expect(errorApi.getErrors()).toEqual([
+        {
+          error: expect.objectContaining({
+            message: expect.stringContaining(error.message),
+            cause: error,
+          }),
+          context: undefined,
+        },
+      ]);
+
+      await userEvent.click(healthyItem);
+    });
+
+    expect(onClick).toHaveBeenCalledTimes(1);
+    expect(screen.queryByRole('menu')).not.toBeInTheDocument();
   });
 
   it('supports an action alongside an internal link', async () => {

--- a/plugins/catalog/src/alpha/components/EntityContextMenu/EntityContextMenu.tsx
+++ b/plugins/catalog/src/alpha/components/EntityContextMenu/EntityContextMenu.tsx
@@ -75,7 +75,7 @@ function EntityContextMenuItem(props: {
   item: EntityContextMenuItemDataWithNode;
 }) {
   return (
-    <ExtensionBoundary node={props.item.node}>
+    <ExtensionBoundary node={props.item.node} errorPresentation="error-api">
       <EntityContextMenuItemContent data={props.item.data} />
     </ExtensionBoundary>
   );


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

Entity context-menu item failures are now reported through `errorApi` without rendering fallback UI into the React Aria collection. This preserves the original extension error while allowing healthy menu items and normal menu interactions to continue working.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))

<!-- mana-workspace:GgMqYbaNcRw -->