### PR TITLE
feat(backend-defaults): add schemaPrefix config for schema mode

### DIFF
--- a/.changeset/schema-prefix-config.md
+++ b/.changeset/schema-prefix-config.md
@@ -1,0 +1,5 @@
+---
+'@backstage/backend-defaults': minor
+---
+
+Add schemaPrefix configuration for pluginDivisionMode: schema. Allows prefixing PostgreSQL schema names to avoid conflicts with existing schemas.

--- a/docs/tutorials/switching-sqlite-postgres.md
+++ b/docs/tutorials/switching-sqlite-postgres.md
@@ -105,3 +105,15 @@ backend:
     client: pg
     pluginDivisionMode: schema # defaults to database, but changing this to schema means plugins will be given their own schema (in the specified/default database)
 ```
+
+If you need to avoid conflicts with existing schemas in your database, you can add a prefix to all plugin schema names:
+
+```yaml
+backend:
+  database:
+    client: pg
+    pluginDivisionMode: schema
+    schemaPrefix: 'backstage_' # defaults to empty string
+```
+
+This will create schemas named `backstage_catalog`, `backstage_auth`, and so on. The combined schema name must not exceed 63 characters.

--- a/docs/tutorials/switching-sqlite-postgres.md
+++ b/docs/tutorials/switching-sqlite-postgres.md
@@ -116,4 +116,10 @@ backend:
     schemaPrefix: 'backstage_' # defaults to empty string
 ```
 
-This will create schemas named `backstage_catalog`, `backstage_auth`, and so on. The combined schema name must not exceed 63 characters.
+This will create schemas named `backstage_catalog`, `backstage_auth`, and so on. The combined schema name must not exceed 63 bytes.
+
+:::caution[Existing Deployments]
+
+Enabling `schemaPrefix` on an existing deployment creates new prefixed schemas and does not migrate data from existing non-prefixed schemas. This configuration is intended for new deployments or to avoid conflicts with existing schemas in your database. If you enable this on an existing Backstage instance, your data will remain in the original non-prefixed schemas while Backstage uses the new prefixed schemas.
+
+:::

--- a/packages/backend-defaults/config.d.ts
+++ b/packages/backend-defaults/config.d.ts
@@ -681,6 +681,11 @@ export interface Config {
       /** Database name prefix override */
       prefix?: string;
       /**
+       * Prefix for schema names when using pluginDivisionMode: schema.
+       * @default ''
+       */
+      schemaPrefix?: string;
+      /**
        * Whether to ensure the given database exists by creating it if it does not.
        * Defaults to true if unspecified.
        */

--- a/packages/backend-defaults/src/entrypoints/database/DatabaseManager.test.ts
+++ b/packages/backend-defaults/src/entrypoints/database/DatabaseManager.test.ts
@@ -246,78 +246,40 @@ describe('DatabaseManagerImpl', () => {
 
 describe('DatabaseManager.fromConfig', () => {
   describe('schemaPrefix validation', () => {
-    it('throws error when schemaPrefix contains double quotes', () => {
-      const config = new ConfigReader({
-        backend: {
-          database: {
-            client: 'pg',
-            schemaPrefix: 'test"--',
-          },
-        },
-      });
+    it('throws error when schemaPrefix contains invalid characters', () => {
+      const invalidPrefixes = ['test"--', 'test-prefix', '123test', 'test@'];
 
-      expect(() => DatabaseManager.fromConfig(config)).toThrow(
-        /Invalid schemaPrefix "test"--"/,
-      );
-      expect(() => DatabaseManager.fromConfig(config)).toThrow(
-        /Schema prefix must start with a letter or underscore and contain only letters, numbers, and underscores/,
-      );
+      invalidPrefixes.forEach(schemaPrefix => {
+        const config = new ConfigReader({
+          backend: {
+            database: {
+              client: 'pg',
+              schemaPrefix,
+            },
+          },
+        });
+
+        expect(() => DatabaseManager.fromConfig(config)).toThrow(
+          /Invalid schemaPrefix/,
+        );
+      });
     });
 
-    it('throws error when schemaPrefix contains special characters', () => {
-      const config = new ConfigReader({
-        backend: {
-          database: {
-            client: 'pg',
-            schemaPrefix: 'test-prefix',
+    it('accepts valid schemaPrefix values', () => {
+      const validPrefixes = ['test_prefix_', '_test_prefix', 'backstage_'];
+
+      validPrefixes.forEach(schemaPrefix => {
+        const config = new ConfigReader({
+          backend: {
+            database: {
+              client: 'pg',
+              schemaPrefix,
+            },
           },
-        },
+        });
+
+        expect(() => DatabaseManager.fromConfig(config)).not.toThrow();
       });
-
-      expect(() => DatabaseManager.fromConfig(config)).toThrow(
-        /Invalid schemaPrefix "test-prefix"/,
-      );
-    });
-
-    it('throws error when schemaPrefix starts with a number', () => {
-      const config = new ConfigReader({
-        backend: {
-          database: {
-            client: 'pg',
-            schemaPrefix: '123test',
-          },
-        },
-      });
-
-      expect(() => DatabaseManager.fromConfig(config)).toThrow(
-        /Invalid schemaPrefix "123test"/,
-      );
-    });
-
-    it('accepts valid schemaPrefix with underscores', () => {
-      const config = new ConfigReader({
-        backend: {
-          database: {
-            client: 'pg',
-            schemaPrefix: 'test_prefix_',
-          },
-        },
-      });
-
-      expect(() => DatabaseManager.fromConfig(config)).not.toThrow();
-    });
-
-    it('accepts valid schemaPrefix starting with underscore', () => {
-      const config = new ConfigReader({
-        backend: {
-          database: {
-            client: 'pg',
-            schemaPrefix: '_test_prefix',
-          },
-        },
-      });
-
-      expect(() => DatabaseManager.fromConfig(config)).not.toThrow();
     });
 
     it('accepts when schemaPrefix is not configured', () => {

--- a/packages/backend-defaults/src/entrypoints/database/DatabaseManager.test.ts
+++ b/packages/backend-defaults/src/entrypoints/database/DatabaseManager.test.ts
@@ -15,7 +15,7 @@
  */
 
 import { ConfigReader } from '@backstage/config';
-import { DatabaseManagerImpl } from './DatabaseManager';
+import { DatabaseManager, DatabaseManagerImpl } from './DatabaseManager';
 import { Connector } from './types';
 import { mockServices } from '@backstage/backend-test-utils';
 
@@ -241,5 +241,95 @@ describe('DatabaseManagerImpl', () => {
     // Destroy should not have been called, but we should have read the config
     expect(destroy).not.toHaveBeenCalled();
     expect(getConfig).toHaveBeenCalled();
+  });
+});
+
+describe('DatabaseManager.fromConfig', () => {
+  describe('schemaPrefix validation', () => {
+    it('throws error when schemaPrefix contains double quotes', () => {
+      const config = new ConfigReader({
+        backend: {
+          database: {
+            client: 'pg',
+            schemaPrefix: 'test"--',
+          },
+        },
+      });
+
+      expect(() => DatabaseManager.fromConfig(config)).toThrow(
+        /Invalid schemaPrefix "test"--"/,
+      );
+      expect(() => DatabaseManager.fromConfig(config)).toThrow(
+        /Schema prefix must start with a letter or underscore and contain only letters, numbers, and underscores/,
+      );
+    });
+
+    it('throws error when schemaPrefix contains special characters', () => {
+      const config = new ConfigReader({
+        backend: {
+          database: {
+            client: 'pg',
+            schemaPrefix: 'test-prefix',
+          },
+        },
+      });
+
+      expect(() => DatabaseManager.fromConfig(config)).toThrow(
+        /Invalid schemaPrefix "test-prefix"/,
+      );
+    });
+
+    it('throws error when schemaPrefix starts with a number', () => {
+      const config = new ConfigReader({
+        backend: {
+          database: {
+            client: 'pg',
+            schemaPrefix: '123test',
+          },
+        },
+      });
+
+      expect(() => DatabaseManager.fromConfig(config)).toThrow(
+        /Invalid schemaPrefix "123test"/,
+      );
+    });
+
+    it('accepts valid schemaPrefix with underscores', () => {
+      const config = new ConfigReader({
+        backend: {
+          database: {
+            client: 'pg',
+            schemaPrefix: 'test_prefix_',
+          },
+        },
+      });
+
+      expect(() => DatabaseManager.fromConfig(config)).not.toThrow();
+    });
+
+    it('accepts valid schemaPrefix starting with underscore', () => {
+      const config = new ConfigReader({
+        backend: {
+          database: {
+            client: 'pg',
+            schemaPrefix: '_test_prefix',
+          },
+        },
+      });
+
+      expect(() => DatabaseManager.fromConfig(config)).not.toThrow();
+    });
+
+    it('accepts when schemaPrefix is not configured', () => {
+      const config = new ConfigReader({
+        backend: {
+          database: {
+            client: 'pg',
+          },
+        },
+      });
+
+      expect(() => DatabaseManager.fromConfig(config)).not.toThrow();
+    });
   });
 });

--- a/packages/backend-defaults/src/entrypoints/database/DatabaseManager.ts
+++ b/packages/backend-defaults/src/entrypoints/database/DatabaseManager.ts
@@ -268,8 +268,7 @@ export class DatabaseManager {
     const databaseConfig = config.getConfig('backend.database');
     const prefix =
       databaseConfig.getOptionalString('prefix') || 'backstage_plugin_';
-    const schemaPrefix =
-      databaseConfig.getOptionalString('schemaPrefix') || '';
+    const schemaPrefix = databaseConfig.getOptionalString('schemaPrefix') || '';
     return new DatabaseManager(
       new DatabaseManagerImpl(
         databaseConfig,

--- a/packages/backend-defaults/src/entrypoints/database/DatabaseManager.ts
+++ b/packages/backend-defaults/src/entrypoints/database/DatabaseManager.ts
@@ -268,11 +268,13 @@ export class DatabaseManager {
     const databaseConfig = config.getConfig('backend.database');
     const prefix =
       databaseConfig.getOptionalString('prefix') || 'backstage_plugin_';
+    const schemaPrefix =
+      databaseConfig.getOptionalString('schemaPrefix') || '';
     return new DatabaseManager(
       new DatabaseManagerImpl(
         databaseConfig,
         {
-          pg: new PgConnector(databaseConfig, prefix),
+          pg: new PgConnector(databaseConfig, prefix, schemaPrefix),
           sqlite3: new Sqlite3Connector(databaseConfig),
           'better-sqlite3': new Sqlite3Connector(databaseConfig),
           mysql: new MysqlConnector(databaseConfig, prefix),

--- a/packages/backend-defaults/src/entrypoints/database/DatabaseManager.ts
+++ b/packages/backend-defaults/src/entrypoints/database/DatabaseManager.ts
@@ -269,6 +269,15 @@ export class DatabaseManager {
     const prefix =
       databaseConfig.getOptionalString('prefix') || 'backstage_plugin_';
     const schemaPrefix = databaseConfig.getOptionalString('schemaPrefix') || '';
+
+    // Validate schemaPrefix contains only safe PostgreSQL identifier characters
+    if (schemaPrefix && !/^[a-zA-Z_][a-zA-Z0-9_]*$/.test(schemaPrefix)) {
+      throw new Error(
+        `Invalid schemaPrefix "${schemaPrefix}". ` +
+          `Schema prefix must start with a letter or underscore and contain only letters, numbers, and underscores.`,
+      );
+    }
+
     return new DatabaseManager(
       new DatabaseManagerImpl(
         databaseConfig,

--- a/packages/backend-defaults/src/entrypoints/database/connectors/postgres.test.ts
+++ b/packages/backend-defaults/src/entrypoints/database/connectors/postgres.test.ts
@@ -1836,23 +1836,6 @@ describe('computePgPluginConfig', () => {
         pluginDivisionMode: 'schema',
       });
 
-      expect(() => {
-        computePgPluginConfig(
-          config,
-          'catalog',
-          prefix,
-          'this_is_a_very_long_prefix_that_will_exceed_the_limit_when_combined_',
-        );
-      }).toThrow(/exceeds the 63-byte limit/);
-    });
-
-    it('throws error when schema name with multibyte UTF-8 characters exceeds 63 bytes', () => {
-      const config = new ConfigReader({
-        client: 'pg',
-        connection: { host: 'localhost' },
-        pluginDivisionMode: 'schema',
-      });
-
       // 'café_' is 6 bytes (café = 5 bytes, underscore = 1 byte)
       // Repeat to create a schema name that exceeds 63 bytes
       const multibytePrefixThatExceeds63Bytes = 'café_'.repeat(11); // 66 bytes

--- a/packages/backend-defaults/src/entrypoints/database/connectors/postgres.test.ts
+++ b/packages/backend-defaults/src/entrypoints/database/connectors/postgres.test.ts
@@ -1067,6 +1067,7 @@ describe('postgres', () => {
       const connector = new PgConnector(
         createConnectorConfig(),
         'backstage_plugin_',
+        '',
         { ensureDatabaseExists },
       );
 
@@ -1092,6 +1093,7 @@ describe('postgres', () => {
       const connector = new PgConnector(
         createConnectorConfig(),
         'backstage_plugin_',
+        '',
         { ensureDatabaseExists },
       );
 
@@ -1122,6 +1124,7 @@ describe('postgres', () => {
           },
         }),
         'backstage_plugin_',
+        '',
         { createAdminClient, adminPoolIdleTimeoutMillis: 10_000 },
       );
 
@@ -1152,6 +1155,7 @@ describe('postgres', () => {
           ensureSchemaExists: true,
         }),
         'backstage_plugin_',
+        '',
         { createAdminClient, adminPoolIdleTimeoutMillis: 10_000 },
       );
 
@@ -1204,6 +1208,7 @@ describe('postgres', () => {
           plugin: { plugin1: { connection: { database: 'database1' } } },
         }),
         'backstage_plugin_',
+        '',
         { createAdminClient },
       );
 
@@ -1236,6 +1241,7 @@ describe('postgres', () => {
           plugin: { plugin1: { connection: { database: 'database1' } } },
         }),
         'backstage_plugin_',
+        '',
         { createAdminClient },
       );
 
@@ -1277,6 +1283,7 @@ describe('postgres', () => {
           ensureSchemaExists: true,
         }),
         'backstage_plugin_',
+        '',
         { createAdminClient },
       );
       const client = await connector.getClient('plugin1', deps);

--- a/packages/backend-defaults/src/entrypoints/database/connectors/postgres.test.ts
+++ b/packages/backend-defaults/src/entrypoints/database/connectors/postgres.test.ts
@@ -1814,6 +1814,38 @@ describe('computePgPluginConfig', () => {
       });
     });
 
+    it('applies schemaPrefix to searchPath in schema mode', () => {
+      const config = new ConfigReader({
+        client: 'pg',
+        connection: { host: 'localhost', database: 'shared_db' },
+        pluginDivisionMode: 'schema',
+      });
+
+      const result = computePgPluginConfig(config, 'catalog', prefix, 'test_');
+
+      expect(result.databaseClientOverrides).toEqual({
+        connection: { database: 'shared_db' },
+        searchPath: ['test_catalog'],
+      });
+    });
+
+    it('throws error when schema name exceeds 63 characters', () => {
+      const config = new ConfigReader({
+        client: 'pg',
+        connection: { host: 'localhost' },
+        pluginDivisionMode: 'schema',
+      });
+
+      expect(() => {
+        computePgPluginConfig(
+          config,
+          'catalog',
+          prefix,
+          'this_is_a_very_long_prefix_that_will_exceed_the_limit_when_combined_',
+        );
+      }).toThrow(/exceeds the 63-character limit/);
+    });
+
     it('returns empty object when no databaseName in schema mode', () => {
       const config = new ConfigReader({
         client: 'pg',

--- a/packages/backend-defaults/src/entrypoints/database/connectors/postgres.test.ts
+++ b/packages/backend-defaults/src/entrypoints/database/connectors/postgres.test.ts
@@ -1829,7 +1829,7 @@ describe('computePgPluginConfig', () => {
       });
     });
 
-    it('throws error when schema name exceeds 63 characters', () => {
+    it('throws error when schema name exceeds 63 bytes', () => {
       const config = new ConfigReader({
         client: 'pg',
         connection: { host: 'localhost' },
@@ -1843,7 +1843,28 @@ describe('computePgPluginConfig', () => {
           prefix,
           'this_is_a_very_long_prefix_that_will_exceed_the_limit_when_combined_',
         );
-      }).toThrow(/exceeds the 63-character limit/);
+      }).toThrow(/exceeds the 63-byte limit/);
+    });
+
+    it('throws error when schema name with multibyte UTF-8 characters exceeds 63 bytes', () => {
+      const config = new ConfigReader({
+        client: 'pg',
+        connection: { host: 'localhost' },
+        pluginDivisionMode: 'schema',
+      });
+
+      // 'café_' is 6 bytes (café = 5 bytes, underscore = 1 byte)
+      // Repeat to create a schema name that exceeds 63 bytes
+      const multibytePrefixThatExceeds63Bytes = 'café_'.repeat(11); // 66 bytes
+
+      expect(() => {
+        computePgPluginConfig(
+          config,
+          'catalog',
+          prefix,
+          multibytePrefixThatExceeds63Bytes,
+        );
+      }).toThrow(/exceeds the 63-byte limit/);
     });
 
     it('returns empty object when no databaseName in schema mode', () => {

--- a/packages/backend-defaults/src/entrypoints/database/connectors/postgres.ts
+++ b/packages/backend-defaults/src/entrypoints/database/connectors/postgres.ts
@@ -945,11 +945,6 @@ export class PgConnector implements Connector {
     if (pluginDbConfig.pluginDivisionMode === 'schema') {
       if (pluginDbConfig.ensureSchemaExists || pluginDbConfig.ensureExists) {
         try {
-          if (!pluginDbConfig.schemaName) {
-            throw new Error(
-              `Schema name is required when pluginDivisionMode is 'schema'`,
-            );
-          }
           await ddlLimiter(() =>
             this.runAdminOperation(this.schemaAdminPool, admin =>
               ensurePgSchema(

--- a/packages/backend-defaults/src/entrypoints/database/connectors/postgres.ts
+++ b/packages/backend-defaults/src/entrypoints/database/connectors/postgres.ts
@@ -691,6 +691,7 @@ export function computePgPluginConfig(
   config: Config,
   pluginId: string,
   prefix: string,
+  schemaPrefix: string = '',
 ): PgPluginDatabaseConfig {
   // Client type
   const pluginClient = config.getOptionalString(

--- a/packages/backend-defaults/src/entrypoints/database/connectors/postgres.ts
+++ b/packages/backend-defaults/src/entrypoints/database/connectors/postgres.ts
@@ -807,6 +807,7 @@ export function computePgPluginConfig(
 export class PgConnector implements Connector {
   private readonly config: Config;
   private readonly prefix: string;
+  private readonly schemaPrefix: string;
   private readonly databaseEnsureCache = new Map<string, Promise<void>>();
   private readonly customEnsureDatabaseExists?: typeof ensurePgDatabaseExists;
   private readonly databaseAdminPool: PgAdminPool;
@@ -815,6 +816,7 @@ export class PgConnector implements Connector {
   constructor(
     config: Config,
     prefix: string,
+    schemaPrefix: string,
     options: {
       ensureDatabaseExists?: typeof ensurePgDatabaseExists;
       createAdminClient?: (overrides: Knex.Config) => Promise<Knex>;
@@ -823,6 +825,7 @@ export class PgConnector implements Connector {
   ) {
     this.config = config;
     this.prefix = prefix;
+    this.schemaPrefix = schemaPrefix;
     this.customEnsureDatabaseExists = options.ensureDatabaseExists;
 
     const createAdminClient =

--- a/packages/backend-defaults/src/entrypoints/database/connectors/postgres.ts
+++ b/packages/backend-defaults/src/entrypoints/database/connectors/postgres.ts
@@ -782,8 +782,8 @@ export function computePgPluginConfig(
     if (schemaName.length > 63) {
       throw new Error(
         `PostgreSQL schema name "${schemaName}" exceeds the 63-character limit. ` +
-        `Consider using a shorter schemaPrefix (current: "${schemaPrefix}") or ` +
-        `plugin ID (current: "${pluginId}").`
+          `Consider using a shorter schemaPrefix (current: "${schemaPrefix}") or ` +
+          `plugin ID (current: "${pluginId}").`,
       );
     }
 

--- a/packages/backend-defaults/src/entrypoints/database/connectors/postgres.ts
+++ b/packages/backend-defaults/src/entrypoints/database/connectors/postgres.ts
@@ -924,6 +924,7 @@ export class PgConnector implements Connector {
       this.config,
       pluginId,
       this.prefix,
+      this.schemaPrefix,
     );
 
     if (pluginDbConfig.databaseName && pluginDbConfig.ensureExists) {

--- a/packages/backend-defaults/src/entrypoints/database/connectors/postgres.ts
+++ b/packages/backend-defaults/src/entrypoints/database/connectors/postgres.ts
@@ -779,9 +779,9 @@ export function computePgPluginConfig(
   if (pluginDivisionMode === 'schema') {
     const schemaName = `${schemaPrefix}${pluginId}`;
 
-    if (schemaName.length > 63) {
+    if (Buffer.byteLength(schemaName, 'utf8') > 63) {
       throw new Error(
-        `PostgreSQL schema name "${schemaName}" exceeds the 63-character limit. ` +
+        `PostgreSQL schema name "${schemaName}" exceeds the 63-byte limit. ` +
           `Consider using a shorter schemaPrefix (current: "${schemaPrefix}") or ` +
           `plugin ID (current: "${pluginId}").`,
       );

--- a/packages/backend-defaults/src/entrypoints/database/connectors/postgres.ts
+++ b/packages/backend-defaults/src/entrypoints/database/connectors/postgres.ts
@@ -940,12 +940,13 @@ export class PgConnector implements Connector {
     if (pluginDbConfig.pluginDivisionMode === 'schema') {
       if (pluginDbConfig.ensureSchemaExists || pluginDbConfig.ensureExists) {
         try {
+          const schemaName = `${this.schemaPrefix}${pluginId}`;
           await ddlLimiter(() =>
             this.runAdminOperation(this.schemaAdminPool, admin =>
               ensurePgSchema(
                 admin,
                 this.config.getOptionalString('role'),
-                pluginId,
+                schemaName,
               ),
             ),
           );

--- a/packages/backend-defaults/src/entrypoints/database/connectors/postgres.ts
+++ b/packages/backend-defaults/src/entrypoints/database/connectors/postgres.ts
@@ -777,8 +777,18 @@ export function computePgPluginConfig(
     databaseClientOverrides = { connection: { database: databaseName } };
   }
   if (pluginDivisionMode === 'schema') {
+    const schemaName = `${schemaPrefix}${pluginId}`;
+
+    if (schemaName.length > 63) {
+      throw new Error(
+        `PostgreSQL schema name "${schemaName}" exceeds the 63-character limit. ` +
+        `Consider using a shorter schemaPrefix (current: "${schemaPrefix}") or ` +
+        `plugin ID (current: "${pluginId}").`
+      );
+    }
+
     databaseClientOverrides = mergeDatabaseConfig({}, databaseClientOverrides, {
-      searchPath: [pluginId],
+      searchPath: [schemaName],
     });
   }
 

--- a/packages/backend-defaults/src/entrypoints/database/connectors/postgres.ts
+++ b/packages/backend-defaults/src/entrypoints/database/connectors/postgres.ts
@@ -673,6 +673,8 @@ export interface PgPluginDatabaseConfig {
   connection: Knex.PgConnectionConfig;
   /** The database name, if any */
   databaseName: string | undefined;
+  /** The schema name, if using schema division mode */
+  schemaName: string | undefined;
   /** Database client overrides including schema overrides if applicable */
   databaseClientOverrides: Knex.Config;
   /** The full knex config for the plugin */
@@ -773,11 +775,13 @@ export function computePgPluginConfig(
 
   // Database client overrides
   let databaseClientOverrides: Knex.Config = {};
+  let schemaName: string | undefined;
+
   if (databaseName) {
     databaseClientOverrides = { connection: { database: databaseName } };
   }
   if (pluginDivisionMode === 'schema') {
-    const schemaName = `${schemaPrefix}${pluginId}`;
+    schemaName = `${schemaPrefix}${pluginId}`;
 
     if (Buffer.byteLength(schemaName, 'utf8') > 63) {
       throw new Error(
@@ -810,6 +814,7 @@ export function computePgPluginConfig(
     pluginDivisionMode,
     connection,
     databaseName,
+    schemaName,
     databaseClientOverrides,
     knexConfig,
   };
@@ -940,13 +945,17 @@ export class PgConnector implements Connector {
     if (pluginDbConfig.pluginDivisionMode === 'schema') {
       if (pluginDbConfig.ensureSchemaExists || pluginDbConfig.ensureExists) {
         try {
-          const schemaName = `${this.schemaPrefix}${pluginId}`;
+          if (!pluginDbConfig.schemaName) {
+            throw new Error(
+              `Schema name is required when pluginDivisionMode is 'schema'`,
+            );
+          }
           await ddlLimiter(() =>
             this.runAdminOperation(this.schemaAdminPool, admin =>
               ensurePgSchema(
                 admin,
                 this.config.getOptionalString('role'),
-                schemaName,
+                pluginDbConfig.schemaName!,
               ),
             ),
           );


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->
This PR adds schemaPrefix config for `pluginDivisionMode: schema` to fix conflicts with existing PostgreSQL schemas.

Fixes: https://github.com/backstage/backstage/issues/35296

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
