### PR TITLE
fix(scaffolder): prevent EntityPicker BUI blur from clobbering valid selection

### DIFF
--- a/.changeset/lucky-pugs-search-calmly.md
+++ b/.changeset/lucky-pugs-search-calmly.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-scaffolder': patch
+---
+
+Fixed a bug in the experimental Backstage UI theme for scaffolder forms where blurring an `EntityPicker` field after selecting a valid entity could silently replace the stored entity reference with the entity's display name, producing an invalid reference that only failed later in the workflow. Free text typed by the user is still committed on blur as before.

--- a/plugins/scaffolder/src/components/fields/EntityPicker/EntityPicker.bui.test.tsx
+++ b/plugins/scaffolder/src/components/fields/EntityPicker/EntityPicker.bui.test.tsx
@@ -1,0 +1,202 @@
+/*
+ * Copyright 2026 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Entity } from '@backstage/catalog-model';
+import {
+  catalogApiRef,
+  entityPresentationApiRef,
+} from '@backstage/plugin-catalog-react';
+import { renderInTestApp, TestApiProvider } from '@backstage/test-utils';
+import { fireEvent, screen } from '@testing-library/react';
+import { ComponentType, PropsWithChildren, ReactNode } from 'react';
+import { EntityPicker } from './EntityPicker';
+import { ScaffolderRJSFFieldProps as FieldProps } from '@backstage/plugin-scaffolder-react';
+import { DefaultEntityPresentationApi } from '@backstage/plugin-catalog';
+import { catalogApiMock } from '@backstage/plugin-catalog-react/testUtils';
+
+jest.mock('@backstage/plugin-scaffolder-react/alpha', () => ({
+  ...jest.requireActual('@backstage/plugin-scaffolder-react/alpha'),
+  useScaffolderTheme: () => 'bui',
+}));
+
+const makeEntity = (
+  kind: string,
+  namespace: string,
+  name: string,
+  title?: string,
+): Entity => ({
+  apiVersion: 'scaffolder.backstage.io/v1beta3',
+  kind,
+  metadata: title ? { namespace, name, title } : { namespace, name },
+});
+
+describe('<EntityPicker /> with bui theme', () => {
+  const onChange = jest.fn();
+  const schema = {};
+  const rawErrors: string[] = [];
+
+  let Wrapper: ComponentType<PropsWithChildren<{}>>;
+
+  const catalogApi = catalogApiMock.mock({
+    streamEntities: jest.fn(),
+  });
+
+  const entities: Entity[] = [
+    makeEntity('Resource', 'default', 'my-subscription', 'My Subscription'),
+    makeEntity('Resource', 'default', 'my-db', 'My DB'),
+  ];
+
+  const baseProps = (overrides: Partial<FieldProps<string>> = {}) =>
+    ({
+      onChange,
+      schema,
+      required: false,
+      uiSchema: { 'ui:options': {} },
+      rawErrors,
+      formData: undefined,
+      ...overrides,
+    } as unknown as FieldProps<string>);
+
+  beforeEach(() => {
+    onChange.mockClear();
+    catalogApi.streamEntities.mockReset();
+    catalogApi.streamEntities.mockImplementation(async function* () {
+      yield entities;
+    });
+
+    Wrapper = ({ children }: { children?: ReactNode }) => (
+      <TestApiProvider
+        apis={[
+          [catalogApiRef, catalogApi],
+          [
+            entityPresentationApiRef,
+            DefaultEntityPresentationApi.create({ catalogApi }),
+          ],
+        ]}
+      >
+        {children}
+      </TestApiProvider>
+    );
+  });
+
+  it('does not clobber a valid selection on blur without defaultKind', async () => {
+    await renderInTestApp(
+      <Wrapper>
+        <EntityPicker
+          {...baseProps({ formData: 'resource:default/my-subscription' })}
+        />
+      </Wrapper>,
+    );
+
+    const input = screen.getByRole('combobox');
+
+    // The display label of the selected entity is shown
+    expect(input).toHaveValue('My Subscription');
+
+    // Blurring must not re-commit the display label as an entity ref
+    fireEvent.blur(input);
+
+    expect(onChange).not.toHaveBeenCalled();
+    expect(input).toHaveValue('My Subscription');
+  });
+
+  it('does not clobber a valid selection on blur with defaultKind set', async () => {
+    await renderInTestApp(
+      <Wrapper>
+        <EntityPicker
+          {...baseProps({
+            formData: 'resource:default/my-subscription',
+            uiSchema: {
+              'ui:options': {
+                defaultKind: 'Resource',
+                defaultNamespace: 'default',
+              },
+            },
+          })}
+        />
+      </Wrapper>,
+    );
+
+    const input = screen.getByRole('combobox');
+    expect(input).toHaveValue('My Subscription');
+
+    fireEvent.blur(input);
+
+    // Previously the label would be re-parsed into a mangled ref such as
+    // "resource:default/my subscription" and silently committed
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it('still commits user-typed free text on blur', async () => {
+    await renderInTestApp(
+      <Wrapper>
+        <EntityPicker
+          {...baseProps({
+            uiSchema: {
+              'ui:options': {
+                defaultKind: 'Group',
+                defaultNamespace: 'default',
+              },
+            },
+          })}
+        />
+      </Wrapper>,
+    );
+
+    const input = screen.getByRole('combobox');
+
+    fireEvent.change(input, { target: { value: 'team-a' } });
+    fireEvent.blur(input);
+
+    expect(onChange).toHaveBeenCalledWith('group:default/team-a');
+  });
+
+  it('commits raw text on blur when it is not a valid entity ref and no defaultKind', async () => {
+    await renderInTestApp(
+      <Wrapper>
+        <EntityPicker {...baseProps()} />
+      </Wrapper>,
+    );
+
+    const input = screen.getByRole('combobox');
+
+    fireEvent.change(input, { target: { value: 'some arbitrary value' } });
+    fireEvent.blur(input);
+
+    // allowArbitraryValues defaults to true; typed text is committed as-is
+    expect(onChange).toHaveBeenCalledWith('some arbitrary value');
+  });
+
+  it('does not commit the display label as a ref when clearing the selection', async () => {
+    await renderInTestApp(
+      <Wrapper>
+        <EntityPicker
+          {...baseProps({ formData: 'resource:default/my-subscription' })}
+        />
+      </Wrapper>,
+    );
+
+    const input = screen.getByRole('combobox');
+    expect(input).toHaveValue('My Subscription');
+
+    // Simulate the clear action of the combobox: selection removed while the
+    // input still holds the programmatically-set display label
+    fireEvent.change(input, { target: { value: '' } });
+    fireEvent.blur(input);
+
+    expect(onChange).toHaveBeenCalledWith(undefined);
+  });
+});

--- a/plugins/scaffolder/src/components/fields/EntityPicker/EntityPicker.tsx
+++ b/plugins/scaffolder/src/components/fields/EntityPicker/EntityPicker.tsx
@@ -203,6 +203,11 @@ export const EntityPicker = (props: EntityPickerProps) => {
   // BUI: controlled input value
   const [inputValue, setInputValue] = useState(formData || '');
 
+  // Tracks whether the current inputValue originates from user typing, as
+  // opposed to being programmatically derived from the selected option's
+  // display label. Only user-typed text should be reconciled on blur.
+  const isUserInputRef = useRef(false);
+
   useEffect(() => {
     if (formData) {
       const opt = buiOptions.find(o => o.value === formData);
@@ -210,7 +215,13 @@ export const EntityPicker = (props: EntityPickerProps) => {
     } else {
       setInputValue('');
     }
+    isUserInputRef.current = false;
   }, [formData, buiOptions]);
+
+  const handleInputChange = useCallback((value: string) => {
+    isUserInputRef.current = true;
+    setInputValue(value);
+  }, []);
 
   const selectedKey =
     formData && buiOptions.some(o => o.value === formData) ? formData : null;
@@ -227,7 +238,9 @@ export const EntityPicker = (props: EntityPickerProps) => {
         const value = String(key);
         lastCommittedRef.current = value;
         onChange(value);
-      } else if (allowArbitraryValues && inputValue) {
+      } else if (allowArbitraryValues && inputValue && isUserInputRef.current) {
+        // Only commit typed free text; a programmatically derived display
+        // label must never be re-committed as an entity ref.
         let entityRef = inputValue;
         try {
           entityRef = stringifyEntityRef(
@@ -247,7 +260,12 @@ export const EntityPicker = (props: EntityPickerProps) => {
   );
 
   const handleBlur = useCallback(() => {
-    if (allowArbitraryValues && inputValue) {
+    // Only reconcile free-text input on blur if the current text was actually
+    // typed by the user. When the text is the display label programmatically
+    // derived from an existing (valid) selection, re-parsing it as an entity
+    // ref would corrupt the committed formData with a kind-less or mangled
+    // value (see issue #35281).
+    if (allowArbitraryValues && inputValue && isUserInputRef.current) {
       let entityRef = inputValue;
       try {
         entityRef = stringifyEntityRef(
@@ -260,6 +278,7 @@ export const EntityPicker = (props: EntityPickerProps) => {
         lastCommittedRef.current = entityRef;
         onChange(entityRef);
       }
+      isUserInputRef.current = false;
     }
   }, [
     allowArbitraryValues,
@@ -321,7 +340,7 @@ export const EntityPicker = (props: EntityPickerProps) => {
           isDisabled={isDisabled || isAutoSelected}
           selectedKey={selectedKey}
           inputValue={inputValue}
-          onInputChange={setInputValue}
+          onInputChange={handleInputChange}
           onSelectionChange={handleSelectionChange}
           onBlur={handleBlur}
           isLoading={loading}


### PR DESCRIPTION
## Summary

Fixes #35281

In the experimental Backstage UI (`bui`) scaffolder theme, blurring an `EntityPicker` field after selecting a valid entity could silently overwrite the committed `formData` with the entity's display label:

- Without `defaultKind`: the label (e.g. `My Subscription`) was committed as-is, replacing a valid ref like `resource:default/my-subscription`
- With `defaultKind`/`defaultNamespace` set: the label was re-parsed into a mangled ref like `resource:default/my subscription`

This happened because the combobox's `inputValue` is programmatically synchronized with the selected option's display label (not the entity ref), while the blur handler unconditionally re-parsed the current input text as if the user had typed it.

## Solution

Track whether the current input text originates from user typing (`isUserInputRef`). Free-text reconciliation on blur (and on clear-selection) now only happens when the user actually typed the text; a programmatically derived display label is never re-committed as an entity ref. User-typed free text still commits on blur exactly as before, so `allowArbitraryValues` workflows are unchanged.

## Testing

- Added `EntityPicker.bui.test.tsx` covering the BUI branch of the field: both corruption scenarios from the issue, typed free-text commit (with and without `defaultKind`), and clear-selection behavior
- Verified the new tests fail on the un-fixed implementation and pass with the fix
- All 31 pre-existing EntityPicker tests (MUI branch) still pass
- `yarn lint`, `yarn prettier --check`, and `yarn tsc` are clean

## Checklist

- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix is effective
- [x] I have made corresponding changes to the documentation (changeset included)
- [x] My changes generate no new warnings
