### PR TITLE
chore(deps): bump nodemailer to ^9.1.1 in notifications-backend-module-email

### DIFF
--- a/plugins/notifications-backend-module-email/package.json
+++ b/plugins/notifications-backend-module-email/package.json
@@ -47,7 +47,7 @@
     "@backstage/plugin-notifications-node": "workspace:^",
     "@backstage/types": "workspace:^",
     "lodash": "^4.17.21",
-    "nodemailer": "^9.0.1",
+    "nodemailer": "^9.1.1",
     "p-throttle": "^4.1.1"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -5719,7 +5719,7 @@ __metadata:
     "@backstage/types": "workspace:^"
     "@types/nodemailer": "npm:^7.0.0"
     lodash: "npm:^4.17.21"
-    nodemailer: "npm:^9.0.1"
+    nodemailer: "npm:^9.1.1"
     p-throttle: "npm:^4.1.1"
   languageName: unknown
   linkType: soft
@@ -36123,10 +36123,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"nodemailer@npm:^9.0.1":
-  version: 9.0.4
-  resolution: "nodemailer@npm:9.0.4"
-  checksum: 10/af8ae3d0846c8904659369b48fc00d09ce8b71fbf59f0541c71c5671f2240803d102d4b533483dde0ec92dceb9b834ff0220d5c149761d13faae62d22b4be2f9
+"nodemailer@npm:^9.1.1":
+  version: 9.1.1
+  resolution: "nodemailer@npm:9.1.1"
+  checksum: 10/d84fd16456a8b1e1f979e65f78f3963819ed0500aaf51544d5da04634ceb0364e5ad7c784793bf7dd7b0028d4bee1d48e5b316394c5c538dbda99f4fc5aa7502
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## What

Bumps the `nodemailer` floor in `@backstage/plugin-notifications-backend-module-email` from `^9.0.1` to `^9.1.1` and updates `yarn.lock` so it resolves to **9.1.1** (was 9.0.4).

## Why

Four Snyk reports flag vulnerable nodemailer resolutions in this package:

- #35594 — Interpretation Conflict via RFC 5322 comment mis-parsing (remediation ≥ 9.1.0)
- #35595 — remediation ≥ 9.1.1
- #35596 — remediation ≥ 9.1.0
- #35597 — remediation ≥ 9.1.0

All four target the same dependency, so this single bump closes them together. `@types/nodemailer` stays at `^7.0.0` (types-only, not affected).

## Notes

- The `yarn.lock` update is exactly what `yarn install` produces for this change: the workspace entry for `plugins/notifications-backend-module-email` now lists `nodemailer: "npm:^9.1.1"`, and the `nodemailer@npm:^9.1.1` checksum was generated with the repo's pinned Yarn 4.8.1 and `compressionLevel: mixed` config (Yarn computes its own archive checksum, distinct from the npm registry integrity — the method was verified by reproducing the existing 9.0.4 entry byte-for-byte).
- `nodemailer` has no other dependents in the monorepo, so this is the only lockfile entry affected.

Fixes #35594, fixes #35595, fixes #35596, fixes #35597