### PR TITLE
test(backend-defaults): cover same-origin fetch mode for GitLab archive

### DIFF
--- a/packages/backend-defaults/src/entrypoints/urlReader/lib/GitlabUrlReader.test.ts
+++ b/packages/backend-defaults/src/entrypoints/urlReader/lib/GitlabUrlReader.test.ts
@@ -396,6 +396,36 @@ describe('GitlabUrlReader', () => {
       expect(indexMarkdownFile.toString()).toBe('# Test\n');
     });
 
+    // GitLab treats a request to repository/archive made with the default fetch
+    // mode of 'cors' as hotlinking, and answers it with 406 - Not Acceptable.
+    // The reader has to opt out by asking for 'same-origin' instead.
+    // See https://github.com/backstage/backstage/issues/34395
+    it('requests the archive with the same-origin fetch mode', async () => {
+      let archiveRequest: Request | undefined;
+      worker.use(
+        http.get(
+          'https://gitlab.com/api/v4/projects/backstage%2Fmock/repository/archive',
+          ({ request }) => {
+            archiveRequest = request;
+            return new HttpResponse(new Uint8Array(archiveBuffer), {
+              status: 200,
+              headers: {
+                'Content-Type': 'application/zip',
+                'content-disposition':
+                  'attachment; filename="mock-main-sha123abc.zip"',
+              },
+            });
+          },
+        ),
+      );
+
+      await gitlabProcessor.readTree(
+        'https://gitlab.com/backstage/mock/tree/main',
+      );
+
+      expect(archiveRequest?.mode).toBe('same-origin');
+    });
+
     it('creates a directory with the wanted files', async () => {
       const response = await gitlabProcessor.readTree(
         'https://gitlab.com/backstage/mock',


### PR DESCRIPTION
Adds a regression test covering the `same-origin` fetch mode in `GitlabUrlReader.readTree`.

[#34415](https://github.com/backstage/backstage/pull/34415) fixed [#34395](https://github.com/backstage/backstage/issues/34395) by passing `mode: 'same-origin'` on the `repository/archive` request — GitLab treats the default `cors` mode as hotlinking and answers with `406 - Not Acceptable`. That fix is a single line with no test behind it, so removing it would silently reintroduce the failure for every GitLab integration.

The assertion is on `request.mode` rather than the `Sec-Fetch-Mode` header because msw intercepts the request before undici applies the header, leaving it `null` in the handler while `mode` is preserved.

No changeset, as this is a test-only change.

