### PR TITLE
fix(catalog): authorize custom location analyzers

### DIFF
--- a/.changeset/tidy-analyzers-agree.md
+++ b/.changeset/tidy-analyzers-agree.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-backend': patch
+---
+
+Apply catalog location analysis permissions consistently when using a custom location analyzer.

--- a/docs/features/software-catalog/configuration.md
+++ b/docs/features/software-catalog/configuration.md
@@ -181,6 +181,18 @@ this remote source, users cannot also register new entities with e.g. the
 [catalog-import](https://github.com/backstage/backstage/tree/master/plugins/catalog-import)
 plugin.
 
+## Location analysis permissions
+
+The catalog location analysis endpoint invokes configured location analyzers,
+which may use configured source control integrations and run parts of the
+catalog processing pipeline in dry-run mode. When the permission system is
+enabled, callers must be granted `catalog.location.analyze`.
+
+Analysis may read through configured integrations and the `UrlReaderService`,
+which operate in a service context. Grant the permission to users who should be
+able to inspect those sources, and keep `backend.reading.allow` scoped according
+to the [Backstage threat model](../../overview/threat-model.md#common-backend-configuration).
+
 ## Automatic removal of orphaned entities
 
 Entities can become orphaned through multiple means, such as when a catalog-info YAML file is moved from one place to another in the version control system without updating the registration in the catalog. The default behavior is to automatically remove orphaned entities. You can read more about orphaned entities [here](life-of-an-entity.md#orphaning).

--- a/plugins/catalog-backend/src/service/CatalogBuilder.ts
+++ b/plugins/catalog-backend/src/service/CatalogBuilder.ts
@@ -515,12 +515,11 @@ export class CatalogBuilder {
       metrics,
     });
 
-    const locationAnalyzer =
+    const locationAnalyzer = new AuthorizedLocationAnalyzer(
       this.locationAnalyzer ??
-      new AuthorizedLocationAnalyzer(
         new RepoLocationAnalyzer(logger, integrations, this.locationAnalyzers),
-        permissions,
-      );
+      permissions,
+    );
     const locationService = new AuthorizedLocationService(
       new DefaultLocationService(locationStore, orchestrator, {
         allowedLocationTypes: this.allowedLocationType,

--- a/plugins/catalog-backend/src/service/CatalogPlugin.test.ts
+++ b/plugins/catalog-backend/src/service/CatalogPlugin.test.ts
@@ -14,15 +14,60 @@
  * limitations under the License.
  */
 import request from 'supertest';
-import { startTestBackend } from '@backstage/backend-test-utils';
+import { mockServices, startTestBackend } from '@backstage/backend-test-utils';
 import { catalogPlugin } from './CatalogPlugin';
 import {
   coreServices,
   createBackendModule,
 } from '@backstage/backend-plugin-api';
 import { createCatalogPermissionRule } from '../permissions';
+import { catalogAnalysisExtensionPoint } from '@backstage/plugin-catalog-node';
+import { AuthorizeResult } from '@backstage/plugin-permission-common';
 
 describe('catalogPlugin', () => {
+  it('applies permissions to a custom location analyzer', async () => {
+    const customLocationAnalyzer = {
+      analyzeLocation: jest.fn().mockResolvedValue({
+        existingEntityFiles: [],
+        generateEntities: [],
+      }),
+    };
+    const { server } = await startTestBackend({
+      features: [
+        mockServices.permissions.factory({
+          result: AuthorizeResult.DENY,
+        }),
+        catalogPlugin,
+        createBackendModule({
+          pluginId: 'catalog',
+          moduleId: 'custom-location-analyzer',
+          register(reg) {
+            reg.registerInit({
+              deps: {
+                analysis: catalogAnalysisExtensionPoint,
+              },
+              async init({ analysis }) {
+                analysis.setLocationAnalyzer(customLocationAnalyzer);
+              },
+            });
+          },
+        }),
+      ],
+    });
+
+    const response = await request(server)
+      .post('/api/catalog/analyze-location')
+      .send({
+        location: {
+          type: 'url',
+          target: 'https://example.com/catalog-info.yaml',
+        },
+      });
+
+    expect(response.status).toBe(403);
+    expect(customLocationAnalyzer.analyzeLocation).not.toHaveBeenCalled();
+  });
+
   it('should register permissions and support custom permission rules', async () => {
     const { server } = await startTestBackend({
       features: [


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Custom catalog location analyzers are now protected by the same `catalog.location.analyze` permission check as the default analyzer. The catalog documentation also clarifies that location analysis may read through configured SCM integrations and URL readers in a service context.

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
