### PR TITLE
Bump backstage/actions to v0.7.11

### DIFF
--- a/.github/workflows/api-breaking-changes.yml
+++ b/.github/workflows/api-breaking-changes.yml
@@ -34,7 +34,7 @@ jobs:
           registry-url: https://registry.npmjs.org/
 
       - name: yarn install
-        uses: backstage/actions/yarn-install@0d281eb2e96927466db49d4cd01d52b14809a66b # v0.7.10
+        uses: backstage/actions/yarn-install@7137f70a0e1e756bd3693c8570ae496d87637af5 # v0.7.11
         with:
           cache-prefix: linux-v22
 

--- a/.github/workflows/automate_changeset_feedback.yml
+++ b/.github/workflows/automate_changeset_feedback.yml
@@ -39,7 +39,7 @@ jobs:
       - name: fetch base
         run: git fetch --depth 1 origin "$GITHUB_BASE_REF"
 
-      - uses: backstage/actions/changeset-feedback@0d281eb2e96927466db49d4cd01d52b14809a66b # v0.7.10
+      - uses: backstage/actions/changeset-feedback@7137f70a0e1e756bd3693c8570ae496d87637af5 # v0.7.11
         name: Generate feedback
         with:
           diff-ref: 'origin/master'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,7 +55,7 @@ jobs:
           registry-url: https://registry.npmjs.org/ # Needed for auth
 
       - name: yarn install
-        uses: backstage/actions/yarn-install@0d281eb2e96927466db49d4cd01d52b14809a66b # v0.7.10
+        uses: backstage/actions/yarn-install@7137f70a0e1e756bd3693c8570ae496d87637af5 # v0.7.11
         with:
           cache-prefix: ${{ runner.os }}-v${{ matrix.node-version }}
 
@@ -91,7 +91,7 @@ jobs:
           registry-url: https://registry.npmjs.org/ # Needed for auth
 
       - name: yarn install
-        uses: backstage/actions/yarn-install@0d281eb2e96927466db49d4cd01d52b14809a66b # v0.7.10
+        uses: backstage/actions/yarn-install@7137f70a0e1e756bd3693c8570ae496d87637af5 # v0.7.11
         with:
           cache-prefix: ${{ runner.os }}-v${{ matrix.node-version }}
 
@@ -275,7 +275,7 @@ jobs:
           registry-url: https://registry.npmjs.org/ # Needed for auth
 
       - name: yarn install
-        uses: backstage/actions/yarn-install@0d281eb2e96927466db49d4cd01d52b14809a66b # v0.7.10
+        uses: backstage/actions/yarn-install@7137f70a0e1e756bd3693c8570ae496d87637af5 # v0.7.11
         with:
           cache-prefix: ${{ runner.os }}-v${{ matrix.node-version }}
 

--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -14,7 +14,7 @@ jobs:
         with:
           egress-policy: audit
 
-      - uses: backstage/actions/cron@0d281eb2e96927466db49d4cd01d52b14809a66b # v0.7.10
+      - uses: backstage/actions/cron@7137f70a0e1e756bd3693c8570ae496d87637af5 # v0.7.11
         with:
           app-id: ${{ secrets.BACKSTAGE_GOALIE_APPLICATION_ID }}
           private-key: ${{ secrets.BACKSTAGE_GOALIE_PRIVATE_KEY }}

--- a/.github/workflows/deploy_docker-image.yml
+++ b/.github/workflows/deploy_docker-image.yml
@@ -42,7 +42,7 @@ jobs:
           registry-url: https://registry.npmjs.org/ # Needed for auth
 
       - name: yarn install
-        uses: backstage/actions/yarn-install@0d281eb2e96927466db49d4cd01d52b14809a66b # v0.7.10
+        uses: backstage/actions/yarn-install@7137f70a0e1e756bd3693c8570ae496d87637af5 # v0.7.11
         with:
           cache-prefix: ${{ runner.os }}-v${{ matrix.node-version }}
 

--- a/.github/workflows/deploy_microsite.yml
+++ b/.github/workflows/deploy_microsite.yml
@@ -94,7 +94,7 @@ jobs:
           registry-url: https://registry.npmjs.org/ # Needed for auth
 
       - name: yarn install
-        uses: backstage/actions/yarn-install@0d281eb2e96927466db49d4cd01d52b14809a66b # v0.7.10
+        uses: backstage/actions/yarn-install@7137f70a0e1e756bd3693c8570ae496d87637af5 # v0.7.11
         with:
           cache-prefix: ${{ runner.os }}-v22.x
 
@@ -167,7 +167,7 @@ jobs:
           registry-url: https://registry.npmjs.org/ # Needed for auth
 
       - name: yarn install
-        uses: backstage/actions/yarn-install@0d281eb2e96927466db49d4cd01d52b14809a66b # v0.7.10
+        uses: backstage/actions/yarn-install@7137f70a0e1e756bd3693c8570ae496d87637af5 # v0.7.11
         with:
           cache-prefix: ${{ runner.os }}-v22.x
 

--- a/.github/workflows/deploy_packages.yml
+++ b/.github/workflows/deploy_packages.yml
@@ -76,7 +76,7 @@ jobs:
           node-version: ${{ matrix.node-version }}
           registry-url: https://registry.npmjs.org/ # Needed for auth
       - name: yarn install
-        uses: backstage/actions/yarn-install@0d281eb2e96927466db49d4cd01d52b14809a66b # v0.7.10
+        uses: backstage/actions/yarn-install@7137f70a0e1e756bd3693c8570ae496d87637af5 # v0.7.11
         with:
           cache-prefix: ${{ runner.os }}-v${{ matrix.node-version }}
 

--- a/.github/workflows/mui-migration-tracker.yml
+++ b/.github/workflows/mui-migration-tracker.yml
@@ -32,7 +32,7 @@ jobs:
           registry-url: https://registry.npmjs.org/ # Needed for auth
 
       - name: yarn install
-        uses: backstage/actions/yarn-install@0d281eb2e96927466db49d4cd01d52b14809a66b # v0.7.10
+        uses: backstage/actions/yarn-install@7137f70a0e1e756bd3693c8570ae496d87637af5 # v0.7.11
         with:
           cache-prefix: ${{ runner.os }}-v22.x
 

--- a/.github/workflows/sync_bui-docs.yml
+++ b/.github/workflows/sync_bui-docs.yml
@@ -26,7 +26,7 @@ jobs:
           registry-url: https://registry.npmjs.org/ # Needed for auth
 
       - name: yarn install
-        uses: backstage/actions/yarn-install@0d281eb2e96927466db49d4cd01d52b14809a66b # v0.7.10
+        uses: backstage/actions/yarn-install@7137f70a0e1e756bd3693c8570ae496d87637af5 # v0.7.11
         with:
           cache-prefix: ${{ runner.os }}-v22.x
 

--- a/.github/workflows/sync_code-formatting.yml
+++ b/.github/workflows/sync_code-formatting.yml
@@ -27,7 +27,7 @@ jobs:
           registry-url: https://registry.npmjs.org/ # Needed for auth
 
       - name: yarn install
-        uses: backstage/actions/yarn-install@0d281eb2e96927466db49d4cd01d52b14809a66b # v0.7.10
+        uses: backstage/actions/yarn-install@7137f70a0e1e756bd3693c8570ae496d87637af5 # v0.7.11
         with:
           cache-prefix: ${{ runner.os }}-v${{ matrix.node-version }}
 

--- a/.github/workflows/sync_pull-requests-scheduled.yml
+++ b/.github/workflows/sync_pull-requests-scheduled.yml
@@ -124,7 +124,7 @@ jobs:
           egress-policy: audit
 
       - name: Backstage PR automation
-        uses: backstage/actions/pr-automation@0d281eb2e96927466db49d4cd01d52b14809a66b # v0.7.10
+        uses: backstage/actions/pr-automation@7137f70a0e1e756bd3693c8570ae496d87637af5 # v0.7.11
         with:
           app-id: ${{ secrets.BACKSTAGE_GOALIE_APPLICATION_ID }}
           private-key: ${{ secrets.BACKSTAGE_GOALIE_PRIVATE_KEY }}

--- a/.github/workflows/sync_pull-requests.yml
+++ b/.github/workflows/sync_pull-requests.yml
@@ -90,7 +90,7 @@ jobs:
 
       - name: Backstage PR automation
         if: steps.context.outputs.pr-number
-        uses: backstage/actions/pr-automation@0d281eb2e96927466db49d4cd01d52b14809a66b # v0.7.10
+        uses: backstage/actions/pr-automation@7137f70a0e1e756bd3693c8570ae496d87637af5 # v0.7.11
         with:
           app-id: ${{ secrets.BACKSTAGE_GOALIE_APPLICATION_ID }}
           private-key: ${{ secrets.BACKSTAGE_GOALIE_PRIVATE_KEY }}

--- a/.github/workflows/sync_release-manifest.yml
+++ b/.github/workflows/sync_release-manifest.yml
@@ -45,7 +45,7 @@ jobs:
           registry-url: https://registry.npmjs.org/ # Needed for auth
 
       - name: yarn install
-        uses: backstage/actions/yarn-install@0d281eb2e96927466db49d4cd01d52b14809a66b # v0.7.10
+        uses: backstage/actions/yarn-install@7137f70a0e1e756bd3693c8570ae496d87637af5 # v0.7.11
         with:
           cache-prefix: ${{ runner.os }}-v22.x
 

--- a/.github/workflows/sync_snyk-github-issues.yml
+++ b/.github/workflows/sync_snyk-github-issues.yml
@@ -25,7 +25,7 @@ jobs:
           registry-url: https://registry.npmjs.org/ # Needed for auth
 
       - name: yarn install
-        uses: backstage/actions/yarn-install@0d281eb2e96927466db49d4cd01d52b14809a66b # v0.7.10
+        uses: backstage/actions/yarn-install@7137f70a0e1e756bd3693c8570ae496d87637af5 # v0.7.11
         with:
           cache-prefix: ${{ runner.os }}-v22.x
 

--- a/.github/workflows/verify_accessibility.yml
+++ b/.github/workflows/verify_accessibility.yml
@@ -30,7 +30,7 @@ jobs:
         with:
           node-version: 22.x
       - name: yarn install
-        uses: backstage/actions/yarn-install@0d281eb2e96927466db49d4cd01d52b14809a66b # v0.7.10
+        uses: backstage/actions/yarn-install@7137f70a0e1e756bd3693c8570ae496d87637af5 # v0.7.11
         with:
           cache-prefix: ${{ runner.os }}-v22.x
       - name: run Lighthouse CI

--- a/.github/workflows/verify_chromatic.yml
+++ b/.github/workflows/verify_chromatic.yml
@@ -48,7 +48,7 @@ jobs:
           registry-url: https://registry.npmjs.org/ # Needed for auth
 
       - name: Install dependencies
-        uses: backstage/actions/yarn-install@0d281eb2e96927466db49d4cd01d52b14809a66b # v0.7.10
+        uses: backstage/actions/yarn-install@7137f70a0e1e756bd3693c8570ae496d87637af5 # v0.7.11
         with:
           cache-prefix: ${{ runner.os }}-v${{ matrix.node-version }}
 

--- a/.github/workflows/verify_e2e-linux.yml
+++ b/.github/workflows/verify_e2e-linux.yml
@@ -83,7 +83,7 @@ jobs:
           registry-url: https://registry.npmjs.org/ # Needed for auth
 
       - name: yarn install
-        uses: backstage/actions/yarn-install@0d281eb2e96927466db49d4cd01d52b14809a66b # v0.7.10
+        uses: backstage/actions/yarn-install@7137f70a0e1e756bd3693c8570ae496d87637af5 # v0.7.11
         with:
           cache-prefix: ${{ runner.os }}-v${{ matrix.node-version }}
 

--- a/.github/workflows/verify_e2e-techdocs.yml
+++ b/.github/workflows/verify_e2e-techdocs.yml
@@ -50,7 +50,7 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
       - name: yarn install
-        uses: backstage/actions/yarn-install@0d281eb2e96927466db49d4cd01d52b14809a66b # v0.7.10
+        uses: backstage/actions/yarn-install@7137f70a0e1e756bd3693c8570ae496d87637af5 # v0.7.11
         with:
           cache-prefix: ${{ runner.os }}-v${{ matrix.node-version }}
 

--- a/.github/workflows/verify_e2e-windows.yml
+++ b/.github/workflows/verify_e2e-windows.yml
@@ -89,7 +89,7 @@ jobs:
           chrome-version: latest
 
       - name: yarn install
-        uses: backstage/actions/yarn-install@0d281eb2e96927466db49d4cd01d52b14809a66b # v0.7.10
+        uses: backstage/actions/yarn-install@7137f70a0e1e756bd3693c8570ae496d87637af5 # v0.7.11
         with:
           cache-prefix: ${{ runner.os }}-v${{ matrix.node-version }}
 

--- a/.github/workflows/verify_microsite.yml
+++ b/.github/workflows/verify_microsite.yml
@@ -100,7 +100,7 @@ jobs:
           registry-url: https://registry.npmjs.org/ # Needed for auth
 
       - name: yarn install
-        uses: backstage/actions/yarn-install@0d281eb2e96927466db49d4cd01d52b14809a66b # v0.7.10
+        uses: backstage/actions/yarn-install@7137f70a0e1e756bd3693c8570ae496d87637af5 # v0.7.11
         with:
           cache-prefix: ${{ runner.os }}-v22.x
 
@@ -170,7 +170,7 @@ jobs:
           registry-url: https://registry.npmjs.org/ # Needed for auth
 
       - name: yarn install
-        uses: backstage/actions/yarn-install@0d281eb2e96927466db49d4cd01d52b14809a66b # v0.7.10
+        uses: backstage/actions/yarn-install@7137f70a0e1e756bd3693c8570ae496d87637af5 # v0.7.11
         with:
           cache-prefix: ${{ runner.os }}-v22.x
 


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Bumps the pinned backstage/actions references in workflows from v0.7.10 to v0.7.11.

This picks up backstage/actions#194, which extends the scheduled dependency PR automerge job to include eligible Dependabot yarn.lock-only PRs and paginate through all open dependency PRs.

Release: https://github.com/backstage/actions/releases/tag/v0.7.11

#### :heavy_check_mark: Checklist

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a Signed-off-by line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))