### PR TITLE
fix(filter-predicates): gracefully handle malformed operator operands

### DIFF
--- a/.changeset/filter-predicates-guard-malformed-operands.md
+++ b/.changeset/filter-predicates-guard-malformed-operands.md
@@ -2,4 +2,4 @@
 '@backstage/filter-predicates': patch
 ---
 
-Filter predicates that use `$in` with a non-array value, or `$hasPrefix` with a non-string value, now simply fail to match instead of throwing an error. This makes evaluation more robust when predicates come from JSON or other sources where the value types are not guaranteed.
+Filter predicates now fail to match gracefully instead of throwing an error when an operator is given a value of an unexpected type. This applies to `$in` and `$all`/`$any` used with a non-array value, and `$hasPrefix` used with a non-string value. This makes evaluation more robust when predicates come from JSON or other sources where the value types are not guaranteed.

--- a/.changeset/filter-predicates-guard-malformed-operands.md
+++ b/.changeset/filter-predicates-guard-malformed-operands.md
@@ -1,0 +1,5 @@
+---
+'@backstage/filter-predicates': patch
+---
+
+Filter predicates that use `$in` with a non-array value, or `$hasPrefix` with a non-string value, now simply fail to match instead of throwing an error. This makes evaluation more robust when predicates come from JSON or other sources where the value types are not guaranteed.

--- a/packages/filter-predicates/src/predicates/evaluate.test.ts
+++ b/packages/filter-predicates/src/predicates/evaluate.test.ts
@@ -288,4 +288,51 @@ describe('evaluate', () => {
     expect(filterPredicateToFilterFunction(operator)(entities[0])).toBe(false);
     expect(filterPredicateToFilterFunction(value)(entities[0])).toBe(false);
   });
+
+  it('gracefully handles malformed value operators', () => {
+    // A non-array $in operand must not match anything and must not throw.
+    const nonArrayIn = {
+      'spec.type': { $in: 'service' },
+    } as unknown as FilterPredicate;
+    for (const entity of entities) {
+      expect(() => evaluateFilterPredicate(nonArrayIn, entity)).not.toThrow();
+      expect(evaluateFilterPredicate(nonArrayIn, entity)).toBe(false);
+      expect(filterPredicateToFilterFunction(nonArrayIn)(entity)).toBe(false);
+    }
+
+    // A non-string $hasPrefix operand must not match anything and must not throw.
+    const nonStringHasPrefix = {
+      'spec.type': { $hasPrefix: 1 },
+    } as unknown as FilterPredicate;
+    for (const entity of entities) {
+      expect(() =>
+        evaluateFilterPredicate(nonStringHasPrefix, entity),
+      ).not.toThrow();
+      expect(evaluateFilterPredicate(nonStringHasPrefix, entity)).toBe(false);
+      expect(filterPredicateToFilterFunction(nonStringHasPrefix)(entity)).toBe(
+        false,
+      );
+    }
+
+    // The guards must not regress the happy path: a valid case-insensitive
+    // $hasPrefix and a valid $in still match.
+    const validHasPrefix: FilterPredicate = {
+      'spec.type': { $hasPrefix: 'G' },
+    };
+    expect(
+      entities
+        .filter(entity => evaluateFilterPredicate(validHasPrefix, entity))
+        .map(e => e.metadata.name),
+    ).toEqual(['a']);
+
+    const validIn: FilterPredicate = {
+      'spec.type': { $in: ['service', 'website'] },
+    };
+    expect(
+      entities
+        .filter(entity => evaluateFilterPredicate(validIn, entity))
+        .map(e => e.metadata.name)
+        .sort(),
+    ).toEqual(['s', 'w']);
+  });
 });

--- a/packages/filter-predicates/src/predicates/evaluate.test.ts
+++ b/packages/filter-predicates/src/predicates/evaluate.test.ts
@@ -335,4 +335,43 @@ describe('evaluate', () => {
         .sort(),
     ).toEqual(['s', 'w']);
   });
+
+  it('gracefully handles malformed logical operators', () => {
+    // A non-array $all or $any operand must not match anything and must not
+    // throw, matching the graceful handling of malformed value operators.
+    const nonArrayAll = {
+      $all: { kind: 'component' },
+    } as unknown as FilterPredicate;
+    const nonArrayAny = { $any: 'component' } as unknown as FilterPredicate;
+    for (const entity of entities) {
+      expect(() => evaluateFilterPredicate(nonArrayAll, entity)).not.toThrow();
+      expect(evaluateFilterPredicate(nonArrayAll, entity)).toBe(false);
+      expect(filterPredicateToFilterFunction(nonArrayAll)(entity)).toBe(false);
+
+      expect(() => evaluateFilterPredicate(nonArrayAny, entity)).not.toThrow();
+      expect(evaluateFilterPredicate(nonArrayAny, entity)).toBe(false);
+      expect(filterPredicateToFilterFunction(nonArrayAny)(entity)).toBe(false);
+    }
+
+    // The guards must not regress the happy path: valid $all and $any arrays
+    // still combine their nested predicates as before.
+    const validAll: FilterPredicate = {
+      $all: [{ kind: 'component' }, { 'spec.type': 'service' }],
+    };
+    expect(
+      entities
+        .filter(entity => evaluateFilterPredicate(validAll, entity))
+        .map(e => e.metadata.name),
+    ).toEqual(['s']);
+
+    const validAny: FilterPredicate = {
+      $any: [{ kind: 'group' }, { kind: 'api' }],
+    };
+    expect(
+      entities
+        .filter(entity => evaluateFilterPredicate(validAny, entity))
+        .map(e => e.metadata.name)
+        .sort(),
+    ).toEqual(['a', 'g']);
+  });
 });

--- a/packages/filter-predicates/src/predicates/evaluate.ts
+++ b/packages/filter-predicates/src/predicates/evaluate.ts
@@ -42,6 +42,9 @@ export function evaluateFilterPredicate(
         'Operator $all must be the only key in the predicate, wrap in $all to combine with other conditions',
       );
     }
+    if (!Array.isArray(predicate.$all)) {
+      return false;
+    }
     return predicate.$all.every(f => evaluateFilterPredicate(f, value));
   }
   if ('$any' in predicate) {
@@ -49,6 +52,9 @@ export function evaluateFilterPredicate(
       throw new InputError(
         'Operator $any must be the only key in the predicate, wrap in $all to combine with other conditions',
       );
+    }
+    if (!Array.isArray(predicate.$any)) {
+      return false;
     }
     return predicate.$any.some(f => evaluateFilterPredicate(f, value));
   }

--- a/packages/filter-predicates/src/predicates/evaluate.ts
+++ b/packages/filter-predicates/src/predicates/evaluate.ts
@@ -112,6 +112,9 @@ function evaluateFilterPredicateValue(
     return value.some(v => evaluateFilterPredicate(filter.$contains, v));
   }
   if ('$in' in filter) {
+    if (!Array.isArray(filter.$in)) {
+      return false;
+    }
     return filter.$in.some(search => valuesAreEqual(value, search));
   }
   if ('$exists' in filter) {
@@ -121,7 +124,7 @@ function evaluateFilterPredicateValue(
     return value === undefined;
   }
   if ('$hasPrefix' in filter) {
-    if (typeof value !== 'string') {
+    if (typeof value !== 'string' || typeof filter.$hasPrefix !== 'string') {
       return false;
     }
     return value.toUpperCase().startsWith(filter.$hasPrefix.toUpperCase());


### PR DESCRIPTION
Changes `@backstage/filter-predicates` so that a known operator given an operand of an unexpected type  `$in`/`$all`/`$any` with a non-array, or `$hasPrefix` with a non-string  returns `false` instead of throwing a `TypeError`, since predicates often originate from JSON/config where operand types aren't guaranteed at compile time.

Default and valid behavior is unchanged, and there is no public API change.

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages.
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message.
