### PR TITLE
fix(frontend-plugin-api): keep extension order when applying plugin overrides

### DIFF
--- a/.changeset/spotty-pugs-argue.md
+++ b/.changeset/spotty-pugs-argue.md
@@ -1,0 +1,5 @@
+---
+'@backstage/frontend-plugin-api': patch
+---
+
+Fixed a bug where overriding a plugin extension with `withOverrides` moved the overridden extension to the end of the plugin's extension list. This caused overridden extensions to lose their original position, for example making an overridden sub page tab move to the end of the tabs on its page. Overridden extensions now keep their original order, while extensions that don't override an existing one are appended at the end.

--- a/packages/frontend-plugin-api/src/wiring/createFrontendPlugin.test.ts
+++ b/packages/frontend-plugin-api/src/wiring/createFrontendPlugin.test.ts
@@ -370,10 +370,19 @@ describe('createFrontendPlugin', () => {
       `);
     });
 
-    it('should allow overriding extensions that have a matching ID, while keeping old extensions that do not have overlapping IDs', async () => {
+    it('should allow overriding extensions that have a matching ID, keeping the original extension order and appending extensions that do not have overlapping IDs', async () => {
       const plugin = createFrontendPlugin({
         pluginId: 'test',
         extensions: [Extension1, Extension2, outputExtension],
+      });
+
+      const NewExtension = createExtension({
+        name: 'new',
+        attachTo: { id: 'test/output', input: 'names' },
+        output: [nameExtensionDataRef],
+        factory() {
+          return [nameExtensionDataRef('extension-new')];
+        },
       });
 
       await renderWithEffects(
@@ -381,6 +390,7 @@ describe('createFrontendPlugin', () => {
           features: [
             plugin.withOverrides({
               extensions: [
+                NewExtension,
                 plugin.getExtension('test/1').override({
                   factory() {
                     return [nameExtensionDataRef('overridden')];
@@ -398,7 +408,7 @@ describe('createFrontendPlugin', () => {
       );
 
       await expect(
-        screen.findByText('Names: extension-2, overridden'),
+        screen.findByText('Names: overridden, extension-2, extension-new'),
       ).resolves.toBeInTheDocument();
     });
   });

--- a/packages/frontend-plugin-api/src/wiring/createFrontendPlugin.test.ts
+++ b/packages/frontend-plugin-api/src/wiring/createFrontendPlugin.test.ts
@@ -411,5 +411,18 @@ describe('createFrontendPlugin', () => {
         screen.findByText('Names: overridden, extension-2, extension-new'),
       ).resolves.toBeInTheDocument();
     });
+
+    it('should throw when overriding the same extension multiple times', () => {
+      const plugin = createFrontendPlugin({
+        pluginId: 'test',
+        extensions: [Extension1, Extension2],
+      });
+
+      expect(() =>
+        plugin.withOverrides({
+          extensions: [Extension1, Extension1],
+        }),
+      ).toThrow("Plugin 'test' provided duplicate extensions: test/1");
+    });
   });
 });

--- a/packages/frontend-plugin-api/src/wiring/createFrontendPlugin.test.ts
+++ b/packages/frontend-plugin-api/src/wiring/createFrontendPlugin.test.ts
@@ -94,6 +94,15 @@ const Child2 = createExtension({
   },
 });
 
+const NewExtension = createExtension({
+  name: 'new',
+  attachTo: { id: 'test/output', input: 'names' },
+  output: [nameExtensionDataRef],
+  factory() {
+    return [nameExtensionDataRef('extension-new')];
+  },
+});
+
 const outputExtension = createExtension({
   name: 'output',
   attachTo: { id: 'app', input: 'root' },
@@ -373,16 +382,7 @@ describe('createFrontendPlugin', () => {
     it('should allow overriding extensions that have a matching ID, keeping the original extension order and appending extensions that do not have overlapping IDs', async () => {
       const plugin = createFrontendPlugin({
         pluginId: 'test',
-        extensions: [Extension1, Extension2, outputExtension],
-      });
-
-      const NewExtension = createExtension({
-        name: 'new',
-        attachTo: { id: 'test/output', input: 'names' },
-        output: [nameExtensionDataRef],
-        factory() {
-          return [nameExtensionDataRef('extension-new')];
-        },
+        extensions: [Extension1, Extension2, Extension3, outputExtension],
       });
 
       await renderWithEffects(
@@ -394,6 +394,11 @@ describe('createFrontendPlugin', () => {
                 plugin.getExtension('test/1').override({
                   factory() {
                     return [nameExtensionDataRef('overridden')];
+                  },
+                }),
+                plugin.getExtension('test/2').override({
+                  factory() {
+                    return [nameExtensionDataRef('overridden-2')];
                   },
                 }),
               ],
@@ -408,7 +413,9 @@ describe('createFrontendPlugin', () => {
       );
 
       await expect(
-        screen.findByText('Names: overridden, extension-2, extension-new'),
+        screen.findByText(
+          'Names: overridden, overridden-2, extension-3:, extension-new',
+        ),
       ).resolves.toBeInTheDocument();
     });
 

--- a/packages/frontend-plugin-api/src/wiring/createFrontendPlugin.ts
+++ b/packages/frontend-plugin-api/src/wiring/createFrontendPlugin.ts
@@ -22,6 +22,7 @@ import {
 import {
   resolveExtensionDefinition,
   resolveExtensionDefinitions,
+  throwOnDuplicateExtensionIds,
 } from './resolveExtensionDefinition';
 import { FeatureFlagConfig } from './types';
 import { MakeSortedExtensionsMap } from './MakeSortedExtensionsMap';
@@ -111,6 +112,11 @@ export interface OverridableFrontendPlugin<
     id: TId,
   ): OverridableExtensionDefinition<TExtensionMap[TId]['T']>;
   withOverrides(options: {
+    /**
+     * Extensions to add to the plugin. An extension that overrides an existing
+     * extension replaces it at its original position in the plugin's list of
+     * extensions, while other extensions are appended at the end.
+     */
     extensions?: Array<ExtensionDefinition>;
 
     /**
@@ -320,21 +326,10 @@ export function createFrontendPlugin<
             extension,
           ] as const,
       );
-      const overrideExtensionIds = overrideExtensionEntries.map(([id]) => id);
-      const duplicateIds = Array.from(
-        new Set(
-          overrideExtensionIds.filter(
-            (id, index) => overrideExtensionIds.indexOf(id) !== index,
-          ),
-        ),
+      throwOnDuplicateExtensionIds(
+        overrideExtensionEntries.map(([id]) => id),
+        { namespace: pluginId, featureType: 'Plugin' },
       );
-      if (duplicateIds.length > 0) {
-        throw new Error(
-          `Plugin '${pluginId}' provided duplicate extensions: ${duplicateIds.join(
-            ', ',
-          )}`,
-        );
-      }
       const overrideExtensionsById = new Map(overrideExtensionEntries);
       // Extensions that override an existing one replace it in place, keeping
       // the original registration order, since the order affects the order of
@@ -351,19 +346,16 @@ export function createFrontendPlugin<
         }
         return extension;
       });
-      const newExtensions = overrideExtensions.filter(
-        e =>
-          !replacedExtensionIds.has(
-            resolveExtensionDefinition(e, { namespace: pluginId }).id,
-          ),
-      );
+      const appendedExtensions = overrideExtensionEntries
+        .filter(([id]) => !replacedExtensionIds.has(id))
+        .map(([, extension]) => extension);
       return createFrontendPlugin({
         ...options,
         pluginId,
         if: ifPredicate,
         title: overrides.title ?? options.title,
         icon: overrides.icon ?? options.icon,
-        extensions: [...mergedExtensions, ...newExtensions],
+        extensions: [...mergedExtensions, ...appendedExtensions],
         info: {
           ...options.info,
           ...overrides.info,

--- a/packages/frontend-plugin-api/src/wiring/createFrontendPlugin.ts
+++ b/packages/frontend-plugin-api/src/wiring/createFrontendPlugin.ts
@@ -313,14 +313,30 @@ export function createFrontendPlugin<
         ifPredicate = overrides.if;
       }
       const overrideExtensions = overrides.extensions ?? [];
-      const overriddenExtensionIds = new Set(
-        overrideExtensions.map(
-          e => resolveExtensionDefinition(e, { namespace: pluginId }).id,
-        ),
+      const overrideExtensionsById = new Map(
+        overrideExtensions.map(e => [
+          resolveExtensionDefinition(e, { namespace: pluginId }).id,
+          e,
+        ]),
       );
-      const nonOverriddenExtensions = (options.extensions ?? []).filter(
+      // Extensions that override an existing one replace it in place, keeping
+      // the original registration order, since the order affects the order of
+      // attachments in the app. Remaining extensions are appended at the end.
+      const replacedExtensionIds = new Set<string>();
+      const mergedExtensions = (options.extensions ?? []).map(extension => {
+        const id = resolveExtensionDefinition(extension, {
+          namespace: pluginId,
+        }).id;
+        const overrideExtension = overrideExtensionsById.get(id);
+        if (overrideExtension) {
+          replacedExtensionIds.add(id);
+          return overrideExtension;
+        }
+        return extension;
+      });
+      const newExtensions = overrideExtensions.filter(
         e =>
-          !overriddenExtensionIds.has(
+          !replacedExtensionIds.has(
             resolveExtensionDefinition(e, { namespace: pluginId }).id,
           ),
       );
@@ -330,7 +346,7 @@ export function createFrontendPlugin<
         if: ifPredicate,
         title: overrides.title ?? options.title,
         icon: overrides.icon ?? options.icon,
-        extensions: [...nonOverriddenExtensions, ...overrideExtensions],
+        extensions: [...mergedExtensions, ...newExtensions],
         info: {
           ...options.info,
           ...overrides.info,

--- a/packages/frontend-plugin-api/src/wiring/createFrontendPlugin.ts
+++ b/packages/frontend-plugin-api/src/wiring/createFrontendPlugin.ts
@@ -313,12 +313,29 @@ export function createFrontendPlugin<
         ifPredicate = overrides.if;
       }
       const overrideExtensions = overrides.extensions ?? [];
-      const overrideExtensionsById = new Map(
-        overrideExtensions.map(e => [
-          resolveExtensionDefinition(e, { namespace: pluginId }).id,
-          e,
-        ]),
+      const overrideExtensionEntries = overrideExtensions.map(
+        extension =>
+          [
+            resolveExtensionDefinition(extension, { namespace: pluginId }).id,
+            extension,
+          ] as const,
       );
+      const overrideExtensionIds = overrideExtensionEntries.map(([id]) => id);
+      const duplicateIds = Array.from(
+        new Set(
+          overrideExtensionIds.filter(
+            (id, index) => overrideExtensionIds.indexOf(id) !== index,
+          ),
+        ),
+      );
+      if (duplicateIds.length > 0) {
+        throw new Error(
+          `Plugin '${pluginId}' provided duplicate extensions: ${duplicateIds.join(
+            ', ',
+          )}`,
+        );
+      }
+      const overrideExtensionsById = new Map(overrideExtensionEntries);
       // Extensions that override an existing one replace it in place, keeping
       // the original registration order, since the order affects the order of
       // attachments in the app. Remaining extensions are appended at the end.

--- a/packages/frontend-plugin-api/src/wiring/resolveExtensionDefinition.ts
+++ b/packages/frontend-plugin-api/src/wiring/resolveExtensionDefinition.ts
@@ -220,20 +220,36 @@ export function resolveExtensionDefinitions(
   }
 
   if (extensions.length !== extensionDefinitionsById.size) {
-    const extensionIds = extensions.map(e => e.id);
-    const duplicates = Array.from(
-      new Set(
-        extensionIds.filter((id, index) => extensionIds.indexOf(id) !== index),
-      ),
+    throwOnDuplicateExtensionIds(
+      extensions.map(e => e.id),
+      context,
     );
+  }
+
+  return { extensions, extensionDefinitionsById };
+}
+
+/**
+ * Throws if the provided list of resolved extension IDs contains duplicates.
+ *
+ * @internal
+ */
+export function throwOnDuplicateExtensionIds(
+  extensionIds: string[],
+  context: { namespace: string; featureType: string },
+): void {
+  const duplicates = Array.from(
+    new Set(
+      extensionIds.filter((id, index) => extensionIds.indexOf(id) !== index),
+    ),
+  );
+  if (duplicates.length > 0) {
     throw new Error(
       `${context.featureType} '${
         context.namespace
       }' provided duplicate extensions: ${duplicates.join(', ')}`,
     );
   }
-
-  return { extensions, extensionDefinitionsById };
 }
 
 /** @internal */

--- a/packages/frontend-plugin-api/src/wiring/resolveExtensionDefinition.ts
+++ b/packages/frontend-plugin-api/src/wiring/resolveExtensionDefinition.ts
@@ -219,12 +219,10 @@ export function resolveExtensionDefinitions(
     });
   }
 
-  if (extensions.length !== extensionDefinitionsById.size) {
-    throwOnDuplicateExtensionIds(
-      extensions.map(e => e.id),
-      context,
-    );
-  }
+  throwOnDuplicateExtensionIds(
+    extensions.map(e => e.id),
+    context,
+  );
 
   return { extensions, extensionDefinitionsById };
 }
@@ -238,16 +236,20 @@ export function throwOnDuplicateExtensionIds(
   extensionIds: string[],
   context: { namespace: string; featureType: string },
 ): void {
-  const duplicates = Array.from(
-    new Set(
-      extensionIds.filter((id, index) => extensionIds.indexOf(id) !== index),
-    ),
-  );
-  if (duplicates.length > 0) {
+  const seen = new Set<string>();
+  const duplicates = new Set<string>();
+  for (const id of extensionIds) {
+    if (seen.has(id)) {
+      duplicates.add(id);
+    } else {
+      seen.add(id);
+    }
+  }
+  if (duplicates.size > 0) {
     throw new Error(
       `${context.featureType} '${
         context.namespace
-      }' provided duplicate extensions: ${duplicates.join(', ')}`,
+      }' provided duplicate extensions: ${Array.from(duplicates).join(', ')}`,
     );
   }
 }


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Fixes #34449

When a plugin extension is overridden via `FrontendPlugin.withOverrides`, the overridden extension was removed from its original position and appended at the end of the plugin's extension list. Since extension order determines attachment order in the app, this reordered things like header tabs: overriding a sub page moved its tab to the end, and could change which sub page the parent page's root path falls through to (e.g. `/create` landing on `/create/tasks` instead of `/create/templates`).

This change makes `withOverrides` replace overridden extensions in place, keeping the original registration order. Extensions that don't override an existing one are still appended at the end, as before. This implements the in-place replacement approach discussed in the issue. Duplicate overrides for the same extension keep throwing the same error as before, now validated through a helper shared with the plugin's own duplicate-extension check.

Reproduced in the example app by overriding the scaffolder `tasks` sub page with a replacement that retitles the tab to `Tasks Override`, so the screenshots show both that the override is in effect and where the tab ends up:

**1. Original, without any override** — tabs in registration order (`Templates, Tasks, Actions, Template Editor, Templating Extensions`):

![original without override](https://raw.githubusercontent.com/gustavolira/backstage/assets/sub-page-override-order/baseline.png)

**2. With the override, before this fix** — the overridden `Tasks Override` tab moves to the end of the tabs:

![override before the fix](https://raw.githubusercontent.com/gustavolira/backstage/assets/sub-page-override-order/before.png)

**3. With the same override, after this fix** — the `Tasks Override` tab stays in the original `Tasks` position:

![override after the fix](https://raw.githubusercontent.com/gustavolira/backstage/assets/sub-page-override-order/after.png)

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))

🤖 Generated with [Claude Code](https://claude.com/claude-code)
