### PR TITLE
backend-app-api: add backend instance IDs

### DIFF
--- a/.changeset/bright-instances-identify.md
+++ b/.changeset/bright-instances-identify.md
@@ -1,0 +1,5 @@
+---
+'@backstage/backend-plugin-api': minor
+---
+
+Added an instance ID to the root instance metadata service. The globally unique ID identifies the running backend instance and remains stable for its lifetime.

--- a/.changeset/bright-instances-identify.md
+++ b/.changeset/bright-instances-identify.md
@@ -2,4 +2,4 @@
 '@backstage/backend-plugin-api': minor
 ---
 
-Added an instance ID to the root instance metadata service. The globally unique ID identifies the running backend instance and remains stable for its lifetime.
+**BREAKING PRODUCERS**: Added an instance ID to the root instance metadata service. Custom implementations and mocks must now provide a globally unique ID that remains stable for the lifetime of the running backend instance.

--- a/.changeset/calm-instances-specialize.md
+++ b/.changeset/calm-instances-specialize.md
@@ -1,0 +1,5 @@
+---
+'@backstage/backend-app-api': minor
+---
+
+Added an `instanceId` option to `createSpecializedBackend`. Each backend instance uses a random UUID by default.

--- a/.changeset/fresh-signals-identify.md
+++ b/.changeset/fresh-signals-identify.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-signals-backend': patch
+---
+
+Use the backend instance ID to identify the event subscription, allowing deployments to control how Signals instances fan out events.

--- a/.changeset/gentle-backends-identify.md
+++ b/.changeset/gentle-backends-identify.md
@@ -1,5 +1,5 @@
 ---
-'@backstage/backend-defaults': minor
+'@backstage/backend-defaults': patch
 ---
 
 Added an `instanceId` option to `createBackend`, allowing deployments to use an externally provided backend instance identifier. Each backend instance uses a random UUID by default.

--- a/.changeset/gentle-backends-identify.md
+++ b/.changeset/gentle-backends-identify.md
@@ -1,0 +1,5 @@
+---
+'@backstage/backend-defaults': minor
+---
+
+Added an `instanceId` option to `createBackend`, allowing deployments to use an externally provided backend instance identifier. Each backend instance uses a random UUID by default.

--- a/.changeset/tidy-mocks-identify.md
+++ b/.changeset/tidy-mocks-identify.md
@@ -1,0 +1,5 @@
+---
+'@backstage/backend-test-utils': patch
+---
+
+Updated the root instance metadata service mock to provide an instance ID.

--- a/docs/backend-system/core-services/root-instance-metadata.md
+++ b/docs/backend-system/core-services/root-instance-metadata.md
@@ -5,7 +5,9 @@ sidebar_label: Root Instance Metadata
 description: Documentation for the Root Instance Metadata service
 ---
 
-The root instance metadata service provides information about the running Backstage backend instance, including its globally unique instance ID and a list of all installed backend plugins.
+The root instance metadata service provides information about a specific running Backstage backend instance, including its globally unique instance ID and a list of all installed backend plugins.
+
+A _backend instance_ is the individual `Backend` object returned by each call to `createBackend` or `createSpecializedBackend`. Every backend instance has its own ID, including multiple instances created in the same process. An instance ID must never be shared with or reused for another backend instance, even after the original instance has stopped.
 
 :::note
 
@@ -41,21 +43,21 @@ createBackendPlugin({
 });
 ```
 
-The instance ID is stable for the lifetime of the backend instance and should be treated as an opaque string. By default, each backend instance is assigned a random UUID.
+The instance ID is stable for the lifetime of the backend instance and should be treated as an opaque string. By default, a new random UUID is generated separately for every backend instance that is created.
 
 ## Setting the instance ID
 
-You can provide the instance ID when you create the backend. This is useful when your deployment environment already provides a suitable identifier, such as a Kubernetes pod UID.
+You can provide the instance ID when you create the backend. This is useful when your deployment environment assigns a fresh, globally unique identifier to every backend instance.
 
 ```ts
 import { createBackend } from '@backstage/backend-defaults';
 
 const backend = createBackend({
-  instanceId: process.env.POD_UID,
+  instanceId: process.env.BACKSTAGE_INSTANCE_ID,
 });
 ```
 
-A configured instance ID must be globally unique. Backstage does not validate the uniqueness of provided IDs.
+A configured instance ID must be globally unique and must not be reused by another backend instance. Backstage does not validate the uniqueness of provided IDs, so the caller is responsible for upholding this requirement.
 
 ## Dynamic plugin registration
 

--- a/docs/backend-system/core-services/root-instance-metadata.md
+++ b/docs/backend-system/core-services/root-instance-metadata.md
@@ -5,7 +5,7 @@ sidebar_label: Root Instance Metadata
 description: Documentation for the Root Instance Metadata service
 ---
 
-The root instance metadata service provides information about the running Backstage backend instance. Currently, it provides a list of all installed backend plugins.
+The root instance metadata service provides information about the running Backstage backend instance, including its globally unique instance ID and a list of all installed backend plugins.
 
 :::note
 
@@ -15,7 +15,7 @@ The root instance metadata service only provides information about the specific 
 
 ## Using the service
 
-The following example shows how to use the root instance metadata service in your `example` backend plugin to access the list of installed backend plugins.
+The following example shows how to use the root instance metadata service in your `example` backend plugin to access the instance ID and the list of installed backend plugins.
 
 ```ts
 import {
@@ -31,13 +31,31 @@ createBackendPlugin({
         instanceMetadata: coreServices.rootInstanceMetadata,
       },
       async init({ instanceMetadata }) {
-        const plugins = instanceMetadata.getInstalledPlugins();
+        const instanceId = instanceMetadata.getId();
+        const plugins = await instanceMetadata.getInstalledPlugins();
+        console.log('Instance ID:', instanceId);
         console.log('Installed plugins:', plugins);
       },
     });
   },
 });
 ```
+
+The instance ID is stable for the lifetime of the backend instance and should be treated as an opaque string. By default, each backend instance is assigned a random UUID.
+
+## Setting the instance ID
+
+You can provide the instance ID when you create the backend. This is useful when your deployment environment already provides a suitable identifier, such as a Kubernetes pod UID.
+
+```ts
+import { createBackend } from '@backstage/backend-defaults';
+
+const backend = createBackend({
+  instanceId: process.env.POD_UID,
+});
+```
+
+A configured instance ID must be globally unique. Backstage does not validate the uniqueness of provided IDs.
 
 ## Dynamic plugin registration
 

--- a/packages/backend-app-api/report.api.md
+++ b/packages/backend-app-api/report.api.md
@@ -60,6 +60,7 @@ export interface CreateSpecializedBackendOptions {
   defaultServiceFactories: ServiceFactory[];
   // (undocumented)
   extensionPointFactoryMiddleware?: ExtensionPointFactoryMiddleware[];
+  instanceId?: string;
 }
 
 // @public

--- a/packages/backend-app-api/src/wiring/BackendInitializer.test.ts
+++ b/packages/backend-app-api/src/wiring/BackendInitializer.test.ts
@@ -1537,7 +1537,7 @@ describe('BackendInitializer', () => {
   });
 
   it('should properly add plugins + modules to the instance metadata service', async () => {
-    expect.assertions(1);
+    expect.assertions(2);
     const backend = new BackendInitializer(baseFactories);
     const plugin = createBackendPlugin({
       pluginId: 'test',
@@ -1556,6 +1556,9 @@ describe('BackendInitializer', () => {
             instanceMetadata: coreServices.rootInstanceMetadata,
           },
           async init({ instanceMetadata }) {
+            expect(instanceMetadata.getId()).toMatch(
+              /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/,
+            );
             await expect(
               instanceMetadata.getInstalledPlugins(),
             ).resolves.toEqual([

--- a/packages/backend-app-api/src/wiring/BackendInitializer.test.ts
+++ b/packages/backend-app-api/src/wiring/BackendInitializer.test.ts
@@ -1536,9 +1536,9 @@ describe('BackendInitializer', () => {
     await init.start();
   });
 
-  it('should properly add plugins + modules to the instance metadata service', async () => {
+  it('should add plugins and modules and default an empty instance ID', async () => {
     expect.assertions(2);
-    const backend = new BackendInitializer(baseFactories);
+    const backend = new BackendInitializer(baseFactories, undefined, '');
     const plugin = createBackendPlugin({
       pluginId: 'test',
       register(reg) {

--- a/packages/backend-app-api/src/wiring/BackendInitializer.ts
+++ b/packages/backend-app-api/src/wiring/BackendInitializer.ts
@@ -51,6 +51,7 @@ import { BackendStartupError } from './BackendStartupError';
 import { createAllowBootFailurePredicate } from './createAllowBootFailurePredicate';
 import type { ConnectionsService } from '@backstage/connections';
 import { connectionsServiceRef } from '@backstage/connections-node';
+import { randomUUID } from 'node:crypto';
 import { withDeclaredConnections } from './withDeclaredConnections';
 import {
   assertObject,
@@ -165,6 +166,7 @@ function collectCallerConnectionRegistrations(
 
 function createRootInstanceMetadataServiceFactory(
   registrations: ReturnType<InternalBackendRegistrations['getRegistrations']>,
+  instanceId: string,
 ) {
   const installedPlugins: Map<string, RootInstanceMetadataServicePluginInfo> =
     new Map();
@@ -203,6 +205,7 @@ function createRootInstanceMetadataServiceFactory(
         ...installedPlugins.values(),
       ]);
       const instanceMetadata = {
+        getId: () => instanceId,
         getInstalledPlugins: () => Promise.resolve(readonlyInstalledPlugins),
       };
 
@@ -260,14 +263,17 @@ export class BackendInitializer {
 
   #unhandledRejectionHandler?: (reason: Error) => void;
   #uncaughtExceptionHandler?: (error: Error) => void;
+  readonly #instanceId: string;
 
   constructor(
     defaultApiFactories: ServiceFactory[],
     extensionPointFactoryMiddleware?: ExtensionPointFactoryMiddleware[],
+    instanceId?: string,
   ) {
     this.#serviceRegistry = ServiceRegistry.create([...defaultApiFactories]);
     this.#extensionPointFactoryMiddleware =
       extensionPointFactoryMiddleware ?? [];
+    this.#instanceId = instanceId ?? randomUUID();
   }
 
   async #getInitDeps(
@@ -401,7 +407,10 @@ export class BackendInitializer {
     );
 
     this.#serviceRegistry.add(
-      createRootInstanceMetadataServiceFactory(this.#allRegistrations),
+      createRootInstanceMetadataServiceFactory(
+        this.#allRegistrations,
+        this.#instanceId,
+      ),
     );
 
     // This makes sure that any uncaught errors or unhandled rejections are

--- a/packages/backend-app-api/src/wiring/BackendInitializer.ts
+++ b/packages/backend-app-api/src/wiring/BackendInitializer.ts
@@ -273,7 +273,7 @@ export class BackendInitializer {
     this.#serviceRegistry = ServiceRegistry.create([...defaultApiFactories]);
     this.#extensionPointFactoryMiddleware =
       extensionPointFactoryMiddleware ?? [];
-    this.#instanceId = instanceId ?? randomUUID();
+    this.#instanceId = instanceId || randomUUID();
   }
 
   async #getInitDeps(

--- a/packages/backend-app-api/src/wiring/BackstageBackend.ts
+++ b/packages/backend-app-api/src/wiring/BackstageBackend.ts
@@ -29,10 +29,12 @@ export class BackstageBackend implements Backend {
   constructor(
     defaultServiceFactories: ServiceFactory[],
     extensionPointFactoryMiddleware?: ExtensionPointFactoryMiddleware[],
+    instanceId?: string,
   ) {
     this.#initializer = new BackendInitializer(
       defaultServiceFactories,
       extensionPointFactoryMiddleware,
+      instanceId,
     );
   }
 

--- a/packages/backend-app-api/src/wiring/createSpecializedBackend.test.ts
+++ b/packages/backend-app-api/src/wiring/createSpecializedBackend.test.ts
@@ -16,8 +16,10 @@
 
 import {
   coreServices,
+  createBackendPlugin,
   createServiceFactory,
 } from '@backstage/backend-plugin-api';
+import { mockServices } from '@backstage/backend-test-utils';
 import { InputError } from '@backstage/errors';
 import { createSpecializedBackend } from './createSpecializedBackend';
 
@@ -26,6 +28,37 @@ describe('createSpecializedBackend', () => {
     expect(() =>
       createSpecializedBackend({ defaultServiceFactories: [] }),
     ).not.toThrow();
+  });
+
+  it('should use the provided instance ID', async () => {
+    expect.assertions(1);
+    const backend = createSpecializedBackend({
+      defaultServiceFactories: [
+        mockServices.rootLifecycle.factory(),
+        mockServices.lifecycle.factory(),
+        mockServices.rootLogger.factory(),
+        mockServices.logger.factory(),
+      ],
+      instanceId: 'my-instance',
+    });
+    backend.add(
+      createBackendPlugin({
+        pluginId: 'test',
+        register(reg) {
+          reg.registerInit({
+            deps: {
+              instanceMetadata: coreServices.rootInstanceMetadata,
+            },
+            async init({ instanceMetadata }) {
+              expect(instanceMetadata.getId()).toBe('my-instance');
+            },
+          });
+        },
+      }),
+    );
+
+    await backend.start();
+    await backend.stop();
   });
 
   it('should report malformed dynamic imports during startup', async () => {

--- a/packages/backend-app-api/src/wiring/createSpecializedBackend.ts
+++ b/packages/backend-app-api/src/wiring/createSpecializedBackend.ts
@@ -46,5 +46,6 @@ export function createSpecializedBackend(
   return new BackstageBackend(
     options.defaultServiceFactories,
     options.extensionPointFactoryMiddleware,
+    options.instanceId,
   );
 }

--- a/packages/backend-app-api/src/wiring/types.ts
+++ b/packages/backend-app-api/src/wiring/types.ts
@@ -64,6 +64,14 @@ export interface Backend {
 export interface CreateSpecializedBackendOptions {
   defaultServiceFactories: ServiceFactory[];
   extensionPointFactoryMiddleware?: ExtensionPointFactoryMiddleware[];
+
+  /**
+   * The globally unique identifier of this Backstage backend instance.
+   *
+   * If omitted, a UUID is generated. Any provided value must be globally
+   * unique.
+   */
+  instanceId?: string;
 }
 
 /**

--- a/packages/backend-app-api/src/wiring/types.ts
+++ b/packages/backend-app-api/src/wiring/types.ts
@@ -66,10 +66,11 @@ export interface CreateSpecializedBackendOptions {
   extensionPointFactoryMiddleware?: ExtensionPointFactoryMiddleware[];
 
   /**
-   * The globally unique identifier of this Backstage backend instance.
+   * The globally unique identifier of this specific Backstage backend
+   * instance.
    *
-   * If omitted, a UUID is generated. Any provided value must be globally
-   * unique.
+   * If omitted, a UUID is generated. Any provided value must not be used by
+   * any other backend instance, including after this instance has stopped.
    */
   instanceId?: string;
 }

--- a/packages/backend-defaults/report.api.md
+++ b/packages/backend-defaults/report.api.md
@@ -8,7 +8,12 @@ import { BackendFeature } from '@backstage/backend-plugin-api';
 import { ServiceFactory } from '@backstage/backend-plugin-api';
 
 // @public (undocumented)
-export function createBackend(): Backend;
+export function createBackend(options?: CreateBackendOptions): Backend;
+
+// @public (undocumented)
+export interface CreateBackendOptions {
+  instanceId?: string;
+}
 
 // @public (undocumented)
 export const defaultServiceFactories: ServiceFactory[];

--- a/packages/backend-defaults/src/CreateBackend.test.ts
+++ b/packages/backend-defaults/src/CreateBackend.test.ts
@@ -16,11 +16,35 @@
 
 import {
   coreServices,
+  createBackendPlugin,
   createServiceFactory,
 } from '@backstage/backend-plugin-api';
 import { createBackend } from './CreateBackend';
 
 describe('createBackend', () => {
+  it('should use the provided instance ID', async () => {
+    expect.assertions(1);
+    const backend = createBackend({ instanceId: 'my-instance' });
+    backend.add(
+      createBackendPlugin({
+        pluginId: 'test',
+        register(reg) {
+          reg.registerInit({
+            deps: {
+              instanceMetadata: coreServices.rootInstanceMetadata,
+            },
+            async init({ instanceMetadata }) {
+              expect(instanceMetadata.getId()).toBe('my-instance');
+            },
+          });
+        },
+      }),
+    );
+
+    await backend.start();
+    await backend.stop();
+  });
+
   it('should not throw when overriding a default service implementation', async () => {
     const backend = createBackend();
 

--- a/packages/backend-defaults/src/CreateBackend.test.ts
+++ b/packages/backend-defaults/src/CreateBackend.test.ts
@@ -16,35 +16,11 @@
 
 import {
   coreServices,
-  createBackendPlugin,
   createServiceFactory,
 } from '@backstage/backend-plugin-api';
 import { createBackend } from './CreateBackend';
 
 describe('createBackend', () => {
-  it('should use the provided instance ID', async () => {
-    expect.assertions(1);
-    const backend = createBackend({ instanceId: 'my-instance' });
-    backend.add(
-      createBackendPlugin({
-        pluginId: 'test',
-        register(reg) {
-          reg.registerInit({
-            deps: {
-              instanceMetadata: coreServices.rootInstanceMetadata,
-            },
-            async init({ instanceMetadata }) {
-              expect(instanceMetadata.getId()).toBe('my-instance');
-            },
-          });
-        },
-      }),
-    );
-
-    await backend.start();
-    await backend.stop();
-  });
-
   it('should not throw when overriding a default service implementation', async () => {
     const backend = createBackend();
 

--- a/packages/backend-defaults/src/CreateBackend.ts
+++ b/packages/backend-defaults/src/CreateBackend.ts
@@ -82,10 +82,11 @@ export const defaultServiceFactories: ServiceFactory[] = [
 /** @public */
 export interface CreateBackendOptions {
   /**
-   * The globally unique identifier of this Backstage backend instance.
+   * The globally unique identifier of this specific Backstage backend
+   * instance.
    *
-   * If omitted, a UUID is generated. Any provided value must be globally
-   * unique.
+   * If omitted, a UUID is generated. Any provided value must not be used by
+   * any other backend instance, including after this instance has stopped.
    */
   instanceId?: string;
 }

--- a/packages/backend-defaults/src/CreateBackend.ts
+++ b/packages/backend-defaults/src/CreateBackend.ts
@@ -79,9 +79,23 @@ export const defaultServiceFactories: ServiceFactory[] = [
   instanceMetadataServiceFactory,
 ];
 
+/** @public */
+export interface CreateBackendOptions {
+  /**
+   * The globally unique identifier of this Backstage backend instance.
+   *
+   * If omitted, a UUID is generated. Any provided value must be globally
+   * unique.
+   */
+  instanceId?: string;
+}
+
 /**
  * @public
  */
-export function createBackend(): Backend {
-  return createSpecializedBackend({ defaultServiceFactories });
+export function createBackend(options: CreateBackendOptions = {}): Backend {
+  return createSpecializedBackend({
+    defaultServiceFactories,
+    instanceId: options.instanceId,
+  });
 }

--- a/packages/backend-defaults/src/CreateBackendOptions.test.ts
+++ b/packages/backend-defaults/src/CreateBackendOptions.test.ts
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2026 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { createSpecializedBackend } from '@backstage/backend-app-api';
+import { createBackend, defaultServiceFactories } from './CreateBackend';
+
+jest.mock('@backstage/backend-app-api', () => ({
+  ...jest.requireActual('@backstage/backend-app-api'),
+  createSpecializedBackend: jest.fn(() => ({})),
+}));
+
+describe('createBackend options', () => {
+  it('should forward the provided instance ID', () => {
+    createBackend({ instanceId: 'my-instance' });
+
+    expect(createSpecializedBackend).toHaveBeenCalledWith({
+      defaultServiceFactories,
+      instanceId: 'my-instance',
+    });
+  });
+});

--- a/packages/backend-defaults/src/index.ts
+++ b/packages/backend-defaults/src/index.ts
@@ -20,5 +20,9 @@
  * @packageDocumentation
  */
 
-export { createBackend, defaultServiceFactories } from './CreateBackend';
+export {
+  createBackend,
+  defaultServiceFactories,
+  type CreateBackendOptions,
+} from './CreateBackend';
 export { discoveryFeatureLoader } from './discoveryFeatureLoader';

--- a/packages/backend-plugin-api/report.api.md
+++ b/packages/backend-plugin-api/report.api.md
@@ -603,6 +603,7 @@ export interface RootHttpRouterService {
 
 // @public (undocumented)
 export interface RootInstanceMetadataService {
+  getId(): string;
   // (undocumented)
   getInstalledPlugins: () => Promise<
     ReadonlyArray<RootInstanceMetadataServicePluginInfo>

--- a/packages/backend-plugin-api/src/services/definitions/RootInstanceMetadataService.ts
+++ b/packages/backend-plugin-api/src/services/definitions/RootInstanceMetadataService.ts
@@ -25,10 +25,12 @@ export interface RootInstanceMetadataServicePluginInfo {
 /** @public */
 export interface RootInstanceMetadataService {
   /**
-   * The globally unique identifier of this Backstage backend instance.
+   * The globally unique identifier of this specific Backstage backend
+   * instance.
    *
-   * The identifier is stable for the lifetime of the instance and should be
-   * treated as an opaque string.
+   * Every backend instance has its own identifier. The identifier is stable
+   * for the lifetime of the instance, must never be reused for another backend
+   * instance, and should be treated as an opaque string.
    */
   getId(): string;
 

--- a/packages/backend-plugin-api/src/services/definitions/RootInstanceMetadataService.ts
+++ b/packages/backend-plugin-api/src/services/definitions/RootInstanceMetadataService.ts
@@ -24,6 +24,14 @@ export interface RootInstanceMetadataServicePluginInfo {
 
 /** @public */
 export interface RootInstanceMetadataService {
+  /**
+   * The globally unique identifier of this Backstage backend instance.
+   *
+   * The identifier is stable for the lifetime of the instance and should be
+   * treated as an opaque string.
+   */
+  getId(): string;
+
   getInstalledPlugins: () => Promise<
     ReadonlyArray<RootInstanceMetadataServicePluginInfo>
   >;

--- a/packages/backend-test-utils/src/services/mockServices.ts
+++ b/packages/backend-test-utils/src/services/mockServices.ts
@@ -566,6 +566,7 @@ export namespace mockServices {
 
   export function rootInstanceMetadata(): RootInstanceMetadataService {
     return {
+      getId: () => 'mock',
       getInstalledPlugins: () => Promise.resolve([]),
     };
   }
@@ -573,6 +574,7 @@ export namespace mockServices {
     export const mock = createServiceMock(
       coreServices.rootInstanceMetadata,
       () => ({
+        getId: jest.fn().mockReturnValue('mock'),
         getInstalledPlugins: jest.fn(),
       }),
     );

--- a/plugins/signals-backend/src/plugin.ts
+++ b/plugins/signals-backend/src/plugin.ts
@@ -39,6 +39,7 @@ export const signalsPlugin = createBackendPlugin({
         userInfo: coreServices.userInfo,
         auth: coreServices.auth,
         events: eventsServiceRef,
+        instanceMetadata: coreServices.rootInstanceMetadata,
       },
       async init({
         httpRouter,
@@ -49,6 +50,7 @@ export const signalsPlugin = createBackendPlugin({
         userInfo,
         auth,
         events,
+        instanceMetadata,
       }) {
         httpRouter.use(
           await createRouter({
@@ -59,6 +61,7 @@ export const signalsPlugin = createBackendPlugin({
             userInfo,
             auth,
             events,
+            instanceMetadata,
           }),
         );
         httpRouter.addAuthPolicy({

--- a/plugins/signals-backend/src/service/SignalManager.test.ts
+++ b/plugins/signals-backend/src/service/SignalManager.test.ts
@@ -61,10 +61,12 @@ class MockWebSocket {
 
 describe('SignalManager', () => {
   let onEvent: Function;
+  let subscription: EventsServiceSubscribeOptions;
 
   const mockEvents = {
     publish: async () => {},
     subscribe: async (subscriber: EventsServiceSubscribeOptions) => {
+      subscription = subscriber;
       onEvent = subscriber.onEvent;
     },
   };
@@ -79,6 +81,13 @@ describe('SignalManager', () => {
     logger: mockServices.logger.mock(),
     config: mockServices.rootConfig(),
     lifecycle: mockLifecycle,
+    instanceMetadata: mockServices.rootInstanceMetadata.mock({
+      getId: () => 'test-instance',
+    }),
+  });
+
+  it('should use the backend instance ID for the event subscription', () => {
+    expect(subscription.id).toBe('test-instance');
   });
 
   it('should close all connections when server is closed', () => {

--- a/plugins/signals-backend/src/service/SignalManager.ts
+++ b/plugins/signals-backend/src/service/SignalManager.ts
@@ -16,7 +16,6 @@
 
 import { EventParams, EventsService } from '@backstage/plugin-events-node';
 import { SignalPayload } from '@backstage/plugin-signals-node';
-import crypto from 'node:crypto';
 import { RawData, WebSocket } from 'ws';
 import { randomUUID as uuid } from 'node:crypto';
 import { JsonObject } from '@backstage/types';
@@ -24,6 +23,7 @@ import {
   BackstageUserInfo,
   LifecycleService,
   LoggerService,
+  RootInstanceMetadataService,
 } from '@backstage/backend-plugin-api';
 import { Config } from '@backstage/config';
 
@@ -47,6 +47,7 @@ export type SignalManagerOptions = {
   config: Config;
   logger: LoggerService;
   lifecycle: LifecycleService;
+  instanceMetadata: RootInstanceMetadataService;
 };
 
 /** @internal */
@@ -69,7 +70,7 @@ export class SignalManager {
     // Use a unique subscriber ID for each signals instance, in order to fan-out
     // all events to each signals instance. This ensures that events always
     // reach users in a scaled deployment.
-    const id = `signals-${crypto.randomBytes(8).toString('hex')}`;
+    const id = options.instanceMetadata.getId();
     this.logger = options.logger.child({ subscriberId: id });
     this.logger.info(`Signals manager is subscribing to signals events`);
 

--- a/plugins/signals-backend/src/service/router.test.ts
+++ b/plugins/signals-backend/src/service/router.test.ts
@@ -36,6 +36,7 @@ describe('createRouter', () => {
       userInfo,
       config: mockServices.rootConfig(),
       lifecycle: mockServices.lifecycle.mock(),
+      instanceMetadata: mockServices.rootInstanceMetadata.mock(),
       auth: mockServices.auth(),
     });
     app = express().use(router).use(mockErrorHandler());

--- a/plugins/signals-backend/src/service/router.ts
+++ b/plugins/signals-backend/src/service/router.ts
@@ -22,6 +22,7 @@ import {
   DiscoveryService,
   LifecycleService,
   LoggerService,
+  RootInstanceMetadataService,
   UserInfoService,
 } from '@backstage/backend-plugin-api';
 import * as https from 'node:https';
@@ -38,6 +39,7 @@ export interface RouterOptions {
   discovery: DiscoveryService;
   config: Config;
   lifecycle: LifecycleService;
+  instanceMetadata: RootInstanceMetadataService;
   userInfo: UserInfoService;
   auth: AuthService;
 }


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Been running into the need for an "instance ID" every now and then, and with the system metadata service in place and stable, I figured it's the perfect place to add it. The ID is a random UUID by default, but could also be wired to something like pod IDs or other unique deployment identifiers for correlation.

Updated the signals backend as the first consumer of this as well.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
