### PR TITLE
fix(integration): use default lodash import to fix ESM consumer break (#35380)

### DIFF
--- a/.changeset/fix-esm-lodash-named-imports.md
+++ b/.changeset/fix-esm-lodash-named-imports.md
@@ -6,4 +6,4 @@
 '@backstage/repo-tools': patch
 ---
 
-Fixed lodash named-import from breaking ESM consumers importing from the package's `import` exports-map condition.
+Fixed `lodash` named-import from breaking ESM consumers importing from the package's `import` exports-map condition.

--- a/.changeset/fix-esm-lodash-named-imports.md
+++ b/.changeset/fix-esm-lodash-named-imports.md
@@ -1,0 +1,9 @@
+---
+'@backstage/integration': patch
+'@backstage/backend-defaults': patch
+'@backstage/backend-dynamic-feature-service': patch
+'@backstage/core-components': patch
+'@backstage/repo-tools': patch
+---
+
+Fixed lodash named-import from breaking ESM consumers importing from the package's `import` exports-map condition.

--- a/packages/backend-defaults/src/entrypoints/database/connectors/mergeDatabaseConfig.ts
+++ b/packages/backend-defaults/src/entrypoints/database/connectors/mergeDatabaseConfig.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { merge } from 'lodash';
+import lodash from 'lodash';
 
 /**
  * Merges database objects together
@@ -24,5 +24,5 @@ import { merge } from 'lodash';
  * @param overrides - Any additional overrides
  */
 export function mergeDatabaseConfig(config: any, ...overrides: any[]) {
-  return merge({}, config, ...overrides);
+  return lodash.merge({}, config, ...overrides);
 }

--- a/packages/backend-defaults/src/entrypoints/database/connectors/mysql.ts
+++ b/packages/backend-defaults/src/entrypoints/database/connectors/mysql.ts
@@ -19,7 +19,7 @@ import { Config, ConfigReader } from '@backstage/config';
 import { InputError } from '@backstage/errors';
 import { JsonObject } from '@backstage/types';
 import knexFactory, { Knex } from 'knex';
-import { merge, omit } from 'lodash';
+import lodash from 'lodash';
 import limiterFactory from 'p-limit';
 import yn from 'yn';
 import { Connector } from '../types';
@@ -359,7 +359,7 @@ export class MysqlConnector implements Connector {
       .getOptionalConfig('knexConfig')
       ?.get<JsonObject>();
 
-    return merge(baseConfig, pluginConfig);
+    return lodash.merge(baseConfig, pluginConfig);
   }
 
   private getEnsureExistsConfig(pluginId: string): boolean {
@@ -393,7 +393,7 @@ export class MysqlConnector implements Connector {
     // `database` property from the base connection is omitted unless `pluginDivisionMode`
     // is set to `schema`.
     if (this.getPluginDivisionModeConfig() !== 'schema') {
-      baseConnection = omit(baseConnection, 'database');
+      baseConnection = lodash.omit(baseConnection, 'database');
     }
 
     // get and normalize optional plugin specific database connection

--- a/packages/backend-defaults/src/entrypoints/database/connectors/postgres.ts
+++ b/packages/backend-defaults/src/entrypoints/database/connectors/postgres.ts
@@ -27,7 +27,7 @@ import {
   JsonObject,
 } from '@backstage/types';
 import knexFactory, { Knex } from 'knex';
-import { merge, omit } from 'lodash';
+import lodash from 'lodash';
 import limiterFactory from 'p-limit';
 import { Client } from 'pg';
 import { Connector } from '../types';
@@ -216,7 +216,7 @@ export async function buildPgDatabaseConfig(
       typeof connectionValue === 'string' || connectionValue instanceof String
         ? connectionValue
         : // connection is an object, omit config-only props
-          omit(connectionValue as Record<string, unknown>, [
+          lodash.omit(connectionValue as Record<string, unknown>, [
             'type',
             'instance',
             'tokenCredential',
@@ -301,7 +301,7 @@ export async function buildAzurePgConfig(config: Config): Promise<Knex.Config> {
   const rawConfig = config.get() as Record<string, unknown>;
 
   const normalized = normalizeConnection(rawConfig.connection as any);
-  const sanitizedConnection = omit(normalized, [
+  const sanitizedConnection = lodash.omit(normalized, [
     'type',
     'instance',
     'tokenCredential',
@@ -383,7 +383,7 @@ export async function buildCloudSqlConfig(
 
   const rawConfig = config.get() as Record<string, unknown>;
   const normalized = normalizeConnection(rawConfig.connection as any);
-  const sanitizedConnection = omit(normalized, [
+  const sanitizedConnection = lodash.omit(normalized, [
     'type',
     'instance',
   ]) as Partial<Knex.StaticConnectionConfig>;
@@ -426,7 +426,7 @@ export async function buildRdsPgConfig(config: Config): Promise<Knex.Config> {
   }
 
   const rawConfig = config.get() as Record<string, unknown>;
-  const sanitizedConnection = omit(
+  const sanitizedConnection = lodash.omit(
     config.get('connection') as Record<string, unknown>,
     ['type', 'region'],
   ) as Partial<Knex.StaticConnectionConfig>;
@@ -712,7 +712,7 @@ export function computePgPluginConfig(
   const baseKnexConfig = config
     .getOptionalConfig('knexConfig')
     ?.get<JsonObject>();
-  const additionalKnexConfig = merge(baseKnexConfig, pluginKnexConfig);
+  const additionalKnexConfig = lodash.merge(baseKnexConfig, pluginKnexConfig);
 
   // Ensure exists flags
   const baseEnsureExists = config.getOptionalBoolean('ensureExists') ?? true;
@@ -738,7 +738,7 @@ export function computePgPluginConfig(
   // The `database` property from the base connection is omitted unless
   // `pluginDivisionMode` is set to `schema`.
   if (pluginDivisionMode !== 'schema') {
-    baseConnection = omit(baseConnection, 'database');
+    baseConnection = lodash.omit(baseConnection, 'database');
   }
 
   // Get and normalize optional plugin specific database connection

--- a/packages/backend-defaults/src/entrypoints/database/connectors/sqlite3.ts
+++ b/packages/backend-defaults/src/entrypoints/database/connectors/sqlite3.ts
@@ -20,7 +20,7 @@ import { Config, ConfigReader } from '@backstage/config';
 import { JsonObject } from '@backstage/types';
 import { ensureDirSync } from 'fs-extra';
 import knexFactory, { Knex } from 'knex';
-import { merge, omit } from 'lodash';
+import lodash from 'lodash';
 import path from 'node:path';
 import { Connector } from '../types';
 import { mergeDatabaseConfig } from './mergeDatabaseConfig';
@@ -291,7 +291,7 @@ export class Sqlite3Connector implements Connector {
       .getOptionalConfig('knexConfig')
       ?.get<JsonObject>();
 
-    return merge(baseConfig, pluginConfig);
+    return lodash.merge(baseConfig, pluginConfig);
   }
 
   private getPluginDivisionModeConfig(): string {
@@ -329,7 +329,7 @@ export class Sqlite3Connector implements Connector {
     // is set to `schema`. SQLite3's `filename` property is an exception as this is used as a
     // directory elsewhere so we preserve `filename`.
     if (this.getPluginDivisionModeConfig() !== 'schema') {
-      baseConnection = omit(baseConnection, 'database');
+      baseConnection = lodash.omit(baseConnection, 'database');
     }
 
     // get and normalize optional plugin specific database connection

--- a/packages/backend-defaults/src/entrypoints/discovery/HostDiscovery.ts
+++ b/packages/backend-defaults/src/entrypoints/discovery/HostDiscovery.ts
@@ -22,7 +22,7 @@ import {
 } from '@backstage/backend-plugin-api';
 import { readHttpServerOptions } from '../rootHttpRouter/http/config';
 import { SrvResolvers } from './SrvResolvers';
-import { trimEnd } from 'lodash';
+import lodash from 'lodash';
 import { getEndpoints } from './parsing';
 
 type Resolver = (pluginId: string) => Promise<string>;
@@ -221,7 +221,10 @@ export class HostDiscovery implements DiscoveryService {
   }
 
   #updateFallbackResolvers(config: Config) {
-    const backendBaseUrl = trimEnd(config.getString('backend.baseUrl'), '/');
+    const backendBaseUrl = lodash.trimEnd(
+      config.getString('backend.baseUrl'),
+      '/',
+    );
 
     const {
       listen: { host: listenHost = '::', port: listenPort },

--- a/packages/backend-defaults/src/entrypoints/scheduler/lib/DefaultSchedulerService.ts
+++ b/packages/backend-defaults/src/entrypoints/scheduler/lib/DefaultSchedulerService.ts
@@ -22,7 +22,7 @@ import {
   RootLifecycleService,
   SchedulerService,
 } from '@backstage/backend-plugin-api';
-import { once } from 'lodash';
+import lodash from 'lodash';
 import { Duration } from 'luxon';
 import { migrateBackendTasks } from '../database/migrateBackendTasks';
 import { PluginTaskSchedulerImpl } from './PluginTaskSchedulerImpl';
@@ -43,7 +43,7 @@ export class DefaultSchedulerService {
     httpRouter: HttpRouterService;
     pluginMetadata: PluginMetadataService;
   }): SchedulerService {
-    const databaseFactory = once(async () => {
+    const databaseFactory = lodash.once(async () => {
       const knex = await options.database.getClient();
 
       if (!options.database.migrations?.skip) {

--- a/packages/backend-defaults/src/entrypoints/urlReader/lib/BitbucketCloudUrlReader.ts
+++ b/packages/backend-defaults/src/entrypoints/urlReader/lib/BitbucketCloudUrlReader.ts
@@ -33,7 +33,7 @@ import {
   ScmIntegrations,
 } from '@backstage/integration';
 import parseGitUrl from 'git-url-parse';
-import { trimEnd } from 'lodash';
+import lodash from 'lodash';
 import { Minimatch } from 'minimatch';
 import { ReaderFactory, ReadTreeResponseFactory } from './types';
 import { ReadUrlResponseFactory } from './ReadUrlResponseFactory';
@@ -210,7 +210,7 @@ export class BitbucketCloudUrlReader implements UrlReaderService {
     // a future improvement, we could be smart and try to deduce that non-glob
     // prefixes (like for filepaths such as some-prefix/**/a.yaml) can be used
     // to get just that part of the repo.
-    const treeUrl = trimEnd(url.replace(filepath, ''), '/');
+    const treeUrl = lodash.trimEnd(url.replace(filepath, ''), '/');
 
     const tree = await this.readTree(treeUrl, {
       etag: options?.etag,

--- a/packages/backend-defaults/src/entrypoints/urlReader/lib/BitbucketServerUrlReader.ts
+++ b/packages/backend-defaults/src/entrypoints/urlReader/lib/BitbucketServerUrlReader.ts
@@ -32,7 +32,7 @@ import {
   ScmIntegrations,
 } from '@backstage/integration';
 import parseGitUrl from 'git-url-parse';
-import { trimEnd } from 'lodash';
+import lodash from 'lodash';
 import { Minimatch } from 'minimatch';
 import { ReaderFactory, ReadTreeResponseFactory } from './types';
 import { ReadUrlResponseFactory } from './ReadUrlResponseFactory';
@@ -194,7 +194,7 @@ export class BitbucketServerUrlReader implements UrlReaderService {
     // a future improvement, we could be smart and try to deduce that non-glob
     // prefixes (like for filepaths such as some-prefix/**/a.yaml) can be used
     // to get just that part of the repo.
-    const treeUrl = trimEnd(url.replace(filepath, ''), '/');
+    const treeUrl = lodash.trimEnd(url.replace(filepath, ''), '/');
 
     const tree = await this.readTree(treeUrl, {
       etag: options?.etag,

--- a/packages/backend-defaults/src/entrypoints/urlReader/lib/GitlabUrlReader.ts
+++ b/packages/backend-defaults/src/entrypoints/urlReader/lib/GitlabUrlReader.ts
@@ -32,7 +32,7 @@ import {
   ScmIntegrations,
 } from '@backstage/integration';
 import parseGitUrl from 'git-url-parse';
-import { trimEnd } from 'lodash';
+import lodash from 'lodash';
 import { Minimatch } from 'minimatch';
 import { ReadUrlResponseFactory } from './ReadUrlResponseFactory';
 import { ReaderFactory, ReadTreeResponseFactory } from './types';
@@ -263,7 +263,7 @@ export class GitlabUrlReader implements UrlReaderService {
 
     const staticPart = this.getStaticPart(filepath);
     const matcher = new Minimatch(filepath);
-    const treeUrl = trimEnd(url.replace(filepath, staticPart), `/`);
+    const treeUrl = lodash.trimEnd(url.replace(filepath, staticPart), `/`);
     const pathPrefix = staticPart ? `${staticPart}/` : '';
     const tree = await this.readTree(treeUrl, {
       etag: options?.etag,

--- a/packages/backend-dynamic-feature-service/src/schemas/schemas.ts
+++ b/packages/backend-dynamic-feature-service/src/schemas/schemas.ts
@@ -25,7 +25,7 @@ import { targetPaths } from '@backstage/cli-common';
 import fs from 'fs-extra';
 import * as path from 'node:path';
 import * as url from 'node:url';
-import { isEmpty } from 'lodash';
+import lodash from 'lodash';
 import { LoggerService } from '@backstage/backend-plugin-api';
 import { JsonObject } from '@backstage/types';
 import { PluginScanner } from '../scanner/plugin-scanner';
@@ -178,7 +178,7 @@ async function gatherDynamicPluginsSchemas(
       continue;
     }
 
-    if (isEmpty(serialized)) {
+    if (lodash.isEmpty(serialized)) {
       continue;
     }
 

--- a/packages/core-components/src/components/DependencyGraph/DependencyGraphContent.tsx
+++ b/packages/core-components/src/components/DependencyGraph/DependencyGraphContent.tsx
@@ -24,7 +24,7 @@ import {
 } from 'react';
 import useMeasure from 'react-use/esm/useMeasure';
 import classNames from 'classnames';
-import { once } from 'lodash';
+import lodash from 'lodash';
 import * as d3Zoom from 'd3-zoom';
 import * as d3Selection from 'd3-selection';
 import useTheme from '@material-ui/core/styles/useTheme';
@@ -329,7 +329,7 @@ export function DependencyGraph<NodeData, EdgeData>(
   };
 
   const [_measureRef] = useMeasure();
-  const measureRef = once(_measureRef);
+  const measureRef = lodash.once(_measureRef);
 
   const scalableHeight =
     fit === 'grow' && !fullScreenHandle.active ? maxHeight : '100%';

--- a/packages/core-components/src/components/Link/Link.tsx
+++ b/packages/core-components/src/components/Link/Link.tsx
@@ -26,7 +26,7 @@ import MaterialLink, {
 import { makeStyles } from '@material-ui/core/styles';
 import Typography from '@material-ui/core/Typography';
 import classnames from 'classnames';
-import { trimEnd } from 'lodash';
+import lodash from 'lodash';
 import {
   ReactNode,
   ReactElement,
@@ -138,7 +138,7 @@ const useBasePath = () => {
   const base = 'http://sample.dev';
   const url = useBaseUrl() ?? '/';
   const { pathname } = new URL(url, base);
-  return trimEnd(pathname, '/');
+  return lodash.trimEnd(pathname, '/');
 };
 
 /** @deprecated Remove once we no longer support React Router v6 beta */

--- a/packages/core-components/src/components/StructuredMetadataTable/StructuredMetadataTable.test.tsx
+++ b/packages/core-components/src/components/StructuredMetadataTable/StructuredMetadataTable.test.tsx
@@ -15,7 +15,7 @@
  */
 
 import { render, within, waitFor } from '@testing-library/react';
-import { startCase } from 'lodash';
+import lodash from 'lodash';
 import { StructuredMetadataTable } from './StructuredMetadataTable';
 
 describe('<StructuredMetadataTable />', () => {
@@ -38,7 +38,7 @@ describe('<StructuredMetadataTable />', () => {
         <StructuredMetadataTable metadata={metadata} />,
       );
       for (const [key, value] of Object.entries(metadata)) {
-        expect(getByText(startCase(key))).toBeInTheDocument();
+        expect(getByText(lodash.startCase(key))).toBeInTheDocument();
         expect(getByText(value)).toBeInTheDocument();
       }
     });
@@ -50,7 +50,7 @@ describe('<StructuredMetadataTable />', () => {
       );
 
       for (const [key, value] of Object.entries(metadata)) {
-        expect(getByText(startCase(key))).toBeInTheDocument();
+        expect(getByText(lodash.startCase(key))).toBeInTheDocument();
         expect(getByText(value.toString())).toBeInTheDocument();
       }
     });
@@ -62,7 +62,7 @@ describe('<StructuredMetadataTable />', () => {
       );
       const keys = Object.keys(metadata);
       keys.forEach(value => {
-        expect(getByText(startCase(value))).toBeInTheDocument();
+        expect(getByText(lodash.startCase(value))).toBeInTheDocument();
       });
       metadata.arrayField.forEach(value => {
         expect(getByText(new RegExp(value))).toBeInTheDocument();
@@ -107,7 +107,9 @@ describe('<StructuredMetadataTable />', () => {
       );
 
       for (const [key, value] of Object.entries(metadata.config)) {
-        expect(getByText(startCase(key), { exact: false })).toBeInTheDocument();
+        expect(
+          getByText(lodash.startCase(key), { exact: false }),
+        ).toBeInTheDocument();
         expect(
           getByText(value.toString(), { exact: false }),
         ).toBeInTheDocument();

--- a/packages/core-components/src/components/Table/Table.tsx
+++ b/packages/core-components/src/components/Table/Table.tsx
@@ -51,7 +51,7 @@ import LastPage from '@material-ui/icons/LastPage';
 import Remove from '@material-ui/icons/Remove';
 import SaveAlt from '@material-ui/icons/SaveAlt';
 import ViewColumn from '@material-ui/icons/ViewColumn';
-import { isEqual, transform } from 'lodash';
+import lodash from 'lodash';
 import {
   CSSProperties,
   forwardRef,
@@ -250,8 +250,8 @@ function convertColumns<T extends object>(
 }
 
 function removeDefaultValues(state: any, defaultState: any): any {
-  return transform(state, (result, value, key) => {
-    if (!isEqual(value, defaultState[key])) {
+  return lodash.transform(state, (result, value, key) => {
+    if (!lodash.isEqual(value, defaultState[key])) {
       result[key] = value;
     }
   });

--- a/packages/core-components/src/hooks/useQueryParamState.ts
+++ b/packages/core-components/src/hooks/useQueryParamState.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { isEqual } from 'lodash';
+import lodash from 'lodash';
 import qs from 'qs';
 import { useEffect, useState } from 'react';
 import { useSearchParams } from 'react-router-dom';
@@ -71,7 +71,7 @@ export function useQueryParamState<T>(
     const newState = extractState(searchParamsString, stateName);
 
     setQueryParamState(oldState =>
-      isEqual(newState, oldState) ? oldState : newState,
+      lodash.isEqual(newState, oldState) ? oldState : newState,
     );
   }, [searchParamsString, setQueryParamState, stateName]);
 

--- a/packages/core-components/src/layout/Sidebar/MobileSidebar.tsx
+++ b/packages/core-components/src/layout/Sidebar/MobileSidebar.tsx
@@ -23,7 +23,7 @@ import Drawer from '@material-ui/core/Drawer';
 import Typography from '@material-ui/core/Typography';
 import CloseIcon from '@material-ui/icons/Close';
 import MenuIcon from '@material-ui/icons/Menu';
-import { orderBy } from 'lodash';
+import lodash from 'lodash';
 import {
   useEffect,
   useState,
@@ -102,7 +102,7 @@ const useStyles = makeStyles<Theme, { sidebarConfig: SidebarConfig }>(
 );
 
 const sortSidebarGroupsForPriority = (children: ReactElement[]) =>
-  orderBy(
+  lodash.orderBy(
     children,
     ({ props: { priority } }) => (Number.isInteger(priority) ? priority : -1),
     'desc',

--- a/packages/core-components/src/layout/Sidebar/utils.ts
+++ b/packages/core-components/src/layout/Sidebar/utils.ts
@@ -15,7 +15,7 @@
  */
 
 import type { Location, Path } from 'history';
-import { isEqual, isMatch } from 'lodash';
+import lodash from 'lodash';
 import qs from 'qs';
 
 export function isLocationMatch(
@@ -31,10 +31,10 @@ export function isLocationMatch(
   ).toString();
   const currentQueryParameters = qs.parse(currentDecodedSearch);
 
-  const queryStringMatcher = exact ? isEqual : isMatch;
+  const queryStringMatcher = exact ? lodash.isEqual : lodash.isMatch;
 
   const matching =
-    isEqual(toLocation.pathname, currentLocation.pathname) &&
+    lodash.isEqual(toLocation.pathname, currentLocation.pathname) &&
     queryStringMatcher(currentQueryParameters, toQueryParameters);
 
   return matching;

--- a/packages/integration/src/bitbucketServer/config.ts
+++ b/packages/integration/src/bitbucketServer/config.ts
@@ -15,7 +15,7 @@
  */
 
 import { Config } from '@backstage/config';
-import { trimEnd } from 'lodash';
+import lodash from 'lodash';
 import { isValidHost } from '../helpers';
 
 /**
@@ -93,7 +93,7 @@ export function readBitbucketServerIntegrationConfig(
   }
 
   if (apiBaseUrl) {
-    apiBaseUrl = trimEnd(apiBaseUrl, '/');
+    apiBaseUrl = lodash.trimEnd(apiBaseUrl, '/');
   } else {
     apiBaseUrl = `https://${host}/rest/api/1.0`;
   }

--- a/packages/integration/src/gerrit/config.ts
+++ b/packages/integration/src/gerrit/config.ts
@@ -15,7 +15,7 @@
  */
 
 import { Config } from '@backstage/config';
-import { trimEnd } from 'lodash';
+import lodash from 'lodash';
 import { isValidHost, isValidUrl } from '../helpers';
 
 /**
@@ -108,17 +108,17 @@ export function readGerritIntegrationConfig(
     );
   }
   if (baseUrl) {
-    baseUrl = trimEnd(baseUrl, '/');
+    baseUrl = lodash.trimEnd(baseUrl, '/');
   } else {
     baseUrl = `https://${host}`;
   }
   if (cloneUrl) {
-    cloneUrl = trimEnd(cloneUrl, '/');
+    cloneUrl = lodash.trimEnd(cloneUrl, '/');
   } else {
     cloneUrl = baseUrl;
   }
 
-  gitilesBaseUrl = trimEnd(gitilesBaseUrl, '/');
+  gitilesBaseUrl = lodash.trimEnd(gitilesBaseUrl, '/');
 
   return {
     host,

--- a/packages/integration/src/gerrit/core.ts
+++ b/packages/integration/src/gerrit/core.ts
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { join, takeWhile, trimEnd, trimStart } from 'lodash';
+import lodash from 'lodash';
 import { GerritIntegrationConfig } from './config';
 
 const GERRIT_BODY_PREFIX = ")]}'";
@@ -53,7 +53,7 @@ export function parseGitilesUrlRef(
   // In case of the gitilesBaseUrl is https://review.gerrit.com/plugins/gitiles
   // and the url provided is https://review.gerrit.com/a/plugins/gitiles/...
   // remove the prefix only if the pathname start with '/a/'
-  const urlPath = trimStart(
+  const urlPath = lodash.trimStart(
     urlParse.pathname
       .substring(urlParse.pathname.startsWith('/a/') ? 2 : 0)
       .replace(baseUrlParse.pathname, ''),
@@ -62,39 +62,39 @@ export function parseGitilesUrlRef(
 
   // Find the project by taking everything up to "/+/".
   const parts = urlPath.split('/').filter(p => !!p);
-  const projectParts = takeWhile(parts, p => p !== '+');
+  const projectParts = lodash.takeWhile(parts, p => p !== '+');
   if (projectParts.length === 0) {
     throw new Error(`Unable to parse gitiles url: ${url}`);
   }
   // Also remove the "+" after the project.
   const rest = parts.slice(projectParts.length + 1);
-  const project = join(projectParts, '/');
+  const project = lodash.join(projectParts, '/');
 
   // match <project>/+/HEAD/<path>
   if (rest.length > 0 && rest[0] === 'HEAD') {
     const ref = rest.shift()!;
-    const path = join(rest, '/');
+    const path = lodash.join(rest, '/');
     return {
       project,
       ref,
       refType: 'head' as const,
       path: path || '/',
-      basePath: trimEnd(url.replace(path, ''), '/'),
+      basePath: lodash.trimEnd(url.replace(path, ''), '/'),
     };
   }
   // match <project>/+/<sha>/<path>
   if (rest.length > 0 && rest[0].length === 40) {
     const ref = rest.shift()!;
-    const path = join(rest, '/');
+    const path = lodash.join(rest, '/');
     return {
       project,
       ref,
       refType: 'sha' as const,
       path: path || '/',
-      basePath: trimEnd(url.replace(path, ''), '/'),
+      basePath: lodash.trimEnd(url.replace(path, ''), '/'),
     };
   }
-  const remainingPath = join(rest, '/');
+  const remainingPath = lodash.join(rest, '/');
   // Regexp for matching "refs/tags/<tag>" or "refs/heads/<branch>/"
   const refsRegexp = /^refs\/(?<refsReference>heads|tags)\/(?<ref>.*?)(\/|$)/;
   const result = refsRegexp.exec(remainingPath);
@@ -118,7 +118,7 @@ export function parseGitilesUrlRef(
       ref,
       refType,
       path: path || '/',
-      basePath: trimEnd(url.replace(path, ''), '/'),
+      basePath: lodash.trimEnd(url.replace(path, ''), '/'),
     };
   }
   throw new Error(`Unable to parse gitiles : ${url}`);
@@ -141,7 +141,7 @@ export function buildGerritGitilesUrl(
 ): string {
   return `${
     config.gitilesBaseUrl
-  }/${project}/+/refs/heads/${branch}/${trimStart(filePath, '/')}`;
+  }/${project}/+/refs/heads/${branch}/${lodash.trimStart(filePath, '/')}`;
 }
 
 /**
@@ -161,7 +161,7 @@ export function buildGerritEditUrl(
 ): string {
   return `${
     config.baseUrl
-  }/admin/repos/edit/repo/${project}/branch/refs/heads/${branch}/file/${trimStart(
+  }/admin/repos/edit/repo/${project}/branch/refs/heads/${branch}/file/${lodash.trimStart(
     filePath,
     '/',
   )}`;

--- a/packages/integration/src/gitea/config.ts
+++ b/packages/integration/src/gitea/config.ts
@@ -15,7 +15,7 @@
  */
 
 import { Config } from '@backstage/config';
-import { trimEnd } from 'lodash';
+import lodash from 'lodash';
 import { isValidHost, isValidUrl } from '../helpers';
 
 /**
@@ -74,7 +74,7 @@ export function readGiteaConfig(config: Config): GiteaIntegrationConfig {
   }
 
   if (baseUrl) {
-    baseUrl = trimEnd(baseUrl, '/');
+    baseUrl = lodash.trimEnd(baseUrl, '/');
   } else {
     baseUrl = `https://${host}`;
   }

--- a/packages/integration/src/github/SingleInstanceGithubCredentialsProvider.ts
+++ b/packages/integration/src/github/SingleInstanceGithubCredentialsProvider.ts
@@ -19,7 +19,7 @@ import { GithubAppConfig, GithubIntegrationConfig } from './config';
 import { createAppAuth } from '@octokit/auth-app';
 import { Octokit, RestEndpointMethodTypes } from '@octokit/rest';
 import { DateTime } from 'luxon';
-import { cloneDeep } from 'lodash';
+import lodash from 'lodash';
 import {
   GithubCredentials,
   GithubCredentialsProvider,
@@ -249,7 +249,7 @@ class GithubAppManager {
   }
 
   async getInstallations(): Promise<Installations> {
-    return cloneDeep(await this.getCachedInstallations());
+    return lodash.cloneDeep(await this.getCachedInstallations());
   }
 
   private async getCachedInstallations(

--- a/packages/integration/src/github/config.ts
+++ b/packages/integration/src/github/config.ts
@@ -15,7 +15,7 @@
  */
 
 import { Config } from '@backstage/config';
-import { trimEnd } from 'lodash';
+import lodash from 'lodash';
 import { isValidHost } from '../helpers';
 
 const GITHUB_HOST = 'github.com';
@@ -147,13 +147,13 @@ export function readGithubIntegrationConfig(
   }
 
   if (apiBaseUrl) {
-    apiBaseUrl = trimEnd(apiBaseUrl, '/');
+    apiBaseUrl = lodash.trimEnd(apiBaseUrl, '/');
   } else if (host === GITHUB_HOST) {
     apiBaseUrl = GITHUB_API_BASE_URL;
   }
 
   if (rawBaseUrl) {
-    rawBaseUrl = trimEnd(rawBaseUrl, '/');
+    rawBaseUrl = lodash.trimEnd(rawBaseUrl, '/');
   } else if (host === GITHUB_HOST) {
     rawBaseUrl = GITHUB_RAW_BASE_URL;
   }

--- a/packages/integration/src/gitlab/config.ts
+++ b/packages/integration/src/gitlab/config.ts
@@ -15,7 +15,7 @@
  */
 
 import { Config } from '@backstage/config';
-import { trimEnd } from 'lodash';
+import lodash from 'lodash';
 import { isValidHost, isValidUrl } from '../helpers';
 
 const GITLAB_HOST = 'gitlab.com';
@@ -124,13 +124,13 @@ export function readGitLabIntegrationConfig(
   const token = config.getOptionalString('token')?.trim();
   let baseUrl = config.getOptionalString('baseUrl');
   if (apiBaseUrl) {
-    apiBaseUrl = trimEnd(apiBaseUrl, '/');
+    apiBaseUrl = lodash.trimEnd(apiBaseUrl, '/');
   } else if (host === GITLAB_HOST) {
     apiBaseUrl = GITLAB_API_BASE_URL;
   }
 
   if (baseUrl) {
-    baseUrl = trimEnd(baseUrl, '/');
+    baseUrl = lodash.trimEnd(baseUrl, '/');
   } else {
     baseUrl = `https://${host}`;
   }
@@ -211,5 +211,5 @@ export function getGitLabIntegrationRelativePath(
   if (config.host !== GITLAB_HOST) {
     relativePath = new URL(config.baseUrl).pathname;
   }
-  return trimEnd(relativePath, '/');
+  return lodash.trimEnd(relativePath, '/');
 }

--- a/packages/integration/src/helpers.ts
+++ b/packages/integration/src/helpers.ts
@@ -15,7 +15,7 @@
  */
 
 import parseGitUrl from 'git-url-parse';
-import { trimEnd } from 'lodash';
+import lodash from 'lodash';
 import { ScmIntegration, ScmIntegrationsGroup } from './types';
 
 /**
@@ -120,7 +120,7 @@ export function defaultScmResolveUrl(options: {
 
     updated = new URL(href);
 
-    const repoRootPath = trimEnd(
+    const repoRootPath = lodash.trimEnd(
       updated.pathname.substring(0, updated.pathname.length - filepath.length),
       '/',
     );

--- a/packages/repo-tools/src/commands/api-reports/api-reports/runApiExtraction.ts
+++ b/packages/repo-tools/src/commands/api-reports/api-reports/runApiExtraction.ts
@@ -23,7 +23,7 @@ import {
 import { TSDocTagSyntaxKind } from '@microsoft/tsdoc';
 import { TSDocConfigFile } from '@microsoft/tsdoc-config';
 import fs from 'fs-extra';
-import { groupBy } from 'lodash';
+import lodash from 'lodash';
 import { minimatch } from 'minimatch';
 import {
   join,
@@ -159,7 +159,7 @@ export async function runApiExtraction({
   const warnings = new Array<string>();
 
   for (const [packageDir, packageEntryPoints] of Object.entries(
-    groupBy(allEntryPoints, ep => ep.packageDir),
+    lodash.groupBy(allEntryPoints, ep => ep.packageDir),
   )) {
     console.log(`## Processing ${packageDir}`);
     const noBail = Array.isArray(allowWarnings)

--- a/packages/repo-tools/src/commands/package/schema/openapi/generate/index.ts
+++ b/packages/repo-tools/src/commands/package/schema/openapi/generate/index.ts
@@ -22,7 +22,7 @@ import {
   getPathToCurrentOpenApiSpec,
   loadAndValidateOpenApiYaml,
 } from '../../../../../lib/openapi/helpers';
-import { debounce } from 'lodash';
+import lodash from 'lodash';
 import { block } from '../../../../../lib/runner';
 
 export async function command(opts: OptionValues) {
@@ -63,7 +63,7 @@ export async function command(opts: OptionValues) {
       const watcher = chokidar.watch(resolvedOpenapiPath);
 
       // The generate command currently takes ~8 seconds to run, so let's debounce calling it so we don't have to cancel it so much.
-      const debouncedCommand = debounce(() => {
+      const debouncedCommand = lodash.debounce(() => {
         console.log('Detected changes! Regenerating...');
         abortController.abort();
         abortController = new AbortController();

--- a/packages/repo-tools/src/commands/repo/schema/openapi/validate.ts
+++ b/packages/repo-tools/src/commands/repo/schema/openapi/validate.ts
@@ -15,7 +15,7 @@
  */
 
 import fs from 'fs-extra';
-import { isEqual } from 'lodash';
+import lodash from 'lodash';
 import { join } from 'node:path';
 import chalk from 'chalk';
 import { relative as relativePath, resolve as resolvePath } from 'node:path';
@@ -59,7 +59,7 @@ async function validate(directoryPath: string) {
   if (!schema.spec) {
     throw new Error(`\`${TS_SCHEMA_PATH}\` needs to have a 'spec' export.`);
   }
-  if (!isEqual(schema.spec, yaml)) {
+  if (!lodash.isEqual(schema.spec, yaml)) {
     const path = relativePath(targetPaths.rootDir, directoryPath);
     throw new Error(
       `\`${YAML_SCHEMA_PATH}\` and \`${TS_SCHEMA_PATH}\` do not match. Please run \`yarn backstage-repo-tools package schema openapi generate\` from '${path}' to regenerate \`${TS_SCHEMA_PATH}\`.`,

--- a/packages/repo-tools/src/lib/openapi/helpers.ts
+++ b/packages/repo-tools/src/lib/openapi/helpers.ts
@@ -17,7 +17,7 @@
 import Parser from '@apidevtools/swagger-parser';
 import fs, { pathExists } from 'fs-extra';
 import YAML from 'js-yaml';
-import { cloneDeep } from 'lodash';
+import lodash from 'lodash';
 import { targetPaths } from '@backstage/cli-common';
 import { resolve } from 'node:path';
 import { YAML_SCHEMA_PATH } from './constants';
@@ -47,7 +47,7 @@ export const getPathToCurrentOpenApiSpec = async () => {
 
 export async function loadAndValidateOpenApiYaml(path: string) {
   const yaml = YAML.load(await fs.readFile(path, 'utf8'));
-  await Parser.validate(cloneDeep(yaml) as any);
+  await Parser.validate(lodash.cloneDeep(yaml) as any);
   return yaml;
 }
 


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Fixes #35380

### Description
In `@backstage/integration@2.1.0+`, an `exports` map has been added where the `import` condition refers to the ESM build (`dist/index.esm.js`). Since `lodash` uses CommonJS and doesn't have statically-named ESM exports, statements like `import { trimEnd } from 'lodash';` are directly emitted by Rollup into the ESM bundle, resulting in

    SyntaxError: The requested module 'lodash' does not provide an export named 'trimEnd'

when `lodash` is imported by an ESM application using the package.

This PR modifies `lodash` named imports in `@backstage/integration` (as well as in other packages which use a similar `exports` map) to use the safe default import style (`import lodash from 'lodash';`) and ensure success when imported via ESM while keeping CommonJS consumers intact.

### Verification

Before:
```
node --input-type=module -e "await import('@backstage/integration')"
# SyntaxError: The requested module 'lodash' does not provide an export named 'trimEnd'
```

After:
```
node --input-type=module -e "await import('@backstage/integration')"
# succeeds, exit code 0
node -e "console.log(Object.keys(require('@backstage/integration')).length)"
# 80 — CJS export count unchanged
```

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
