### PR TITLE
test(kubernetes): complete MSW 2 migration

### DIFF
--- a/plugins/kubernetes-backend/src/service/KubernetesFetcher.test.ts
+++ b/plugins/kubernetes-backend/src/service/KubernetesFetcher.test.ts
@@ -198,20 +198,24 @@ describe('KubernetesFetcher', () => {
     it('does not follow HTTP redirects when fetching resources', async () => {
       let redirectTargetCalled = false;
       worker.use(
-        rest.get('http://localhost:9999/api/v1/pods', (_, res, ctx) =>
-          res(
-            ctx.status(302),
-            ctx.set('Location', 'http://evil.example.com/api/v1/pods'),
-          ),
+        http.get(
+          'http://localhost:9999/api/v1/pods',
+          () =>
+            new HttpResponse(null, {
+              status: 302,
+              headers: {
+                Location: 'http://evil.example.com/api/v1/pods',
+              },
+            }),
         ),
-        rest.get('http://evil.example.com/api/v1/pods', () => {
+        http.get('http://evil.example.com/api/v1/pods', () => {
           redirectTargetCalled = true;
           throw new Error('redirect target must not be requested');
         }),
-        rest.get('http://localhost:9999/api/v1/services', (req, res, ctx) =>
-          res(
-            checkToken(req, ctx, 'token'),
-            withLabels(req, ctx, {
+        http.get('http://localhost:9999/api/v1/services', ({ request: req }) =>
+          response(
+            checkToken(req, 'token'),
+            withLabels(req, {
               items: [{ metadata: { name: 'service-name' } }],
             }),
           ),
@@ -1443,10 +1447,10 @@ describe('KubernetesFetcher', () => {
 
     it('should mask secret data requested as a custom resource, leaving other custom resources intact', async () => {
       worker.use(
-        rest.get('http://localhost:9999/api/v1/secrets', (req, res, ctx) =>
-          res(
-            checkToken(req, ctx, 'token'),
-            withLabels(req, ctx, {
+        http.get('http://localhost:9999/api/v1/secrets', ({ request: req }) =>
+          response(
+            checkToken(req, 'token'),
+            withLabels(req, {
               kind: 'SecretList',
               items: [
                 {
@@ -1460,12 +1464,12 @@ describe('KubernetesFetcher', () => {
             }),
           ),
         ),
-        rest.get(
+        http.get(
           'http://localhost:9999/apis/some-group/v2/things',
-          (req, res, ctx) =>
-            res(
-              checkToken(req, ctx, 'token'),
-              withLabels(req, ctx, {
+          ({ request: req }) =>
+            response(
+              checkToken(req, 'token'),
+              withLabels(req, {
                 kind: 'ThingList',
                 items: [
                   {


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Completes the MSW 2 migration from #35174 for tests that were added to `KubernetesFetcher.test.ts` after that branch was created. This fixes the type errors currently present on `master` while preserving the redirect and secret-redaction coverage.

No changeset is included because this only updates test code.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))