### PR TITLE
fix(catalog): restore the gap between About card labels and values

### DIFF
--- a/.changeset/about-field-label-spacing.md
+++ b/.changeset/about-field-label-spacing.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog': patch
+---
+
+Fixed a regression where the About card's field labels (OWNER, SYSTEM, TAGS, etc.) lost their vertical gap above the value.

--- a/plugins/catalog/src/components/AboutCard/AboutField.test.tsx
+++ b/plugins/catalog/src/components/AboutCard/AboutField.test.tsx
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2026 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { renderInTestApp } from '@backstage/test-utils';
+import { screen } from '@testing-library/react';
+import { AboutField } from './AboutField';
+
+// jsdom does not apply the plugin's style sheet over MUI's own in
+// getComputedStyle, so the assertion reads the margin declared by the
+// component's own class instead of the computed value.
+function marginBottomDeclaredByOwnClass(element: Element): string | undefined {
+  const ownClasses = Array.from(element.classList)
+    .filter(cls => !cls.startsWith('Mui'))
+    .map(cls => `.${cls}`);
+  return Array.from(document.styleSheets)
+    .flatMap(sheet => Array.from(sheet.cssRules))
+    .filter((rule): rule is CSSStyleRule => rule instanceof CSSStyleRule)
+    .filter(rule => ownClasses.includes(rule.selectorText))
+    .map(rule => rule.style.marginBottom)
+    .find(Boolean);
+}
+
+describe('<AboutField />', () => {
+  it('keeps a gap between the label and its value', async () => {
+    await renderInTestApp(<AboutField label="Owner" value="team-a" />);
+
+    expect(marginBottomDeclaredByOwnClass(screen.getByText('Owner'))).toBe(
+      '8px',
+    );
+  });
+});

--- a/plugins/catalog/src/components/AboutCard/AboutField.tsx
+++ b/plugins/catalog/src/components/AboutCard/AboutField.tsx
@@ -36,6 +36,7 @@ const useStyles = makeStyles(theme => ({
     letterSpacing: 0.5,
     overflow: 'hidden',
     whiteSpace: 'nowrap',
+    marginBottom: theme.spacing(1),
   },
 }));
 


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Since `@backstage/plugin-catalog` 2.0.8 the About card's field labels (OWNER, SYSTEM, TAGS) sit directly on their values, see #35393 for before and after screenshots.

Commit 80b37b3 changed the `AboutField` label from `variant="h2"` to `variant="inherit"` to keep the 10px label size. The gap it lost was not the h2 line height but the `marginBottom: 8` that `createBaseThemeOptions` gives the `h2` typography variant; `inherit` applies no variant class, so `.MuiTypography-root`'s `margin: 0` is all that remains.

This puts `marginBottom: theme.spacing(1)` on the label's own class, which is the same 8px through the same mechanism (a class after the root class) that the `h2` variant used to provide, without bringing back the h2 font size.

The regression test renders an `AboutField` and asserts that the label's own class declares an 8px `margin-bottom`; it fails on `master` and passes with the change. It reads the declared rule rather than the computed style because jsdom does not cascade the plugin's sheet over MUI's (the existing 24px `lineHeight` on the value computes as 1.43 there too). I have not attached a new screenshot: the rendered result is the "Before" column in the issue, and the test measures the gap that column shows.

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))

Fixes #35393
