### PR TITLE
fix: gracefully skip stale PR sync contexts

### DIFF
--- a/.github/workflows/sync_pull-requests.yml
+++ b/.github/workflows/sync_pull-requests.yml
@@ -69,8 +69,8 @@ jobs:
                 pullRequest.head.sha !== workflowRun.head_sha ||
                 pullRequest.head.repo?.id !== workflowRun.head_repository?.id
               ) {
-                core.setFailed(
-                  'PR context does not match the triggering workflow run',
+                core.notice(
+                  'Ignoring stale PR context that does not match the triggering workflow run',
                 );
                 return;
               }


### PR DESCRIPTION
Stale `workflow_run` events can refer to an earlier PR head after a newer commit has landed. Treat that expected race as a notice and skip PR automation, while continuing to fail malformed context artifacts.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))

Validation: parsed the workflow as YAML and exercised the embedded script with mocked stale and malformed artifacts.