### PR TITLE
fix(catalog): stabilize alpha model layers and verify built-in compatibility

### DIFF
--- a/.changeset/friendly-tables-inherit.md
+++ b/.changeset/friendly-tables-inherit.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-backend': patch
+---
+
+Fixed catalog model relations to inherit the source entity namespace when no default namespace is configured, as documented. Explicit namespaces in entity references and explicitly configured default namespaces continue to take precedence.

--- a/.changeset/quiet-models-stabilize.md
+++ b/.changeset/quiet-models-stabilize.md
@@ -1,0 +1,5 @@
+---
+'@backstage/catalog-model': patch
+---
+
+Fixed several issues in the alpha catalog model layer system. Schema updates now preserve sibling field validation when changing a property named `type`, support deleting inherited fields and constraints, and retain literal JSON values in `const` and `default`. Kind schemas without an explicit root type retain their fields, and invalid combined schemas are rejected during model compilation. Empty kind descriptions and reverse relation titles are now applied correctly.

--- a/packages/catalog-model/report-alpha.api.md
+++ b/packages/catalog-model/report-alpha.api.md
@@ -220,7 +220,6 @@ export interface CatalogModelKindVersionDefinition {
   description?: string;
   name: string | string[];
   relationFields?: CatalogModelKindRelationFieldDefinition[];
-  // (undocumented)
   schema: {
     jsonSchema: JsonObject;
   };

--- a/packages/catalog-model/src/model/compileCatalogModel.relations.test.ts
+++ b/packages/catalog-model/src/model/compileCatalogModel.relations.test.ts
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2026 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { compileCatalogModel } from './compileCatalogModel';
+import { createCatalogModelLayer } from './createCatalogModelLayer';
+
+describe('compileCatalogModel relations', () => {
+  it.each(['Maintains', ''])(
+    'updates the existing reverse relation title to %j without repeating its type',
+    title => {
+      const layer = createCatalogModelLayer({
+        layerId: 'example.com/ownership',
+        builder: model => {
+          model.addRelationPair({
+            fromKind: 'Component',
+            toKind: 'Group',
+            forward: { type: 'ownedBy', title: 'Owned by' },
+            reverse: { type: 'ownerOf', title: 'Owner of' },
+            description: 'Ownership',
+          });
+          model.updateRelationPair({
+            fromKind: 'Component',
+            toKind: 'Group',
+            forward: { type: 'ownedBy' },
+            reverse: { title },
+          });
+        },
+      });
+
+      expect(compileCatalogModel([layer]).listRelations()).toEqual([
+        {
+          fromKind: ['Component'],
+          toKind: ['Group'],
+          forward: { type: 'ownedBy', title: 'Owned by' },
+          reverse: { type: 'ownerOf', title },
+          description: 'Ownership',
+        },
+        {
+          fromKind: ['Group'],
+          toKind: ['Component'],
+          forward: { type: 'ownerOf', title },
+          reverse: { type: 'ownedBy', title: 'Owned by' },
+          description: 'Ownership',
+        },
+      ]);
+    },
+  );
+});

--- a/packages/catalog-model/src/model/compileCatalogModel.schemas.test.ts
+++ b/packages/catalog-model/src/model/compileCatalogModel.schemas.test.ts
@@ -1,0 +1,191 @@
+/*
+ * Copyright 2026 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import Ajv from 'ajv';
+import { JsonObject } from '@backstage/types';
+import { Entity } from '../entity';
+import { compileCatalogModel } from './compileCatalogModel';
+import { createCatalogModelLayer } from './createCatalogModelLayer';
+import { defaultCatalogEntityModel } from './defaultCatalogEntityModel';
+
+function updateComponent(jsonSchema: JsonObject) {
+  return createCatalogModelLayer({
+    layerId: 'example.com/component-update',
+    builder: model =>
+      model.updateKind({
+        names: { kind: 'Component' },
+        versions: [{ name: 'v1alpha1', schema: { jsonSchema } }],
+      }),
+  });
+}
+
+const component = {
+  apiVersion: 'backstage.io/v1alpha1',
+  kind: 'Component',
+  metadata: { name: 'example' },
+  spec: { type: 'service', owner: 'team', lifecycle: 'production' },
+};
+
+describe('compiled catalog model schemas', () => {
+  it('retains built-in field validation when restricting spec.type', () => {
+    const model = compileCatalogModel([
+      defaultCatalogEntityModel,
+      updateComponent({
+        properties: { spec: { properties: { type: { enum: ['service'] } } } },
+      }),
+    ]);
+    const validate = new Ajv({ allowUnionTypes: true }).compile(
+      model.getKind(component)!.jsonSchema,
+    );
+
+    expect(validate(component)).toBe(true);
+    expect(
+      validate({ ...component, spec: { ...component.spec, type: 'website' } }),
+    ).toBe(false);
+    expect(
+      validate({ ...component, spec: { ...component.spec, owner: 7 } }),
+    ).toBe(false);
+    expect(
+      validate({ ...component, spec: { ...component.spec, lifecycle: [] } }),
+    ).toBe(false);
+  });
+
+  it('allows reusing schema fragments in a patch', () => {
+    const shared = { minLength: 2 };
+    const model = compileCatalogModel([
+      defaultCatalogEntityModel,
+      updateComponent({
+        properties: {
+          spec: { properties: { owner: shared, lifecycle: shared } },
+        },
+      }),
+    ]);
+    const validate = new Ajv({ allowUnionTypes: true }).compile(
+      model.getKind(component)!.jsonSchema,
+    );
+
+    expect(validate(component)).toBe(true);
+    expect(
+      validate({ ...component, spec: { ...component.spec, owner: 'a' } }),
+    ).toBe(false);
+    expect(
+      validate({ ...component, spec: { ...component.spec, lifecycle: 'a' } }),
+    ).toBe(false);
+  });
+
+  it('allows patches to remove inherited properties and constraints', () => {
+    const model = compileCatalogModel([
+      defaultCatalogEntityModel,
+      updateComponent({
+        properties: {
+          spec: {
+            required: ['type', 'lifecycle'],
+            properties: { owner: null, type: { minLength: null } },
+          },
+        },
+      }),
+    ]);
+    const schema = model.getKind(component)!.jsonSchema;
+    const validate = new Ajv({ allowUnionTypes: true }).compile(schema);
+    expect(
+      validate({ ...component, spec: { type: '', lifecycle: 'production' } }),
+    ).toBe(true);
+    expect(validate({ ...component, spec: { type: '', lifecycle: [] } })).toBe(
+      false,
+    );
+    expect(schema).toMatchObject({
+      properties: { spec: { properties: { lifecycle: { type: 'string' } } } },
+    });
+    expect((schema.properties as JsonObject).spec).not.toHaveProperty(
+      'properties.owner',
+    );
+  });
+
+  it('rejects invalid final schemas after applying a patch', () => {
+    const update = updateComponent({
+      properties: { spec: { required: 'owner' } },
+    });
+    expect(() =>
+      compileCatalogModel([defaultCatalogEntityModel, update]),
+    ).toThrow(/Invalid JSON schema/);
+  });
+
+  it('preserves the spec of a kind whose root type is omitted', () => {
+    const layer = createCatalogModelLayer({
+      layerId: 'example.com/widget',
+      builder: model =>
+        model.addKind({
+          group: 'example.com',
+          names: { kind: 'Widget', singular: 'widget', plural: 'widgets' },
+          description: 'A widget',
+          versions: [
+            {
+              name: 'v1',
+              schema: {
+                jsonSchema: {
+                  required: ['spec'],
+                  properties: {
+                    spec: {
+                      type: 'object',
+                      required: ['size'],
+                      properties: { size: { type: 'number' } },
+                    },
+                  },
+                },
+              },
+            },
+          ],
+        }),
+    });
+    const entity: Entity = {
+      apiVersion: 'example.com/v1',
+      kind: 'Widget',
+      metadata: { name: 'one' },
+      spec: { size: 3 },
+    };
+    const schema = compileCatalogModel([layer]).getKind(entity)!.jsonSchema;
+    const validate = new Ajv().compile(schema);
+    expect(validate(entity)).toBe(true);
+    expect(validate({ ...entity, spec: { size: 'large' } })).toBe(false);
+    expect(validate({ ...entity, spec: undefined })).toBe(false);
+  });
+
+  it('rejects kind declarations and updates with non-object roots', () => {
+    expect(() =>
+      createCatalogModelLayer({
+        layerId: 'example.com/invalid',
+        builder: model =>
+          model.addKind({
+            group: 'example.com',
+            names: { kind: 'Invalid', singular: 'invalid', plural: 'invalids' },
+            description: 'Invalid',
+            versions: [
+              {
+                name: 'v1',
+                schema: { jsonSchema: { type: 'string', properties: {} } },
+              },
+            ],
+          }),
+      }),
+    ).toThrow(/type.*object/);
+    expect(() =>
+      compileCatalogModel([
+        defaultCatalogEntityModel,
+        updateComponent({ type: 'string' }),
+      ]),
+    ).toThrow(/type.*object/);
+  });
+});

--- a/packages/catalog-model/src/model/compileCatalogModel.ts
+++ b/packages/catalog-model/src/model/compileCatalogModel.ts
@@ -18,6 +18,8 @@ import { InputError } from '@backstage/errors';
 import { JsonObject } from '@backstage/types';
 import lodash from 'lodash';
 import { mergeJsonSchemas } from './jsonSchema/mergeJsonSchemas';
+import { validateMetaSchema } from './jsonSchema/validateMetaSchema';
+import { validateKindRootSchemaSemantics } from './jsonSchema/validateKindRootSchemaSemantics';
 import { CatalogModelOp } from './operations';
 import { ops } from './operations/util';
 import { OpDeclareAnnotationV1 } from './operations/declareAnnotation';
@@ -281,6 +283,13 @@ function applyUpdateRelation(
     relation.forward.title = op.properties.title;
     relation.reverse.title = op.properties.title;
   }
+  if (op.properties.reverseTitle !== undefined) {
+    relation.reverse.title = op.properties.reverseTitle;
+    const reverse = relations.get(relation.reverse.type);
+    if (reverse) {
+      reverse.forward.title = op.properties.reverseTitle;
+    }
+  }
   if (op.properties.description !== undefined) {
     relation.description = op.properties.description;
   }
@@ -423,6 +432,10 @@ function buildFullSchema(options: {
   labels: Map<string, LabelState>;
   tags: Map<string, TagState>;
 }): JsonObject {
+  // Patches may contain deletion markers and are not standalone schemas.
+  // Validate the final kind definition before adding the generated envelope.
+  validateMetaSchema(options.kindSchema);
+  validateKindRootSchemaSemantics(options.kindSchema);
   const annotationProperties: JsonObject = {};
   for (const [name, state] of options.annotations) {
     annotationProperties[name] = state.schema?.jsonSchema ?? { type: 'string' };
@@ -527,7 +540,9 @@ function buildFullSchema(options: {
   // The kind schema is the base, and the generated schema (apiVersion, kind,
   // metadata) takes priority in case of overlap — though they should not
   // overlap in practice.
-  return mergeJsonSchemas(options.kindSchema, generatedSchema);
+  const schema = mergeJsonSchemas(options.kindSchema, generatedSchema);
+  validateMetaSchema(schema);
+  return schema;
 }
 
 // #region Main compilation

--- a/packages/catalog-model/src/model/jsonSchema/mergeJsonSchemas.test.ts
+++ b/packages/catalog-model/src/model/jsonSchema/mergeJsonSchemas.test.ts
@@ -17,6 +17,93 @@
 import { mergeJsonSchemas } from './mergeJsonSchemas';
 
 describe('mergeJsonSchemas', () => {
+  it('preserves literal JSON values inside const and default keywords', () => {
+    expect(
+      mergeJsonSchemas(
+        { const: 'previous', default: 'previous' },
+        { const: null, default: null },
+      ),
+    ).toEqual({ const: null, default: null });
+    expect(
+      mergeJsonSchemas(
+        { const: { type: 'old', name: 'old' } },
+        { const: { type: 'new', nested: null } },
+      ),
+    ).toEqual({ const: { type: 'new', nested: null } });
+    expect(
+      mergeJsonSchemas({}, { properties: { nothing: { const: null } } }),
+    ).toEqual({ properties: { nothing: { const: null } } });
+    expect(
+      mergeJsonSchemas(
+        {},
+        { default: { config: { type: 'data', nullable: null } } },
+      ),
+    ).toEqual({ default: { config: { type: 'data', nullable: null } } });
+  });
+
+  it('preserves sibling schemas when updating a property named type', () => {
+    for (const keyword of [
+      'properties',
+      'patternProperties',
+      'definitions',
+      '$defs',
+    ]) {
+      expect(
+        mergeJsonSchemas(
+          {
+            [keyword]: {
+              type: { type: 'string', minLength: 1 },
+              owner: { type: 'string' },
+            },
+          },
+          { [keyword]: { type: { enum: ['service'] } } },
+        ),
+      ).toEqual({
+        [keyword]: {
+          type: { type: 'string', minLength: 1, enum: ['service'] },
+          owner: { type: 'string' },
+        },
+      });
+    }
+  });
+
+  it('compares union types by value and retains constraints when adding a type', () => {
+    expect(
+      mergeJsonSchemas(
+        { type: ['string', 'null'], minLength: 1 },
+        { type: ['string', 'null'], description: 'updated' },
+      ),
+    ).toEqual({
+      type: ['string', 'null'],
+      minLength: 1,
+      description: 'updated',
+    });
+    expect(
+      mergeJsonSchemas(
+        { properties: { name: { type: 'string' } } },
+        { type: 'object' },
+      ),
+    ).toEqual({ type: 'object', properties: { name: { type: 'string' } } });
+  });
+
+  it('applies deletions inside newly added schemas', () => {
+    expect(
+      mergeJsonSchemas(
+        {},
+        { properties: { spec: { type: 'object', description: null } } },
+      ),
+    ).toEqual({ properties: { spec: { type: 'object' } } });
+  });
+
+  it('retains constraints when equivalent type unions are reordered', () => {
+    expect(
+      mergeJsonSchemas(
+        { type: ['string', 'null'], minLength: 1 },
+        { type: ['null', 'string'] },
+      ),
+    ).toEqual({ type: ['null', 'string'], minLength: 1 });
+  });
+
   it('should merge scalar properties from source into target', () => {
     const result = mergeJsonSchemas(
       { type: 'object', description: 'old' },

--- a/packages/catalog-model/src/model/jsonSchema/mergeJsonSchemas.ts
+++ b/packages/catalog-model/src/model/jsonSchema/mergeJsonSchemas.ts
@@ -15,7 +15,34 @@
  */
 
 import { JsonObject } from '@backstage/types';
+import isEqual from 'lodash/isEqual';
 import { isJsonObject } from './util';
+
+// Values under these keywords are maps of names to schemas, not schemas
+// themselves. In particular, a property named "type" is not a type keyword.
+const schemaMapKeywords = new Set([
+  'properties',
+  'patternProperties',
+  'definitions',
+  '$defs',
+  'dependencies',
+  'dependentSchemas',
+]);
+
+const schemaKeywords = new Set([
+  'additionalProperties',
+  'additionalItems',
+  'items',
+  'contains',
+  'propertyNames',
+  'not',
+  'if',
+  'then',
+  'else',
+  'unevaluatedProperties',
+  'unevaluatedItems',
+  'contentSchema',
+]);
 
 /**
  * Merges two JSON schemas into a single schema.
@@ -30,12 +57,15 @@ import { isJsonObject } from './util';
  * `target` schema. The `target` schema is assumed to be a pre-validated fully
  * valid JSON Schema. The `source` schema is similar, but with one addition -
  * object fields can have the special value `null` which leads to a deletion of
- * the corresponding property in `target` if it existed.
+ * the corresponding property in `target` if it existed. The `const` and
+ * `default` keywords contain literal JSON data and are replaced as-is,
+ * including literal `null` values.
  *
  * If a property `type` is defined in the `source` schema and different from the
- * one in the `target` schema, a full replacement happens at that point. But you
- * can also just define just for example `description` and similar; those just
- * get merged into the existing definition if any.
+ * one explicitly declared in the `target` schema, a full replacement happens
+ * at that schema node. Property-name maps are merged without applying this
+ * rule to properties named `type`. Updates that only define `description` and
+ * similar keywords are merged into the existing definition if any.
  *
  * @param target - The schema to merge into (left unchanged).
  * @param source - The schema to merge from (left unchanged).
@@ -45,20 +75,45 @@ export function mergeJsonSchemas(
   target: JsonObject,
   source: JsonObject,
 ): JsonObject {
-  // If the type field differs, the source schema fully replaces target
-  if ('type' in source && source.type !== target.type) {
-    return { ...source };
-  }
+  return mergeObjects(target, source, 'schema');
+}
 
-  const result: JsonObject = { ...target };
+function mergeObjects(
+  target: JsonObject,
+  source: JsonObject,
+  context: 'schema' | 'map' | 'data',
+): JsonObject {
+  const replacesType =
+    context === 'schema' &&
+    source.type !== undefined &&
+    source.type !== null &&
+    target.type !== undefined &&
+    !isEqual([source.type].flat().sort(), [target.type].flat().sort());
+  const result: JsonObject = replacesType ? {} : { ...target };
 
   for (const [key, value] of Object.entries(source)) {
-    if (value === null) {
+    if (context === 'schema' && (key === 'const' || key === 'default')) {
+      // Literal data is not a schema patch, even when it contains nulls or
+      // properties with names such as "type".
+      result[key] = value;
+    } else if (value === null) {
       // null means delete the property
       delete result[key];
-    } else if (isJsonObject(value) && isJsonObject(result[key])) {
-      // Both sides are objects — recurse
-      result[key] = mergeJsonSchemas(result[key], value);
+    } else if (isJsonObject(value)) {
+      let childContext: 'schema' | 'map' | 'data' = 'data';
+      if (
+        context === 'map' ||
+        (context === 'schema' && schemaKeywords.has(key))
+      ) {
+        childContext = 'schema';
+      } else if (context === 'schema' && schemaMapKeywords.has(key)) {
+        childContext = 'map';
+      }
+      result[key] = mergeObjects(
+        isJsonObject(result[key]) ? result[key] : {},
+        value,
+        childContext,
+      );
     } else {
       // Scalar or array — source overrides target
       result[key] = value;

--- a/packages/catalog-model/src/model/jsonSchema/util.test.ts
+++ b/packages/catalog-model/src/model/jsonSchema/util.test.ts
@@ -58,6 +58,18 @@ describe('isJsonObjectDeep', () => {
     expect(isJsonObjectDeep([1, 2])).toBe(false);
   });
 
+  it('should allow shared objects and arrays without circular references', () => {
+    const sharedObject = { value: 'ok' };
+    const sharedArray = [sharedObject];
+    expect(
+      isJsonObjectDeep({
+        first: sharedObject,
+        second: sharedObject,
+        arrays: [sharedArray, sharedArray],
+      }),
+    ).toBe(true);
+  });
+
   it('should return false when a nested value is a function', () => {
     expect(isJsonObjectDeep({ fn: () => {} })).toBe(false);
   });

--- a/packages/catalog-model/src/model/jsonSchema/util.ts
+++ b/packages/catalog-model/src/model/jsonSchema/util.ts
@@ -31,7 +31,7 @@ export function isJsonObjectDeep(value: unknown): value is JsonObject {
   if (!isJsonObject(value)) {
     return false;
   }
-  const seen = new Set<unknown>();
+  const seen = new Set<unknown>([value]);
   return Object.values(value).every(v => isJsonValueDeep(v, seen));
 }
 
@@ -51,11 +51,9 @@ function isJsonValueDeep(value: unknown, seen: Set<unknown>): boolean {
     return false;
   }
   seen.add(value);
-  if (Array.isArray(value)) {
-    return value.every(v => isJsonValueDeep(v, seen));
-  }
-  if (isJsonObject(value)) {
-    return Object.values(value).every(v => isJsonValueDeep(v, seen));
-  }
-  return false;
+  const result = Array.isArray(value)
+    ? value.every(v => isJsonValueDeep(v, seen))
+    : Object.values(value).every(v => isJsonValueDeep(v, seen));
+  seen.delete(value);
+  return result;
 }

--- a/packages/catalog-model/src/model/jsonSchema/validateKindRootSchemaSemantics.ts
+++ b/packages/catalog-model/src/model/jsonSchema/validateKindRootSchemaSemantics.ts
@@ -110,6 +110,10 @@ export function validateKindRootSchemaSemantics(
     throw new InputError('Schema must be an object');
   }
 
+  if (schema.type !== undefined && schema.type !== 'object') {
+    throw new InputError('Schema root type must be "object"');
+  }
+
   for (const field of FORBIDDEN_SCHEMA_STRUCTURAL_FIELDS) {
     if (field in schema) {
       throw new InputError(

--- a/packages/catalog-model/src/model/modelActions/addKind.ts
+++ b/packages/catalog-model/src/model/modelActions/addKind.ts
@@ -108,6 +108,11 @@ export interface CatalogModelKindVersionDefinition {
    */
   relationFields?: CatalogModelKindRelationFieldDefinition[];
 
+  /**
+   * The entity schema, excluding the generated kind, apiVersion, and metadata
+   * fields. Its root type must be `object` or omitted; an omitted root type is
+   * supplied during compilation.
+   */
   schema: {
     jsonSchema: JsonObject;
   };

--- a/packages/catalog-model/src/model/modelActions/updateKind.test.ts
+++ b/packages/catalog-model/src/model/modelActions/updateKind.test.ts
@@ -15,8 +15,40 @@
  */
 
 import { opsFromCatalogModelUpdateKind } from './updateKind';
+import { compileCatalogModel } from '../compileCatalogModel';
+import { createCatalogModelLayer } from '../createCatalogModelLayer';
 
 describe('opsFromCatalogModelUpdateKind', () => {
+  it('allows clearing a kind description without changing its names', () => {
+    const layer = createCatalogModelLayer({
+      layerId: 'example.com/component',
+      builder: model => {
+        model.addKind({
+          group: 'example.com',
+          names: {
+            kind: 'Component',
+            singular: 'component',
+            plural: 'components',
+          },
+          description: 'Original description',
+        });
+        model.updateKind({ names: { kind: 'Component' }, description: '' });
+      },
+    });
+
+    expect(compileCatalogModel([layer]).listKinds()).toEqual([
+      {
+        names: {
+          kind: 'Component',
+          singular: 'component',
+          plural: 'components',
+        },
+        description: '',
+        versions: [],
+      },
+    ]);
+  });
+
   it('should produce an updateKind op when names are updated', () => {
     const ops = opsFromCatalogModelUpdateKind({
       names: { kind: 'Component', singular: 'comp' },

--- a/packages/catalog-model/src/model/modelActions/updateKind.ts
+++ b/packages/catalog-model/src/model/modelActions/updateKind.ts
@@ -16,7 +16,6 @@
 
 import { JsonObject } from '@backstage/types';
 import { reduceKindSchema } from '../jsonSchema/reduceKindSchema';
-import { validateMetaSchema } from '../jsonSchema/validateMetaSchema';
 import { CatalogModelOp } from '../operations';
 import { createUpdateKindOp } from '../operations/updateKind';
 import { createUpdateKindVersionOp } from '../operations/updateKindVersion';
@@ -93,6 +92,11 @@ export interface CatalogModelUpdateKindVersionDefinition {
 
   /**
    * The JSON schema to deep merge with the existing schema for this version.
+   * Object fields set to `null` delete the corresponding inherited field.
+   * Values of `const` and `default` are literal JSON data, so `null` is
+   * retained for those keywords rather than interpreted as a deletion.
+   * Arrays replace the inherited array in full. The resulting schema is
+   * validated when the model is compiled.
    */
   schema?: {
     jsonSchema: JsonObject;
@@ -104,7 +108,11 @@ export function opsFromCatalogModelUpdateKind(
 ): CatalogModelOp[] {
   const ops: CatalogModelOp[] = [];
 
-  if (kind.names.singular || kind.names.plural || kind.description) {
+  if (
+    kind.names.singular !== undefined ||
+    kind.names.plural !== undefined ||
+    kind.description !== undefined
+  ) {
     ops.push(
       createUpdateKindOp({
         kind: kind.names.kind,
@@ -121,9 +129,6 @@ export function opsFromCatalogModelUpdateKind(
     const jsonSchema = version.schema
       ? reduceKindSchema(version.schema.jsonSchema)
       : undefined;
-    if (jsonSchema) {
-      validateMetaSchema(jsonSchema);
-    }
     const names = Array.isArray(version.name) ? version.name : [version.name];
     for (const name of names) {
       const specTypes = version.specType?.length

--- a/packages/catalog-model/src/model/modelActions/updateRelationPair.ts
+++ b/packages/catalog-model/src/model/modelActions/updateRelationPair.ts
@@ -63,8 +63,9 @@ export interface CatalogModelUpdateRelationPairDefinition {
    */
   reverse: {
     /**
-     * The technical type of the relation, e.g. "ownerOf". Specify this if you
-     * want to override the default value.
+     * The technical type of an existing reverse relation, e.g. "ownerOf".
+     * If omitted, title updates apply to the currently declared reverse
+     * relation.
      */
     type?: string;
     /**
@@ -90,6 +91,9 @@ export function opsFromCatalogModelUpdateRelationPair(
           toKind: secondKind,
           properties: {
             reverseType: relationPair.reverse.type,
+            reverseTitle: relationPair.reverse.type
+              ? undefined
+              : relationPair.reverse.title,
             title: relationPair.forward.title,
             description: relationPair.description,
           },

--- a/packages/catalog-model/src/model/operations/updateKindVersion.ts
+++ b/packages/catalog-model/src/model/operations/updateKindVersion.ts
@@ -15,7 +15,7 @@
  */
 
 import { z } from 'zod/v3';
-import { jsonSchemaSchema } from '../jsonSchema/zod';
+import { jsonObjectSchema } from '../jsonSchema/zod';
 
 const relationFieldSchema = z.strictObject({
   /**
@@ -104,10 +104,12 @@ export const opUpdateKindVersionV1Schema = z.strictObject({
      *
      * This schema gets deep merged with the default one for this version. It
      * can therefore be used for both amending and changing existing fields.
+     * Null-valued object fields delete inherited fields. Validation of the
+     * resulting JSON schema takes place during model compilation.
      */
     schema: z
       .strictObject({
-        jsonSchema: jsonSchemaSchema,
+        jsonSchema: jsonObjectSchema,
       })
       .optional(),
   }),

--- a/packages/catalog-model/src/model/operations/updateRelation.ts
+++ b/packages/catalog-model/src/model/operations/updateRelation.ts
@@ -51,6 +51,10 @@ export const opUpdateRelationV1Schema = z.strictObject({
      */
     reverseType: z.string().optional(),
     /**
+     * A human-readable title for the currently declared reverse relation.
+     */
+    reverseTitle: z.string().optional(),
+    /**
      * A human-readable title for the relation type, e.g. "owned by".
      */
     title: z.string().optional(),

--- a/plugins/catalog-backend/src/processors/ModelProcessor.compatibility.test.ts
+++ b/plugins/catalog-backend/src/processors/ModelProcessor.compatibility.test.ts
@@ -26,6 +26,8 @@ import { ModelProcessor } from './ModelProcessor';
 const fixtures: Array<{
   kind: string;
   spec: Entity['spec'];
+  requiredSpecFields: string[];
+  invalidSpecOverrides: NonNullable<Entity['spec']>[];
   relations: Array<{
     forward: string;
     reverse: string;
@@ -36,6 +38,14 @@ const fixtures: Array<{
 }> = [
   {
     kind: 'Component',
+    requiredSpecFields: ['type', 'lifecycle', 'owner'],
+    invalidSpecOverrides: [
+      { type: 7 },
+      { lifecycle: '' },
+      { owner: 7 },
+      { providesApis: 'api-a' },
+      { providesApis: ['api-a', 7] },
+    ],
     spec: {
       type: 'service',
       lifecycle: 'production',
@@ -91,6 +101,8 @@ const fixtures: Array<{
   },
   {
     kind: 'API',
+    requiredSpecFields: ['type', 'lifecycle', 'owner', 'definition'],
+    invalidSpecOverrides: [{ owner: '' }, { definition: 7 }],
     spec: {
       type: 'openapi',
       lifecycle: 'production',
@@ -111,6 +123,8 @@ const fixtures: Array<{
   },
   {
     kind: 'Resource',
+    requiredSpecFields: ['type', 'owner'],
+    invalidSpecOverrides: [{ owner: 7 }, { dependsOn: ['resource-a', ''] }],
     spec: {
       type: 'database',
       owner: 'team',
@@ -137,6 +151,8 @@ const fixtures: Array<{
   },
   {
     kind: 'System',
+    requiredSpecFields: ['owner'],
+    invalidSpecOverrides: [{ owner: '' }, { domain: 7 }],
     spec: { owner: 'team', domain: 'domain' },
     relations: [
       { forward: 'ownedBy', reverse: 'ownerOf', kind: 'Group', name: 'team' },
@@ -145,6 +161,8 @@ const fixtures: Array<{
   },
   {
     kind: 'Domain',
+    requiredSpecFields: ['owner'],
+    invalidSpecOverrides: [{ owner: 7 }, { subdomainOf: '' }],
     spec: { owner: 'team', subdomainOf: 'parent' },
     relations: [
       { forward: 'ownedBy', reverse: 'ownerOf', kind: 'Group', name: 'team' },
@@ -153,6 +171,12 @@ const fixtures: Array<{
   },
   {
     kind: 'Group',
+    requiredSpecFields: ['type', 'children'],
+    invalidSpecOverrides: [
+      { children: 'child' },
+      { children: ['child', 7] },
+      { profile: { displayName: 7 } },
+    ],
     spec: {
       type: 'team',
       parent: 'parent',
@@ -194,6 +218,12 @@ const fixtures: Array<{
   },
   {
     kind: 'User',
+    requiredSpecFields: ['memberOf'],
+    invalidSpecOverrides: [
+      { memberOf: 'team' },
+      { memberOf: ['team', ''] },
+      { profile: { email: 7 } },
+    ],
     spec: { memberOf: ['team-b', 'team-a'] },
     relations: [
       {
@@ -212,12 +242,74 @@ const fixtures: Array<{
   },
   {
     kind: 'Location',
+    requiredSpecFields: [],
+    invalidSpecOverrides: [
+      { target: 7 },
+      { targets: ['https://example.com/valid.yaml', ''] },
+      { presence: 'sometimes' },
+    ],
     spec: { type: 'url', target: 'https://example.com/catalog-info.yaml' },
     relations: [],
   },
 ];
 
 describe('ModelProcessor compatibility with built-in kinds', () => {
+  it.each(fixtures)(
+    'rejects malformed $kind entities across versions and namespaces like the legacy processor',
+    async ({ kind, spec, requiredSpecFields, invalidSpecOverrides }) => {
+      const processors = [
+        new ModelProcessor(
+          ModelHolder.modelPassthroughForTest(
+            compileCatalogModel([defaultCatalogEntityModel]),
+          ),
+        ),
+        new BuiltinKindsEntityProcessor(),
+      ];
+
+      for (const apiVersion of [
+        'backstage.io/v1alpha1',
+        'backstage.io/v1beta1',
+      ]) {
+        for (const namespace of [undefined, 'custom-ns']) {
+          const valid: Entity = {
+            apiVersion,
+            kind,
+            metadata: { name: 'entity', ...(namespace ? { namespace } : {}) },
+            spec,
+          };
+          const invalidEntities: Entity[] = [
+            { ...valid, spec: undefined },
+            { ...valid, metadata: { ...valid.metadata, name: '' } },
+            ...requiredSpecFields.map(field => {
+              const incompleteSpec = { ...spec };
+              delete incompleteSpec[field];
+              return { ...valid, spec: incompleteSpec };
+            }),
+            ...invalidSpecOverrides.map(overrides => ({
+              ...valid,
+              spec: { ...spec, ...overrides },
+            })),
+          ];
+
+          for (const processor of processors) {
+            for (const input of invalidEntities) {
+              const entity = await processor.preProcessEntity(
+                structuredClone(input),
+              );
+              await expect(
+                processor.validateEntityKind(entity),
+              ).rejects.toThrow(TypeError);
+            }
+            // Rejected inputs must not poison a cached validator for valid data.
+            await expect(
+              processor.validateEntityKind(structuredClone(valid)),
+            ).resolves.toBe(true);
+          }
+        }
+      }
+    },
+  );
+
   it.each(fixtures)(
     'processes $kind across versions and namespaces like the legacy processor',
     async ({ kind, spec, relations }) => {

--- a/plugins/catalog-backend/src/processors/ModelProcessor.compatibility.test.ts
+++ b/plugins/catalog-backend/src/processors/ModelProcessor.compatibility.test.ts
@@ -1,0 +1,297 @@
+/*
+ * Copyright 2026 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Entity } from '@backstage/catalog-model';
+import {
+  compileCatalogModel,
+  defaultCatalogEntityModel,
+} from '@backstage/catalog-model/alpha';
+import { ModelHolder } from '../model/ModelHolder';
+import { BuiltinKindsEntityProcessor } from './BuiltinKindsEntityProcessor';
+import { ModelProcessor } from './ModelProcessor';
+
+const fixtures: Array<{
+  kind: string;
+  spec: Entity['spec'];
+  relations: Array<{
+    forward: string;
+    reverse: string;
+    kind: string;
+    name: string;
+    namespace?: string;
+  }>;
+}> = [
+  {
+    kind: 'Component',
+    spec: {
+      type: 'service',
+      lifecycle: 'production',
+      owner: 'team',
+      subcomponentOf: 'parent',
+      providesApis: ['api-b', 'api-a'],
+      consumesApis: ['API:external/consumed-api'],
+      dependsOn: ['Resource:database'],
+      dependencyOf: ['Component:dependent'],
+      system: 'system',
+    },
+    relations: [
+      { forward: 'ownedBy', reverse: 'ownerOf', kind: 'Group', name: 'team' },
+      {
+        forward: 'partOf',
+        reverse: 'hasPart',
+        kind: 'Component',
+        name: 'parent',
+      },
+      {
+        forward: 'providesApi',
+        reverse: 'apiProvidedBy',
+        kind: 'API',
+        name: 'api-a',
+      },
+      {
+        forward: 'providesApi',
+        reverse: 'apiProvidedBy',
+        kind: 'API',
+        name: 'api-b',
+      },
+      {
+        forward: 'consumesApi',
+        reverse: 'apiConsumedBy',
+        kind: 'API',
+        name: 'consumed-api',
+        namespace: 'external',
+      },
+      {
+        forward: 'dependsOn',
+        reverse: 'dependencyOf',
+        kind: 'Resource',
+        name: 'database',
+      },
+      {
+        forward: 'dependencyOf',
+        reverse: 'dependsOn',
+        kind: 'Component',
+        name: 'dependent',
+      },
+      { forward: 'partOf', reverse: 'hasPart', kind: 'System', name: 'system' },
+    ],
+  },
+  {
+    kind: 'API',
+    spec: {
+      type: 'openapi',
+      lifecycle: 'production',
+      owner: 'User:external/owner',
+      definition: 'openapi: 3.0.0',
+      system: 'system',
+    },
+    relations: [
+      {
+        forward: 'ownedBy',
+        reverse: 'ownerOf',
+        kind: 'User',
+        name: 'owner',
+        namespace: 'external',
+      },
+      { forward: 'partOf', reverse: 'hasPart', kind: 'System', name: 'system' },
+    ],
+  },
+  {
+    kind: 'Resource',
+    spec: {
+      type: 'database',
+      owner: 'team',
+      dependsOn: ['Resource:infrastructure'],
+      dependencyOf: ['Component:consumer'],
+      system: 'system',
+    },
+    relations: [
+      { forward: 'ownedBy', reverse: 'ownerOf', kind: 'Group', name: 'team' },
+      {
+        forward: 'dependsOn',
+        reverse: 'dependencyOf',
+        kind: 'Resource',
+        name: 'infrastructure',
+      },
+      {
+        forward: 'dependencyOf',
+        reverse: 'dependsOn',
+        kind: 'Component',
+        name: 'consumer',
+      },
+      { forward: 'partOf', reverse: 'hasPart', kind: 'System', name: 'system' },
+    ],
+  },
+  {
+    kind: 'System',
+    spec: { owner: 'team', domain: 'domain' },
+    relations: [
+      { forward: 'ownedBy', reverse: 'ownerOf', kind: 'Group', name: 'team' },
+      { forward: 'partOf', reverse: 'hasPart', kind: 'Domain', name: 'domain' },
+    ],
+  },
+  {
+    kind: 'Domain',
+    spec: { owner: 'team', subdomainOf: 'parent' },
+    relations: [
+      { forward: 'ownedBy', reverse: 'ownerOf', kind: 'Group', name: 'team' },
+      { forward: 'partOf', reverse: 'hasPart', kind: 'Domain', name: 'parent' },
+    ],
+  },
+  {
+    kind: 'Group',
+    spec: {
+      type: 'team',
+      parent: 'parent',
+      children: ['child-b', 'child-a'],
+      members: ['user-b', 'user-a'],
+    },
+    relations: [
+      {
+        forward: 'childOf',
+        reverse: 'parentOf',
+        kind: 'Group',
+        name: 'parent',
+      },
+      {
+        forward: 'parentOf',
+        reverse: 'childOf',
+        kind: 'Group',
+        name: 'child-a',
+      },
+      {
+        forward: 'parentOf',
+        reverse: 'childOf',
+        kind: 'Group',
+        name: 'child-b',
+      },
+      {
+        forward: 'hasMember',
+        reverse: 'memberOf',
+        kind: 'User',
+        name: 'user-a',
+      },
+      {
+        forward: 'hasMember',
+        reverse: 'memberOf',
+        kind: 'User',
+        name: 'user-b',
+      },
+    ],
+  },
+  {
+    kind: 'User',
+    spec: { memberOf: ['team-b', 'team-a'] },
+    relations: [
+      {
+        forward: 'memberOf',
+        reverse: 'hasMember',
+        kind: 'Group',
+        name: 'team-a',
+      },
+      {
+        forward: 'memberOf',
+        reverse: 'hasMember',
+        kind: 'Group',
+        name: 'team-b',
+      },
+    ],
+  },
+  {
+    kind: 'Location',
+    spec: { type: 'url', target: 'https://example.com/catalog-info.yaml' },
+    relations: [],
+  },
+];
+
+describe('ModelProcessor compatibility with built-in kinds', () => {
+  it.each(fixtures)(
+    'processes $kind across versions and namespaces like the legacy processor',
+    async ({ kind, spec, relations }) => {
+      const processor = new ModelProcessor(
+        ModelHolder.modelPassthroughForTest(
+          compileCatalogModel([defaultCatalogEntityModel]),
+        ),
+      );
+      const legacyProcessor = new BuiltinKindsEntityProcessor();
+      const location = {
+        type: 'url',
+        target: 'https://example.com/catalog-info.yaml',
+      };
+
+      for (const apiVersion of [
+        'backstage.io/v1alpha1',
+        'backstage.io/v1beta1',
+      ]) {
+        for (const namespace of [undefined, 'custom-ns']) {
+          const input: Entity = {
+            apiVersion,
+            kind,
+            metadata: { name: 'entity', ...(namespace ? { namespace } : {}) },
+            spec,
+          };
+          const entity = await processor.preProcessEntity(
+            structuredClone(input),
+          );
+          const legacyEntity = await legacyProcessor.preProcessEntity(
+            structuredClone(input),
+          );
+          expect(entity).toEqual(legacyEntity);
+          await expect(processor.validateEntityKind(entity)).resolves.toBe(
+            true,
+          );
+          await expect(
+            legacyProcessor.validateEntityKind(legacyEntity),
+          ).resolves.toBe(true);
+
+          const emit = jest.fn();
+          const legacyEmit = jest.fn();
+          await expect(
+            processor.postProcessEntity(entity, location, emit),
+          ).resolves.toEqual(entity);
+          await legacyProcessor.postProcessEntity(
+            legacyEntity,
+            location,
+            legacyEmit,
+          );
+
+          const source = {
+            kind,
+            namespace: namespace ?? 'default',
+            name: 'entity',
+          };
+          const expected = relations.flatMap(relation => {
+            const target = {
+              kind: relation.kind,
+              namespace: relation.namespace ?? namespace ?? 'default',
+              name: relation.name,
+            };
+            return [
+              { source, type: relation.forward, target },
+              { source: target, type: relation.reverse, target: source },
+            ];
+          });
+          for (const emitted of [emit.mock.calls, legacyEmit.mock.calls]) {
+            expect(emitted).toHaveLength(expected.length);
+            expect(emitted.map(([result]) => result.relation)).toEqual(
+              expect.arrayContaining(expected),
+            );
+          }
+        }
+      }
+    },
+  );
+});

--- a/plugins/catalog-backend/src/processors/ModelProcessor.test.ts
+++ b/plugins/catalog-backend/src/processors/ModelProcessor.test.ts
@@ -20,6 +20,7 @@ import {
   CatalogModelKind,
   CatalogModelRelation,
   compileCatalogModel,
+  createCatalogModelLayer,
   defaultCatalogEntityModel,
 } from '@backstage/catalog-model/alpha';
 import { ModelProcessor } from './ModelProcessor';
@@ -442,55 +443,80 @@ describe('ModelProcessor', () => {
       );
     });
 
-    it('uses defaultNamespace inherit to pick the entity namespace', async () => {
-      const processor = new ModelProcessor(createModel());
-      const emit = jest.fn();
-      const entity = createEntity({
-        type: 'service',
-        lifecycle: 'production',
-        owner: 'my-team',
-      });
-      entity.metadata.namespace = 'custom-ns';
+    it('resolves relation namespaces from model defaults and explicit references', async () => {
+      for (const [defaultNamespace, shorthandNamespace] of [
+        [undefined, 'custom-ns'],
+        ['inherit', 'custom-ns'],
+        ['default', 'default'],
+      ] as const) {
+        const layer = createCatalogModelLayer({
+          layerId: 'test/owner-namespace',
+          builder: builder => {
+            builder.updateKind({
+              names: { kind: 'Component' },
+              versions: [
+                {
+                  name: 'v1alpha1',
+                  relationFields: [
+                    {
+                      selector: { path: 'spec.owner' },
+                      relation: 'ownedBy',
+                      defaultKind: 'Group',
+                      defaultNamespace,
+                    },
+                  ],
+                },
+              ],
+            });
+          },
+        });
+        const processor = new ModelProcessor(
+          ModelHolder.modelPassthroughForTest(
+            compileCatalogModel([defaultCatalogEntityModel, layer]),
+          ),
+        );
 
-      await processor.postProcessEntity(entity, location, emit);
+        for (const [owner, entityNamespace, targetNamespace, targetKind] of [
+          ['my-team', 'custom-ns', shorthandNamespace, 'Group'],
+          ['group:other-ns/my-team', 'custom-ns', 'other-ns', 'group'],
+          ['my-team', undefined, 'default', 'Group'],
+        ] as const) {
+          const entity = createEntity({
+            type: 'service',
+            lifecycle: 'production',
+            owner,
+          });
+          entity.metadata.namespace = entityNamespace;
+          const emit = jest.fn();
 
-      expect(emit).toHaveBeenCalledWith(
-        expect.objectContaining({
-          type: 'relation',
-          relation: expect.objectContaining({
-            type: 'ownedBy',
-            target: { kind: 'Group', namespace: 'custom-ns', name: 'my-team' },
-          }),
-        }),
-      );
-    });
+          await processor.postProcessEntity(entity, location, emit);
 
-    it('uses default namespace when defaultNamespace is not inherit', async () => {
-      const processor = new ModelProcessor(createModel());
-      const emit = jest.fn();
-      const entity = createEntity({
-        type: 'service',
-        lifecycle: 'production',
-        owner: 'my-team',
-        dependsOn: ['service-a'],
-      });
-      entity.metadata.namespace = 'custom-ns';
-
-      await processor.postProcessEntity(entity, location, emit);
-
-      expect(emit).toHaveBeenCalledWith(
-        expect.objectContaining({
-          type: 'relation',
-          relation: expect.objectContaining({
-            type: 'dependsOn',
-            target: {
-              kind: 'Component',
-              namespace: 'default',
-              name: 'service-a',
-            },
-          }),
-        }),
-      );
+          const source = {
+            kind: 'Component',
+            namespace: entityNamespace ?? 'default',
+            name: 'my-component',
+          };
+          const target = {
+            kind: targetKind,
+            namespace: targetNamespace,
+            name: 'my-team',
+          };
+          expect(emit.mock.calls).toEqual([
+            [
+              {
+                type: 'relation',
+                relation: { source, type: 'ownedBy', target },
+              },
+            ],
+            [
+              {
+                type: 'relation',
+                relation: { source: target, type: 'ownerOf', target: source },
+              },
+            ],
+          ]);
+        }
+      }
     });
 
     it('handles entities with no spec gracefully', async () => {

--- a/plugins/catalog-backend/src/processors/ModelProcessor.ts
+++ b/plugins/catalog-backend/src/processors/ModelProcessor.ts
@@ -86,6 +86,8 @@ export class ModelProcessor implements CatalogProcessor {
    * For all fields in the entity that the model says are relations: if the
    * field is a string or an array of strings, emit both the forward and reverse
    * relations that the model says apply for it.
+   * References without a namespace inherit the entity namespace unless the
+   * relation field explicitly selects the default namespace.
    */
   async postProcessEntity(
     entity: Entity,
@@ -116,9 +118,9 @@ export class ModelProcessor implements CatalogProcessor {
         const targetRef = parseEntityRef(shorthandRef, {
           defaultKind: fieldModel.defaultKind,
           defaultNamespace:
-            fieldModel.defaultNamespace === 'inherit'
-              ? selfNamespace
-              : DEFAULT_NAMESPACE,
+            fieldModel.defaultNamespace === 'default'
+              ? DEFAULT_NAMESPACE
+              : selfNamespace,
         });
 
         const targetKind = targetRef.kind.toLowerCase();

--- a/plugins/catalog-backend/src/processors/SchemaValidator.test.ts
+++ b/plugins/catalog-backend/src/processors/SchemaValidator.test.ts
@@ -32,6 +32,31 @@ const schema = {
 };
 
 describe('SchemaValidator', () => {
+  it('resolves local and root-ID references independently for each schema', () => {
+    const validator = new SchemaValidator();
+    const createSchema = (minimum: number) => ({
+      $id: 'https://example.com/widget',
+      type: 'object',
+      definitions: { size: { type: 'number', minimum } },
+      properties: {
+        local: { $ref: '#/definitions/size' },
+        absolute: { $ref: 'https://example.com/widget#/definitions/size' },
+      },
+    });
+    const original = createSchema(1);
+    const stricter = createSchema(5);
+
+    expect(validator.validate(original, { local: 3, absolute: 3 })).toEqual([]);
+    expect(validator.validate(stricter, { local: 5, absolute: 5 })).toEqual([]);
+    expect(validator.validate(stricter, { local: 3, absolute: 5 })).not.toEqual(
+      [],
+    );
+    expect(validator.validate(stricter, { local: 5, absolute: 3 })).not.toEqual(
+      [],
+    );
+    expect(validator.validate(original, { local: 3, absolute: 3 })).toEqual([]);
+  });
+
   it('returns no errors for valid data', () => {
     const validator = new SchemaValidator();
     const errors = validator.validate(schema, {


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

Fixes existing bugs in the alpha catalog model layer system:

- Preserve schema constraints when patching fields named `type`, handle equivalent type unions, support deletion patches and shared schema fragments, and validate the combined kind schema.
- Apply empty kind descriptions and reverse relation titles, and inherit the source namespace when a relation field leaves its namespace policy unspecified.
- Add compatibility coverage through the real model compiler and processors for all eight built-in kinds, both API versions, namespaces, and forward/reverse relations, compared with the legacy processor. Includes rejection of malformed entities and validation of good entities after failures.

Builds on @GabDug's merged fix in #34552, with additional local/absolute self-reference regression coverage. The prerequisite commit is now on master and is not included in this PR's diff.

Verified: 1,010 tests across catalog-model and the catalog backend processors, root `yarn tsc`, `yarn lint --fix`, and full `yarn build:api-reports`.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
