### PR TITLE
feat(errors): add includeCause option to stringifyError

### DIFF
--- a/.changeset/errors-stringify-include-cause.md
+++ b/.changeset/errors-stringify-include-cause.md
@@ -1,0 +1,5 @@
+---
+'@backstage/errors': minor
+---
+
+Added an `includeCause` option to `stringifyError`. When enabled, the returned string includes the chain of underlying error causes, each separated by `'; caused by: '`, which makes it easier to log the full context behind a failure. The default behavior is unchanged and only stringifies the outermost error.

--- a/.changeset/errors-stringify-include-cause.md
+++ b/.changeset/errors-stringify-include-cause.md
@@ -2,4 +2,4 @@
 '@backstage/errors': minor
 ---
 
-Added an `includeCause` option to `stringifyError`. When enabled, the returned string includes the chain of underlying error causes, each separated by `'; caused by: '`, which makes it easier to log the full context behind a failure. The default behavior is unchanged and only stringifies the outermost error.
+Added an `includeCause` option to `stringifyError`. When enabled, the returned string includes the chain of underlying error causes, each separated by `'; caused by: '`, which makes it easier to log the full context behind a failure. The default behavior is unchanged and only includes the outermost error.

--- a/packages/errors/report.api.md
+++ b/packages/errors/report.api.md
@@ -157,7 +157,12 @@ export class ServiceUnavailableError extends CustomErrorBase {
 }
 
 // @public
-export function stringifyError(error: unknown): string;
+export function stringifyError(
+  error: unknown,
+  options?: {
+    includeCause?: boolean;
+  },
+): string;
 
 // @public
 export function toError(value: unknown): ErrorLike;

--- a/packages/errors/src/serialization/error.test.ts
+++ b/packages/errors/src/serialization/error.test.ts
@@ -112,4 +112,44 @@ describe('serialization', () => {
     expect(stringifyError(new Error('m3'))).toEqual('Error: m3');
     expect(stringifyError(new TypeError('m4'))).toEqual('TypeError: m4');
   });
+
+  it('appends the cause chain only when includeCause is set', () => {
+    const leaf = new Error('leaf');
+    const middle = new Error('middle', { cause: leaf });
+    const root = new Error('root', { cause: middle });
+
+    // By default and with includeCause disabled, only the outermost error is
+    // stringified and the cause chain is dropped.
+    expect(stringifyError(root)).toEqual('Error: root');
+    expect(stringifyError(root, { includeCause: false })).toEqual(
+      'Error: root',
+    );
+
+    // With includeCause enabled, every level of the chain is appended.
+    expect(stringifyError(root, { includeCause: true })).toEqual(
+      'Error: root; caused by: Error: middle; caused by: Error: leaf',
+    );
+
+    // An error without a cause is unchanged by the option.
+    expect(stringifyError(new Error('solo'), { includeCause: true })).toEqual(
+      'Error: solo',
+    );
+
+    // Non-error causes and non-error inputs are stringified with the same
+    // fallback used for the outermost value.
+    const withStringCause = new Error('wrap', { cause: 'boom' });
+    expect(stringifyError(withStringCause, { includeCause: true })).toEqual(
+      "Error: wrap; caused by: unknown error 'boom'",
+    );
+    expect(stringifyError('plain', { includeCause: true })).toEqual(
+      "unknown error 'plain'",
+    );
+
+    // A cyclic cause chain terminates instead of looping forever.
+    const cyclic: Error & { cause?: unknown } = new Error('cyclic');
+    cyclic.cause = cyclic;
+    expect(stringifyError(cyclic, { includeCause: true })).toEqual(
+      'Error: cyclic',
+    );
+  });
 });

--- a/packages/errors/src/serialization/error.ts
+++ b/packages/errors/src/serialization/error.ts
@@ -89,12 +89,10 @@ export function deserializeError<T extends Error = Error>(
 }
 
 /**
- * Stringifies an error, including its name and message where available.
- *
- * @param error - The error.
- * @public
+ * Stringifies a single error, using its name and message where available and
+ * falling back to a generic representation otherwise.
  */
-export function stringifyError(error: unknown): string {
+function stringifyOne(error: unknown): string {
   if (isError(error)) {
     // Prefer error.toString, but if it's not implemented we use a nicer fallback
     const str = String(error);
@@ -102,4 +100,53 @@ export function stringifyError(error: unknown): string {
   }
 
   return `unknown error '${error}'`;
+}
+
+/**
+ * Stringifies an error, including its name and message where available.
+ *
+ * @remarks
+ *
+ * When the `includeCause` option is set, the chain of underlying causes is
+ * appended to the output, each separated by `'; caused by: '`. The chain
+ * traversal is bounded and safe against cyclic causes. The default behavior,
+ * with no options, only stringifies the outermost error.
+ *
+ * @param error - The error.
+ * @param options - Optional stringification options.
+ * @public
+ * @example
+ *
+ * ```ts
+ * const err = new Error('failed to load', { cause: new Error('timeout') });
+ * stringifyError(err);
+ * // 'Error: failed to load'
+ * stringifyError(err, { includeCause: true });
+ * // 'Error: failed to load; caused by: Error: timeout'
+ * ```
+ */
+export function stringifyError(
+  error: unknown,
+  options?: {
+    /** Append the chain of underlying error causes to the output (default false) */
+    includeCause?: boolean;
+  },
+): string {
+  if (!options?.includeCause) {
+    return stringifyOne(error);
+  }
+
+  const parts: string[] = [];
+  const seen = new Set<unknown>();
+  let current: unknown = error;
+  while (current !== undefined && current !== null && !seen.has(current)) {
+    seen.add(current);
+    parts.push(stringifyOne(current));
+    current =
+      typeof current === 'object'
+        ? (current as { cause?: unknown }).cause
+        : undefined;
+  }
+
+  return parts.join('; caused by: ');
 }


### PR DESCRIPTION
Adds an opt-in `includeCause` option to `stringifyError` in `@backstage/errors`. Today `stringifyError` only renders the outermost error, so the underlying cause chain is silently dropped from logs. With `{ includeCause: true }` the full chain is appended, each level separated by `'; caused by: '`.

The default behavior is unchanged callers that don't pass the option get exactly the same output as before. Traversal is bounded and guards against cyclic causes, and non-error causes fall back to the same representation used for the outermost value.

```ts
const err = new Error('failed to load', { cause: new Error('timeout') });
stringifyError(err);
// 'Error: failed to load'
stringifyError(err, { includeCause: true });
// 'Error: failed to load; caused by: Error: timeout'
```

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))