### PR TITLE
fix(catalog): restore AboutField spacing

### DIFF
--- a/.changeset/tidy-catalog-about-spacing.md
+++ b/.changeset/tidy-catalog-about-spacing.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog': patch
+---
+
+Preserve spacing between About card field labels and values.

--- a/plugins/catalog/src/components/AboutCard/AboutField.tsx
+++ b/plugins/catalog/src/components/AboutCard/AboutField.tsx
@@ -34,6 +34,7 @@ const useStyles = makeStyles(theme => ({
     fontSize: '10px',
     fontWeight: 'bold',
     letterSpacing: 0.5,
+    marginBottom: '4px',
     overflow: 'hidden',
     whiteSpace: 'nowrap',
   },


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Restores a small gap between About card field labels and their values after the label typography was changed to `variant="inherit"`. This keeps the 10px label override while preventing values from appearing cramped.

Fixes #35393

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages.
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (not available in this environment)
- [x] All your commits have a `Signed-off-by` line in the message.

AI disclosure: Prepared with AI assistance and verified against the repository source and checks.