### PR TITLE
Fix duplicate catalog model layers across sources

### DIFF
--- a/.changeset/fuzzy-layers-dedupe.md
+++ b/.changeset/fuzzy-layers-dedupe.md
@@ -1,0 +1,5 @@
+---
+'@backstage/catalog-model': patch
+---
+
+Allow independently registered catalog model sources to share identical layers, while reporting a clear error for conflicting layers with the same ID.

--- a/packages/catalog-model/src/model/compileCatalogModel.test.ts
+++ b/packages/catalog-model/src/model/compileCatalogModel.test.ts
@@ -18,6 +18,7 @@ import Ajv from 'ajv';
 import { createCatalogModelLayer } from './createCatalogModelLayer';
 import { compileCatalogModel } from './compileCatalogModel';
 import { defaultCatalogEntityModel } from './defaultCatalogEntityModel';
+import { CatalogModelSources } from './sources/CatalogModelSources';
 
 const layer = createCatalogModelLayer({
   layerId: 'Test',
@@ -136,6 +137,104 @@ describe('compileCatalogModel', () => {
     expect(
       model.getKind({ kind: 'Unknown', apiVersion: 'example.com/v1alpha1' }),
     ).toBeUndefined();
+  });
+});
+
+describe('compileCatalogModel layer identities', () => {
+  const annotationLayer = (layerId: string, annotationName: string) =>
+    createCatalogModelLayer({
+      layerId,
+      builder: model => {
+        model.addAnnotation({
+          name: annotationName,
+          description: `Annotation from ${layerId}`,
+        });
+      },
+    });
+
+  it('deduplicates identical layers emitted by independent model sources', async () => {
+    const sources = [
+      CatalogModelSources.static([
+        annotationLayer('example.com/shared', 'example.com/shared'),
+        annotationLayer('example.com/a', 'example.com/a'),
+      ]),
+      CatalogModelSources.static([
+        annotationLayer('example.com/shared', 'example.com/shared'),
+        annotationLayer('example.com/b', 'example.com/b'),
+      ]),
+    ];
+    const layers = await Promise.all(
+      sources.map(async source => {
+        const iterator = source.read();
+        try {
+          const result = await iterator.next();
+          return result.value?.data.map(entry => entry.layer) ?? [];
+        } finally {
+          await iterator.return(undefined);
+        }
+      }),
+    );
+
+    const annotationNames = compileCatalogModel(layers.flat())
+      .getMetadata()
+      .annotations.map(annotation => annotation.name);
+
+    expect(annotationNames).toEqual(
+      expect.arrayContaining([
+        'backstage.io/managed-by-location',
+        'example.com/shared',
+        'example.com/a',
+        'example.com/b',
+      ]),
+    );
+    expect(
+      annotationNames.filter(name => name === 'example.com/shared'),
+    ).toHaveLength(1);
+    expect(
+      annotationNames.filter(
+        name => name === 'backstage.io/managed-by-location',
+      ),
+    ).toHaveLength(1);
+  });
+
+  it('ignores non-semantic opaque fields when comparing layers', () => {
+    const sharedLayer = annotationLayer(
+      'example.com/shared',
+      'example.com/shared',
+    );
+    const sharedLayerWithSource = {
+      ...sharedLayer,
+      source: 'example.com/source',
+    };
+
+    const annotationNames = compileCatalogModel([
+      sharedLayer,
+      sharedLayerWithSource,
+    ])
+      .getMetadata()
+      .annotations.map(annotation => annotation.name);
+
+    expect(
+      annotationNames.filter(name => name === 'example.com/shared'),
+    ).toHaveLength(1);
+  });
+
+  it('rejects conflicting definitions without hiding declaration conflicts', () => {
+    expect(() =>
+      compileCatalogModel([
+        annotationLayer('example.com/conflict', 'example.com/a'),
+        annotationLayer('example.com/conflict', 'example.com/b'),
+      ]),
+    ).toThrow(
+      'Catalog model layer ID "example.com/conflict" has conflicting definitions',
+    );
+
+    expect(() =>
+      compileCatalogModel([
+        annotationLayer('example.com/a', 'example.com/conflict'),
+        annotationLayer('example.com/b', 'example.com/conflict'),
+      ]),
+    ).toThrow('Annotation "example.com/conflict" is declared more than once');
   });
 });
 

--- a/packages/catalog-model/src/model/compileCatalogModel.ts
+++ b/packages/catalog-model/src/model/compileCatalogModel.ts
@@ -539,15 +539,28 @@ function buildFullSchema(options: {
  * @alpha
  * @param inputs - The layers to compile.
  * @returns The compiled catalog model.
+ * @throws An `InputError` if layers with the same ID have conflicting
+ * definitions, or if the combined model is invalid.
  */
 export function compileCatalogModel(
   inputs: Iterable<CatalogModelLayer>,
 ): CatalogModel {
-  // Collect all ops from all inputs
-  let allOps: CatalogModelOp[] = [];
+  // Collect all ops from all unique inputs
+  const allOps: CatalogModelOp[] = [];
+  const layerOpsById = new Map<string, CatalogModelOp[]>();
   for (const input of inputs) {
     const internal = OpaqueCatalogModelLayer.toInternal(input);
-    allOps = allOps.concat(internal.ops);
+    const existingOps = layerOpsById.get(internal.layerId);
+    if (existingOps) {
+      if (!lodash.isEqual(existingOps, internal.ops)) {
+        throw new InputError(
+          `Catalog model layer ID "${internal.layerId}" has conflicting definitions`,
+        );
+      }
+      continue;
+    }
+    layerOpsById.set(internal.layerId, internal.ops);
+    allOps.push(...internal.ops);
   }
 
   const sortedOps = sortOps(allOps);


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Fixes #35406.

Catalog model sources can each include the default model, which previously caused duplicate declarations when multiple sources were combined. The compiler now deduplicates structurally identical layers by ID across all inputs and reports a clear conflict when one ID has different definitions.

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))