### PR TITLE
fix(app-backend): handle repeated protected sign-in

### DIFF
--- a/.changeset/quiet-cookies-repeat.md
+++ b/.changeset/quiet-cookies-repeat.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-app-backend': patch
+---
+
+Fix protected app sign-in returning a 404 when an authenticated browser repeats the sign-in handoff.

--- a/.changeset/quiet-cookies-repeat.md
+++ b/.changeset/quiet-cookies-repeat.md
@@ -2,4 +2,4 @@
 '@backstage/plugin-app-backend': patch
 ---
 
-Fix protected app sign-in returning a 404 when an authenticated browser repeats the sign-in handoff.
+Fix protected app sign-in returning a 404 when an authenticated browser repeats the sign-in handoff for the same user.

--- a/docs/tutorials/enable-public-entry.md
+++ b/docs/tutorials/enable-public-entry.md
@@ -53,7 +53,7 @@ With that, Backstage's cli and backend will detect public entry point and serve 
    );
    ```
 
-   The `signInPageModule` is your custom sign-in page extension that you should already have configured in your app. The `appModulePublicSignIn` from `@backstage/plugin-app/alpha` provides the `CookieAuthRedirect` component that triggers an authenticated redirect to the main app after sign-in.
+   The `signInPageModule` is your custom sign-in page extension that you should already have configured in your app. The `appModulePublicSignIn` from `@backstage/plugin-app/alpha` provides the `CookieAuthRedirect` component that triggers an authenticated redirect to the main app after sign-in. Repeated redirect handoffs are safe and continue to the main app when the user is already authenticated.
 
    :::note
    The frontend will handle cookie refreshing automatically, so you don't have to worry about it.

--- a/docs/tutorials/enable-public-entry.md
+++ b/docs/tutorials/enable-public-entry.md
@@ -53,7 +53,7 @@ With that, Backstage's cli and backend will detect public entry point and serve 
    );
    ```
 
-   The `signInPageModule` is your custom sign-in page extension that you should already have configured in your app. The `appModulePublicSignIn` from `@backstage/plugin-app/alpha` provides the `CookieAuthRedirect` component that triggers an authenticated redirect to the main app after sign-in. Repeated redirect handoffs are safe and continue to the main app when the user is already authenticated.
+   The `signInPageModule` is your custom sign-in page extension that you should already have configured in your app. The `appModulePublicSignIn` from `@backstage/plugin-app/alpha` provides the `CookieAuthRedirect` component that triggers an authenticated redirect to the main app after sign-in. Repeated redirect handoffs for the same user are safe and continue to the main app when the user is already authenticated.
 
    :::note
    The frontend will handle cookie refreshing automatically, so you don't have to worry about it.

--- a/plugins/app-backend/src/service/router.test.ts
+++ b/plugins/app-backend/src/service/router.test.ts
@@ -23,6 +23,7 @@ import { createRouter } from './router';
 import { loadConfigSchema } from '@backstage/config-loader';
 import {
   mockCredentials,
+  mockErrorHandler,
   mockServices,
   TestDatabases,
 } from '@backstage/backend-test-utils';
@@ -158,7 +159,7 @@ describe('createRouter with public entry point', () => {
       }),
       appPackageName: 'example-app',
     });
-    app = express().use(router);
+    app = express().use(router).use(mockErrorHandler());
   });
 
   beforeEach(() => {
@@ -211,7 +212,7 @@ describe('createRouter with public entry point', () => {
       .set('Content-Type', 'application/x-www-form-urlencoded')
       .send(`type=sign-in&token=${mockCredentials.user.token()}`);
 
-    expect(response.status).toBe(500);
+    expect(response.status).toBe(401);
     expect(response.header['set-cookie']).toBeUndefined();
   });
 
@@ -221,7 +222,7 @@ describe('createRouter with public entry point', () => {
       .set('Content-Type', 'application/x-www-form-urlencoded')
       .send('type=something-else');
 
-    expect(response.status).toBe(500);
+    expect(response.status).toBe(400);
   });
 });
 

--- a/plugins/app-backend/src/service/router.test.ts
+++ b/plugins/app-backend/src/service/router.test.ts
@@ -204,6 +204,17 @@ describe('createRouter with public entry point', () => {
     expect(response.text.trim()).toBe('this is index.html');
   });
 
+  it('rejects repeated sign-in from a different authenticated user', async () => {
+    const response = await request(app)
+      .post('/')
+      .set('Cookie', mockCredentials.limitedUser.cookie('user:default/other'))
+      .set('Content-Type', 'application/x-www-form-urlencoded')
+      .send(`type=sign-in&token=${mockCredentials.user.token()}`);
+
+    expect(response.status).toBe(500);
+    expect(response.header['set-cookie']).toBeUndefined();
+  });
+
   it('rejects POST requests without a sign-in type', async () => {
     const response = await request(app)
       .post('/')

--- a/plugins/app-backend/src/service/router.test.ts
+++ b/plugins/app-backend/src/service/router.test.ts
@@ -192,6 +192,18 @@ describe('createRouter with public entry point', () => {
     expect(response.text.trim()).toBe('this is index.html');
   });
 
+  it('handles repeated sign-in from an authenticated user', async () => {
+    const response = await request(app)
+      .post('/')
+      .set('Cookie', mockCredentials.limitedUser.cookie())
+      .set('Content-Type', 'application/x-www-form-urlencoded')
+      .send(`type=sign-in&token=${mockCredentials.user.token()}`);
+
+    expect(response.status).toBe(200);
+    expect(response.header['set-cookie']).toBeDefined();
+    expect(response.text.trim()).toBe('this is index.html');
+  });
+
   it('rejects POST requests without a sign-in type', async () => {
     const response = await request(app)
       .post('/')

--- a/plugins/app-backend/src/service/router.ts
+++ b/plugins/app-backend/src/service/router.ts
@@ -166,6 +166,27 @@ export async function createRouter(
 
     const publicRouter = Router();
 
+    const getRequestCredentials = async (
+      req: express.Request,
+      res: express.Response,
+    ) => {
+      try {
+        return await httpAuth.credentials(req, {
+          allow: ['user', 'service', 'none'],
+          allowLimitedAccess: true,
+        });
+      } catch {
+        // If we fail to authenticate, make sure the session cookie is cleared
+        // and continue as unauthenticated. If the user is logged in they will
+        // immediately be redirected back to the protected app via the POST.
+        const credentials = await auth.getNoneCredentials();
+        await httpAuth.issueUserCookie(res, {
+          credentials,
+        });
+        return credentials;
+      }
+    };
+
     // Handle sign-in before checking the existing session cookie so repeated
     // handoffs remain idempotent for users that are already authenticated.
     publicRouter.post(
@@ -173,10 +194,27 @@ export async function createRouter(
       express.urlencoded({ extended: true }),
       async (req, res, next) => {
         if (req.body.type === 'sign-in') {
+          const existingCredentials = await getRequestCredentials(req, res);
+
+          if (auth.isPrincipal(existingCredentials, 'service')) {
+            next('router');
+            return;
+          }
+
           const credentials = await auth.authenticate(req.body.token);
 
           if (!auth.isPrincipal(credentials, 'user')) {
             throw new AuthenticationError('Invalid token, not a user');
+          }
+
+          if (
+            auth.isPrincipal(existingCredentials, 'user') &&
+            existingCredentials.principal.userEntityRef !==
+              credentials.principal.userEntityRef
+          ) {
+            throw new AuthenticationError(
+              'Refused to replace an existing authenticated session',
+            );
           }
 
           await httpAuth.issueUserCookie(res, {
@@ -195,25 +233,12 @@ export async function createRouter(
     );
 
     publicRouter.use(async (req, res, next) => {
-      try {
-        const credentials = await httpAuth.credentials(req, {
-          allow: ['user', 'service', 'none'],
-          allowLimitedAccess: true,
-        });
+      const credentials = await getRequestCredentials(req, res);
 
-        if (credentials.principal.type === 'none') {
-          next();
-        } else {
-          next('router');
-        }
-      } catch {
-        // If we fail to authenticate, make sure the session cookie is cleared
-        // and continue as unauthenticated. If the user is logged in they will
-        // immediately be redirected back to the protected app via the POST.
-        await httpAuth.issueUserCookie(res, {
-          credentials: await auth.getNoneCredentials(),
-        });
+      if (credentials.principal.type === 'none') {
         next();
+      } else {
+        next('router');
       }
     });
 

--- a/plugins/app-backend/src/service/router.ts
+++ b/plugins/app-backend/src/service/router.ts
@@ -166,29 +166,8 @@ export async function createRouter(
 
     const publicRouter = Router();
 
-    publicRouter.use(async (req, res, next) => {
-      try {
-        const credentials = await httpAuth.credentials(req, {
-          allow: ['user', 'service', 'none'],
-          allowLimitedAccess: true,
-        });
-
-        if (credentials.principal.type === 'none') {
-          next();
-        } else {
-          next('router');
-        }
-      } catch {
-        // If we fail to authenticate, make sure the session cookie is cleared
-        // and continue as unauthenticated. If the user is logged in they will
-        // immediately be redirected back to the protected app via the POST.
-        await httpAuth.issueUserCookie(res, {
-          credentials: await auth.getNoneCredentials(),
-        });
-        next();
-      }
-    });
-
+    // Handle sign-in before checking the existing session cookie so repeated
+    // handoffs remain idempotent for users that are already authenticated.
     publicRouter.post(
       '*',
       express.urlencoded({ extended: true }),
@@ -214,6 +193,29 @@ export async function createRouter(
         }
       },
     );
+
+    publicRouter.use(async (req, res, next) => {
+      try {
+        const credentials = await httpAuth.credentials(req, {
+          allow: ['user', 'service', 'none'],
+          allowLimitedAccess: true,
+        });
+
+        if (credentials.principal.type === 'none') {
+          next();
+        } else {
+          next('router');
+        }
+      } catch {
+        // If we fail to authenticate, make sure the session cookie is cleared
+        // and continue as unauthenticated. If the user is logged in they will
+        // immediately be redirected back to the protected app via the POST.
+        await httpAuth.issueUserCookie(res, {
+          credentials: await auth.getNoneCredentials(),
+        });
+        next();
+      }
+    });
 
     publicRouter.use(
       await createEntryPointRouter({


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Protected app sign-in handoffs can be submitted after the backend has already issued the session cookie, for example when the handoff is repeated by another browser context. The existing cookie check routes that authenticated POST away from the sign-in handler and into the GET-only app fallback, which returns 404.

This keeps the handoff idempotent: repeated authenticated submissions are validated, refresh the user cookie, and continue to the protected app.

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (not applicable; backend-only fix)
- [x] All commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))

#### Validation

- `CI=1 yarn test plugins/app-backend/src/service/router.test.ts`
- `yarn lint --fix`
- `yarn tsc`
- `yarn build:api-reports plugins/app-backend`

The regression test returns 404 with the previous middleware ordering and 200 with this change.
