### PR TITLE
feat(core-components): allow configuring CopyTextButton visual variant

### DIFF
--- a/.changeset/copytextbutton-variant.md
+++ b/.changeset/copytextbutton-variant.md
@@ -1,0 +1,5 @@
+---
+'@backstage/core-components': patch
+---
+
+Added an optional `variant` prop to `CopyTextButton` to allow configuring its visual style (`primary`, `secondary`, or `tertiary`).

--- a/packages/core-components/report.api.md
+++ b/packages/core-components/report.api.md
@@ -8,6 +8,7 @@ import { BackstageIdentityApi } from '@backstage/core-plugin-api';
 import { BackstagePalette } from '@backstage/theme';
 import { BackstageUserIdentity } from '@backstage/core-plugin-api';
 import { BottomNavigationActionProps } from '@material-ui/core/BottomNavigationAction';
+import { ButtonIconProps } from '@backstage/ui';
 import { ButtonProps as ButtonProps_2 } from '@material-ui/core/Button';
 import { CardHeaderProps } from '@material-ui/core/CardHeader';
 import { ChangeEvent } from 'react';
@@ -221,6 +222,7 @@ export interface CopyTextButtonProps {
   text: string;
   tooltipDelay?: number;
   tooltipText?: string;
+  variant?: ButtonIconProps['variant'];
 }
 
 // @public (undocumented)

--- a/packages/core-components/src/components/CopyTextButton/CopyTextButton.stories.tsx
+++ b/packages/core-components/src/components/CopyTextButton/CopyTextButton.stories.tsx
@@ -47,3 +47,26 @@ export const WithAriaLabel = () => (
     aria-label="This is an aria label"
   />
 );
+
+export const Variants = () => (
+  <div style={{ display: 'flex', gap: '16px', alignItems: 'center' }}>
+    <CopyTextButton
+      text="Primary variant text"
+      variant="primary"
+      aria-label="Copy primary"
+      tooltipText="Primary variant"
+    />
+    <CopyTextButton
+      text="Secondary variant text"
+      variant="secondary"
+      aria-label="Copy secondary"
+      tooltipText="Secondary variant"
+    />
+    <CopyTextButton
+      text="Tertiary variant text"
+      variant="tertiary"
+      aria-label="Copy tertiary"
+      tooltipText="Tertiary variant"
+    />
+  </div>
+);

--- a/packages/core-components/src/components/CopyTextButton/CopyTextButton.test.tsx
+++ b/packages/core-components/src/components/CopyTextButton/CopyTextButton.test.tsx
@@ -104,4 +104,16 @@ describe('<CopyTextButton />', () => {
     );
     expect(getByLabelText('text for aria-label')).toBeInTheDocument();
   });
+
+  it('forwards variant to the button element', async () => {
+    const { getByLabelText } = await renderInTestApp(
+      <TestApiProvider apis={apis}>
+        <CopyTextButton {...props} variant="secondary" />
+      </TestApiProvider>,
+    );
+    expect(getByLabelText('Copy text')).toHaveAttribute(
+      'data-variant',
+      'secondary',
+    );
+  });
 });

--- a/packages/core-components/src/components/CopyTextButton/CopyTextButton.tsx
+++ b/packages/core-components/src/components/CopyTextButton/CopyTextButton.tsx
@@ -15,7 +15,12 @@
  */
 
 import { errorApiRef, useApi } from '@backstage/core-plugin-api';
-import { ButtonIcon, Tooltip, TooltipTrigger } from '@backstage/ui';
+import {
+  ButtonIcon,
+  ButtonIconProps,
+  Tooltip,
+  TooltipTrigger,
+} from '@backstage/ui';
 import CopyIcon from '@material-ui/icons/FileCopy';
 import { useEffect, useRef, useState } from 'react';
 import useCopyToClipboard from 'react-use/esm/useCopyToClipboard';
@@ -57,6 +62,15 @@ export interface CopyTextButtonProps {
    * Default: "Copy text"
    */
   'aria-label'?: string;
+
+  /**
+   * The visual variant of the button
+   *
+   * @remarks
+   *
+   * Default: "primary"
+   */
+  variant?: ButtonIconProps['variant'];
 }
 
 /**
@@ -85,6 +99,7 @@ export function CopyTextButton(props: CopyTextButtonProps) {
     tooltipDelay = 1000,
     tooltipText = t('copyTextButton.tooltipText'),
     'aria-label': ariaLabel = 'Copy text',
+    variant,
   } = props;
   const errorApi = useApi(errorApiRef);
   const [open, setOpen] = useState(false);
@@ -127,6 +142,7 @@ export function CopyTextButton(props: CopyTextButtonProps) {
         icon={<CopyIcon />}
         onPress={handleCopyClick}
         aria-label={ariaLabel}
+        variant={variant}
       />
       <Tooltip>{tooltipText}</Tooltip>
     </TooltipTrigger>


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Allows configuring the visual variant (`primary`, `secondary`, or `tertiary`) of `CopyTextButton` by exposing an optional `variant` prop forwarded to the underlying Backstage UI `ButtonIcon`.

Closes #34888

<details>
<summary>Check for visual variants clip</summary>

[Screencast From 2026-09-07 08-21-31.webm](https://github.com/user-attachments/assets/38a83857-d6cf-4785-a7ef-54f8bc1a635c)

</details>

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
