### PR TITLE
fix(scaffolder-react): handle back/next mouse buttons in Stepper

### DIFF
--- a/.changeset/scaffolder-stepper-history-navigation.md
+++ b/.changeset/scaffolder-stepper-history-navigation.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-scaffolder-react': patch
+---
+
+Fixed the scaffolder `Stepper` ignoring browser back/forward navigation. Previously the wizard's active step lived only in React state, so no history entries were pushed as a user moved through steps — the browser's (or a mouse's) back/forward buttons would skip the whole wizard and land on whichever page was open before the template was opened, instead of stepping back and forward like the on-page Back/Next buttons do. Each step change now also pushes a history entry, and a `popstate` listener drives the step back in sync with it.

--- a/.changeset/scaffolder-stepper-history-navigation.md
+++ b/.changeset/scaffolder-stepper-history-navigation.md
@@ -2,4 +2,4 @@
 '@backstage/plugin-scaffolder-react': patch
 ---
 
-Fixed the scaffolder `Stepper` ignoring browser back/forward navigation. Previously the wizard's active step lived only in React state, so no history entries were pushed as a user moved through steps — the browser's (or a mouse's) back/forward buttons would skip the whole wizard and land on whichever page was open before the template was opened, instead of stepping back and forward like the on-page Back/Next buttons do. Each step change now also pushes a history entry, and a `popstate` listener drives the step back in sync with it.
+Fixed the scaffolder `Stepper` ignoring browser back/forward navigation. Previously, using the browser's (or a mouse's) back/forward buttons while filling out a template would skip the whole wizard and land on whichever page was open before the template was opened. The wizard now steps back and forward through its own steps first, matching the on-page Back/Next buttons, including re-validating the current step's data before a forward navigation is allowed to proceed.

--- a/plugins/scaffolder-react/src/next/components/Stepper/Stepper.test.tsx
+++ b/plugins/scaffolder-react/src/next/components/Stepper/Stepper.test.tsx
@@ -18,6 +18,7 @@ import { JsonValue } from '@backstage/types';
 import type { RJSFValidationError } from '@rjsf/utils';
 import { act, fireEvent, waitFor } from '@testing-library/react';
 import { useEffect } from 'react';
+import { BrowserRouter } from 'react-router-dom';
 
 import { FieldExtensionComponentProps } from '../../../extensions';
 import { LayoutTemplate } from '../../../layouts';
@@ -790,7 +791,13 @@ describe('Stepper', () => {
   });
 
   describe('browser back/forward navigation', () => {
-    it('should step back and forward through the wizard on history navigation, matching the Back/Next buttons', async () => {
+    // These tests need window.location/history to actually drive the
+    // router (unlike the MemoryRouter the other tests get from
+    // renderInTestApp), since the behaviour under test is specifically
+    // about the wizard's interaction with real browser navigation.
+    const withBrowserRouter = { components: { Router: BrowserRouter } };
+
+    it('should step back and forward through the wizard on history navigation, matching the Back/Next buttons, and leave the wizard on a Back past its first step', async () => {
       const manifest: TemplateParameterSchema = {
         steps: [
           {
@@ -805,10 +812,21 @@ describe('Stepper', () => {
         title: 'History navigation test',
       };
 
-      const { getByRole, queryByRole } = await renderInTestApp(
+      // Simulate arriving at the wizard the way the real app does: the
+      // template list is the previous entry, the wizard route is pushed on
+      // top of it when a template is selected.
+      window.history.replaceState({}, '', '/create');
+      window.history.pushState(
+        {},
+        '',
+        '/create/actions/history-navigation-test',
+      );
+
+      const { getByRole, queryByRole, unmount } = await renderInTestApp(
         <SecretsContextProvider>
           <Stepper manifest={manifest} extensions={[]} onCreate={jest.fn()} />
         </SecretsContextProvider>,
+        withBrowserRouter,
       );
 
       expect(getByRole('textbox', { name: 'name' })).toBeInTheDocument();
@@ -830,6 +848,10 @@ describe('Stepper', () => {
       expect(
         queryByRole('textbox', { name: 'description' }),
       ).not.toBeInTheDocument();
+      // Still inside the wizard - only the step changed, not the route.
+      expect(window.location.pathname).toBe(
+        '/create/actions/history-navigation-test',
+      );
 
       // And forward.
       await act(async () => {
@@ -841,6 +863,107 @@ describe('Stepper', () => {
           getByRole('textbox', { name: 'description' }),
         ).toBeInTheDocument();
       });
+
+      // Back to step 1, then back again should leave the wizard entirely -
+      // a duplicate history entry from mounting would require this second
+      // press to only unmask the first one, leaving the route unchanged.
+      await act(async () => {
+        window.history.back();
+      });
+      await waitFor(() => {
+        expect(getByRole('textbox', { name: 'name' })).toBeInTheDocument();
+      });
+
+      await act(async () => {
+        window.history.back();
+      });
+      await waitFor(() => {
+        expect(window.location.pathname).toBe('/create');
+      });
+
+      unmount();
+    });
+
+    it('should block a forward history navigation that would restore now-invalid step data, matching the Next button', async () => {
+      const manifest: TemplateParameterSchema = {
+        steps: [
+          {
+            title: 'Step 1',
+            schema: {
+              properties: { name: { type: 'string', pattern: '^[a-z]+$' } },
+            },
+          },
+          {
+            title: 'Step 2',
+            schema: { properties: { description: { type: 'string' } } },
+          },
+        ],
+        title: 'History navigation validation test',
+      };
+
+      window.history.replaceState({}, '', '/create');
+      window.history.pushState(
+        {},
+        '',
+        '/create/actions/history-navigation-validation-test',
+      );
+
+      const { getByRole, queryByRole, unmount } = await renderInTestApp(
+        <SecretsContextProvider>
+          <Stepper manifest={manifest} extensions={[]} onCreate={jest.fn()} />
+        </SecretsContextProvider>,
+        withBrowserRouter,
+      );
+
+      await act(async () => {
+        fireEvent.change(getByRole('textbox', { name: 'name' }), {
+          target: { value: 'validname' },
+        });
+      });
+
+      await act(async () => {
+        fireEvent.click(getByRole('button', { name: 'Next' }));
+      });
+
+      expect(getByRole('textbox', { name: 'description' })).toBeInTheDocument();
+
+      await act(async () => {
+        window.history.back();
+      });
+
+      await waitFor(() => {
+        expect(getByRole('textbox', { name: 'name' })).toBeInTheDocument();
+      });
+
+      // Make step 1's data invalid, then try to go Forward like the
+      // browser would - clicking Next would be blocked, so this must be too.
+      await act(async () => {
+        fireEvent.change(getByRole('textbox', { name: 'name' }), {
+          target: { value: '123' },
+        });
+      });
+
+      await act(async () => {
+        window.history.forward();
+      });
+
+      await waitFor(() => {
+        expect(
+          queryByRole('textbox', { name: 'description' }),
+        ).not.toBeInTheDocument();
+      });
+      expect(getByRole('textbox', { name: 'name' })).toBeInTheDocument();
+
+      // Confirm the browser's forward move was actually undone (not just
+      // that the step didn't change), so no history mismatch is left
+      // behind for whatever mounts next.
+      await waitFor(() => {
+        expect(window.location.pathname).toBe(
+          '/create/actions/history-navigation-validation-test',
+        );
+      });
+
+      unmount();
     });
   });
 

--- a/plugins/scaffolder-react/src/next/components/Stepper/Stepper.test.tsx
+++ b/plugins/scaffolder-react/src/next/components/Stepper/Stepper.test.tsx
@@ -819,8 +819,7 @@ describe('Stepper', () => {
 
       expect(getByRole('textbox', { name: 'description' })).toBeInTheDocument();
 
-      // Simulate the browser's (or a mouse's) back button: it pops the
-      // history entry the Next click pushed and fires `popstate`.
+      // Simulate the browser back button.
       await act(async () => {
         window.history.back();
       });
@@ -832,7 +831,7 @@ describe('Stepper', () => {
         queryByRole('textbox', { name: 'description' }),
       ).not.toBeInTheDocument();
 
-      // Forward should restore the step Next led to, same as clicking it.
+      // And forward.
       await act(async () => {
         window.history.forward();
       });

--- a/plugins/scaffolder-react/src/next/components/Stepper/Stepper.test.tsx
+++ b/plugins/scaffolder-react/src/next/components/Stepper/Stepper.test.tsx
@@ -789,6 +789,62 @@ describe('Stepper', () => {
     unmount();
   });
 
+  describe('browser back/forward navigation', () => {
+    it('should step back and forward through the wizard on history navigation, matching the Back/Next buttons', async () => {
+      const manifest: TemplateParameterSchema = {
+        steps: [
+          {
+            title: 'Step 1',
+            schema: { properties: { name: { type: 'string' } } },
+          },
+          {
+            title: 'Step 2',
+            schema: { properties: { description: { type: 'string' } } },
+          },
+        ],
+        title: 'History navigation test',
+      };
+
+      const { getByRole, queryByRole } = await renderInTestApp(
+        <SecretsContextProvider>
+          <Stepper manifest={manifest} extensions={[]} onCreate={jest.fn()} />
+        </SecretsContextProvider>,
+      );
+
+      expect(getByRole('textbox', { name: 'name' })).toBeInTheDocument();
+
+      await act(async () => {
+        fireEvent.click(getByRole('button', { name: 'Next' }));
+      });
+
+      expect(getByRole('textbox', { name: 'description' })).toBeInTheDocument();
+
+      // Simulate the browser's (or a mouse's) back button: it pops the
+      // history entry the Next click pushed and fires `popstate`.
+      await act(async () => {
+        window.history.back();
+      });
+
+      await waitFor(() => {
+        expect(getByRole('textbox', { name: 'name' })).toBeInTheDocument();
+      });
+      expect(
+        queryByRole('textbox', { name: 'description' }),
+      ).not.toBeInTheDocument();
+
+      // Forward should restore the step Next led to, same as clicking it.
+      await act(async () => {
+        window.history.forward();
+      });
+
+      await waitFor(() => {
+        expect(
+          getByRole('textbox', { name: 'description' }),
+        ).toBeInTheDocument();
+      });
+    });
+  });
+
   describe('Scaffolder Layouts', () => {
     it('should render the step in the scaffolder layout', async () => {
       const ScaffolderLayout: LayoutTemplate = ({ properties }) => (

--- a/plugins/scaffolder-react/src/next/components/Stepper/Stepper.tsx
+++ b/plugins/scaffolder-react/src/next/components/Stepper/Stepper.tsx
@@ -243,18 +243,12 @@ export const Stepper = (stepperProps: StepperProps) => {
     }
   }, [activeStep]);
 
-  // Without this, activeStep lives only in React state: the stepper never
-  // pushes a browser history entry, so the browser's (or a mouse's)
-  // back/forward buttons skip the whole wizard instead of stepping back and
-  // forward like the on-page Back/Next buttons do.
+  // Keeps browser/mouse back-forward in sync with activeStep.
   const isPopStateStepRef = useRef(false);
 
   useEffect(() => {
     if (isPopStateStepRef.current) {
-      // This change came from the popstate listener below, not from
-      // handleNext/handleBack/a step-label click — the browser already
-      // moved the history pointer, so pushing again would create a
-      // duplicate entry.
+      // Change came from popstate below; the history pointer already moved.
       isPopStateStepRef.current = false;
       return;
     }
@@ -267,8 +261,7 @@ export const Stepper = (stepperProps: StepperProps) => {
     const onPopState = (event: PopStateEvent) => {
       const step = (event.state as { scaffolderStep?: number } | null)
         ?.scaffolderStep;
-      // No `scaffolderStep` means the entry predates the wizard (or belongs
-      // to a different page) — let the browser navigate away as normal.
+      // No scaffolderStep = entry predates the wizard; let navigation proceed.
       if (typeof step === 'number') {
         isPopStateStepRef.current = true;
         setActiveStep(step);

--- a/plugins/scaffolder-react/src/next/components/Stepper/Stepper.tsx
+++ b/plugins/scaffolder-react/src/next/components/Stepper/Stepper.tsx
@@ -245,6 +245,12 @@ export const Stepper = (stepperProps: StepperProps) => {
 
   // Keeps browser/mouse back-forward in sync with activeStep.
   const isPopStateStepRef = useRef(false);
+  const hasMountedHistoryRef = useRef(false);
+  const stepsStateRef = useRef(stepsState);
+
+  useEffect(() => {
+    stepsStateRef.current = stepsState;
+  }, [stepsState]);
 
   useEffect(() => {
     if (isPopStateStepRef.current) {
@@ -252,25 +258,57 @@ export const Stepper = (stepperProps: StepperProps) => {
       isPopStateStepRef.current = false;
       return;
     }
+    if (!hasMountedHistoryRef.current) {
+      // Replace, don't push: the current entry is already the wizard's
+      // entry, so pushing here would leave a duplicate behind it and Back
+      // would have to be pressed twice to actually leave the wizard.
+      hasMountedHistoryRef.current = true;
+      window.history.replaceState({ scaffolderStep: activeStep }, '');
+      return;
+    }
     window.history.pushState({ scaffolderStep: activeStep }, '');
   }, [activeStep]);
 
   useEffect(() => {
-    window.history.replaceState({ scaffolderStep: 0 }, '');
-
     const onPopState = (event: PopStateEvent) => {
       const step = (event.state as { scaffolderStep?: number } | null)
         ?.scaffolderStep;
-      // No scaffolderStep = entry predates the wizard; let navigation proceed.
-      if (typeof step === 'number') {
+      // No scaffolderStep = entry predates the wizard; let navigation
+      // proceed. Same step = the pointer already matches; nothing to sync.
+      if (typeof step !== 'number' || step === activeStep) {
+        return;
+      }
+
+      if (step < activeStep) {
         isPopStateStepRef.current = true;
         setActiveStep(step);
+        return;
       }
+
+      // Stepping forward must pass the same validation as the Next button,
+      // otherwise Forward could reach a step whose prior data is now invalid.
+      (async () => {
+        setErrors(undefined);
+        setIsValidating(true);
+        const returnedValidation = await validation(stepsStateRef.current);
+        setIsValidating(false);
+
+        if (hasErrors(returnedValidation)) {
+          setErrors(returnedValidation);
+          // Undo the browser's forward move; the step didn't actually change.
+          window.history.go(-1);
+          return;
+        }
+
+        setErrors(undefined);
+        isPopStateStepRef.current = true;
+        setActiveStep(step);
+      })();
     };
 
     window.addEventListener('popstate', onPopState);
     return () => window.removeEventListener('popstate', onPopState);
-  }, []);
+  }, [activeStep, validation]);
 
   const mergedUiSchema = merge({}, propUiSchema, currentStep?.uiSchema);
 

--- a/plugins/scaffolder-react/src/next/components/Stepper/Stepper.tsx
+++ b/plugins/scaffolder-react/src/next/components/Stepper/Stepper.tsx
@@ -243,6 +243,42 @@ export const Stepper = (stepperProps: StepperProps) => {
     }
   }, [activeStep]);
 
+  // Without this, activeStep lives only in React state: the stepper never
+  // pushes a browser history entry, so the browser's (or a mouse's)
+  // back/forward buttons skip the whole wizard instead of stepping back and
+  // forward like the on-page Back/Next buttons do.
+  const isPopStateStepRef = useRef(false);
+
+  useEffect(() => {
+    if (isPopStateStepRef.current) {
+      // This change came from the popstate listener below, not from
+      // handleNext/handleBack/a step-label click — the browser already
+      // moved the history pointer, so pushing again would create a
+      // duplicate entry.
+      isPopStateStepRef.current = false;
+      return;
+    }
+    window.history.pushState({ scaffolderStep: activeStep }, '');
+  }, [activeStep]);
+
+  useEffect(() => {
+    window.history.replaceState({ scaffolderStep: 0 }, '');
+
+    const onPopState = (event: PopStateEvent) => {
+      const step = (event.state as { scaffolderStep?: number } | null)
+        ?.scaffolderStep;
+      // No `scaffolderStep` means the entry predates the wizard (or belongs
+      // to a different page) — let the browser navigate away as normal.
+      if (typeof step === 'number') {
+        isPopStateStepRef.current = true;
+        setActiveStep(step);
+      }
+    };
+
+    window.addEventListener('popstate', onPopState);
+    return () => window.removeEventListener('popstate', onPopState);
+  }, []);
+
   const mergedUiSchema = merge({}, propUiSchema, currentStep?.uiSchema);
 
   const [isCreating, setIsCreating] = useState(false);


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This PR is assisted by Claude Sonnet.

The scaffolder `Stepper` didn't react well to back/next mouse buttons: the browser was bringing us to the templates page instead of the previous/next stepper page. 

This adds a `window.history` entry on every step change (carrying the new
step index) and a `popstate` listener that drives `setActiveStep` back in
sync with it, so browser/mouse back-forward now matches the page's own
Back/Next buttons. Going back past the first step still leaves the page
normally, same as any other route.

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages.
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message.
