### PR TITLE
chore: refresh Node 24 third-party actions

### DIFF
--- a/.github/workflows/issue.yaml
+++ b/.github/workflows/issue.yaml
@@ -27,7 +27,7 @@ jobs:
           sparse-checkout: .github
 
       - name: Add issue labels
-        uses: github/issue-labeler@c1b0f9f52a63158c4adc09425e858e87b32e9685 # v3.4
+        uses: github/issue-labeler@ccca1e16fcb66762200e616fc29b57b940c1cb67 # v3.5
         with:
           include-title: 1
           include-body: 0

--- a/.github/workflows/sync_pull-requests-scheduled.yml
+++ b/.github/workflows/sync_pull-requests-scheduled.yml
@@ -25,7 +25,7 @@ jobs:
 
       - name: Generate app token
         id: token
-        uses: actions/create-github-app-token@df432ceedc7162793a195dd1713ff69aefc7379e # v2.0.6
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
           app-id: ${{ secrets.BACKSTAGE_GOALIE_APPLICATION_ID }}
           private-key: ${{ secrets.BACKSTAGE_GOALIE_PRIVATE_KEY }}

--- a/.github/workflows/verify_e2e-windows.yml
+++ b/.github/workflows/verify_e2e-windows.yml
@@ -84,7 +84,9 @@ jobs:
           npm prefix -g | % {npm config set node_gyp "$_\node_modules\node-gyp\bin\node-gyp.js"}
 
       - name: setup chrome
-        uses: browser-actions/setup-chrome@803ef6dfb4fdf22089c9563225d95e4a515820a0 # latest
+        uses: browser-actions/setup-chrome@48ad923757ca74d66703209fe939badbdf80f2f4 # v2.2.0
+        with:
+          chrome-version: latest
 
       - name: yarn install
         uses: backstage/actions/yarn-install@0d281eb2e96927466db49d4cd01d52b14809a66b # v0.7.10


### PR DESCRIPTION
Refresh three third-party workflow actions from their Node 16/20 builds to current Node 24 releases:

- `browser-actions/setup-chrome` v2.2.0
- `actions/create-github-app-token` v3.2.0
- `github/issue-labeler` v3.5

The setup-chrome v2 release changed its default from the latest Chrome for Testing build to stable. Explicitly retain `chrome-version: latest` to preserve the workflow behavior.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))

Validation: parsed all three edited workflow files as YAML and verified each immutable SHA against the upstream release tag and Node 24 action manifest.