### PR TITLE
fix(backend-test-utils): increase test database cleanup timeout

### DIFF
--- a/.changeset/test-database-cleanup-timeout.md
+++ b/.changeset/test-database-cleanup-timeout.md
@@ -1,0 +1,5 @@
+---
+'@backstage/backend-test-utils': patch
+---
+
+Increased the test database cleanup timeout to 60 seconds to reduce timeout failures when using Docker.

--- a/packages/backend-test-utils/src/database/TestDatabases.ts
+++ b/packages/backend-test-utils/src/database/TestDatabases.ts
@@ -49,7 +49,8 @@ export class TestDatabases {
 
   /**
    * Creates an empty `TestDatabases` instance, and sets up Jest to clean up
-   * all of its acquired resources after all tests finish.
+   * all of its acquired resources after all tests finish, with a timeout of
+   * 60 seconds for cleanup.
    *
    * You typically want to create just a single instance like this at the top
    * of your test file or `describe` block, and then call `init` many times on
@@ -104,7 +105,7 @@ export class TestDatabases {
     if (supportedIds.length > 0) {
       afterAll(async () => {
         await databases.shutdown();
-      });
+      }, 60_000);
     }
 
     return databases;


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

Docker database shutdown can exceed Jest's default hook timeout, forcing test suites to increase their global timeout. Give the cleanup hook in `TestDatabases.create` a 60-second timeout instead.

Validation: pre-commit ESLint, Prettier, and documentation checks passed. Tests were not run because dependency installation failed to resolve `artifactory.spotify.net`. Attempted `yarn build:api-reports`; its TypeScript check failed with 555 errors across 107 files.

AI assistance was used to prepare this change.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
