### PR TITLE
fix(scaffolder-backend): count scaffolder.task.count once per task run, not once per failing step

### DIFF
--- a/.changeset/scaffolder-task-count-per-run.md
+++ b/.changeset/scaffolder-task-count-per-run.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-scaffolder-backend': patch
+---
+
+Fixed `scaffolder.task.count` (and the deprecated `scaffolder_task_count` Prometheus counter) incrementing once per **failing step** instead of once per **failed task run**. A task with multiple steps that continue running after a failure (via `if: ${{ always() }}` or `if: ${{ failure() }}`) previously recorded one `result: 'failed'` count for every failing step in that single run, inflating the metric relative to `result: 'ok'`, which is recorded exactly once per successful task. The task-level failure is now recorded once, after the workflow loop finishes, using the first error encountered — matching the existing log message semantics ("First error from step ..."). `scaffolder.step.count` is unaffected and still records one outcome per step.

--- a/plugins/scaffolder-backend/src/scaffolder/tasks/NunjucksWorkflowRunner.test.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/tasks/NunjucksWorkflowRunner.test.ts
@@ -301,6 +301,37 @@ describe('NunjucksWorkflowRunner', () => {
     });
   });
 
+  it('counts both task and step metrics as failed when a single step fails', async () => {
+    const template = 'template:default/example';
+    fakeActionHandler.mockRejectedValueOnce(new Error('boom'));
+    const task = createMockTaskWithSpec({
+      steps: [{ id: 'test', name: 'Test step', action: 'jest-mock-action' }],
+      templateInfo: { entityRef: template },
+    });
+
+    await expect(runner.execute(task)).rejects.toThrow('boom');
+
+    const taskCountIndex = metrics.createCounter.mock.calls.findIndex(
+      ([name]) => name === 'scaffolder.task.count',
+    );
+    const taskCount = metrics.createCounter.mock.results[taskCountIndex].value;
+    expect(taskCount.add).toHaveBeenCalledTimes(1);
+    expect(taskCount.add).toHaveBeenCalledWith(1, {
+      template,
+      result: 'failed',
+    });
+
+    const stepCountIndex = metrics.createCounter.mock.calls.findIndex(
+      ([name]) => name === 'scaffolder.step.count',
+    );
+    const stepCount = metrics.createCounter.mock.results[stepCountIndex].value;
+    expect(stepCount.add).toHaveBeenCalledWith(1, {
+      template,
+      step: 'Test step',
+      result: 'failed',
+    });
+  });
+
   it('should throw an error if the action does not exist', async () => {
     const task = createMockTaskWithSpec({
       steps: [{ id: 'test', name: 'name', action: 'does-not-exist' }],
@@ -3554,6 +3585,79 @@ describe('NunjucksWorkflowRunner', () => {
       await expect(runner.execute(task)).rejects.toThrow('step failed');
       expect(failingCleanup).toHaveBeenCalledTimes(1);
       expect(cleanupHandler).toHaveBeenCalledTimes(1);
+    });
+
+    it('should count scaffolder.task.count once per task run even when multiple steps fail', async () => {
+      const failingCleanup = jest
+        .fn()
+        .mockRejectedValue(new Error('cleanup failed'));
+      actionRegistry.register(
+        createTemplateAction({
+          id: 'failing-cleanup-for-task-count',
+          description: 'Failing cleanup',
+          handler: failingCleanup,
+        }),
+      );
+
+      const task = createMockTaskWithSpec({
+        steps: [
+          {
+            id: 'step1',
+            name: 'Failing step',
+            action: 'failing-action',
+          },
+          {
+            id: 'step2',
+            name: 'Failing cleanup',
+            action: 'failing-cleanup-for-task-count',
+            if: '${{ always() }}',
+          },
+          {
+            id: 'step3',
+            name: 'Successful cleanup',
+            action: 'cleanup-action',
+            if: '${{ always() }}',
+          },
+        ],
+      });
+
+      await expect(runner.execute(task)).rejects.toThrow('step failed');
+
+      const taskCountIndex = metrics.createCounter.mock.calls.findIndex(
+        ([name]) => name === 'scaffolder.task.count',
+      );
+      const taskCount =
+        metrics.createCounter.mock.results[taskCountIndex].value;
+      const failedTaskCountCalls = taskCount.add.mock.calls.filter(
+        (call: [number, { result: string }]) => call[1].result === 'failed',
+      );
+      // Exactly one task-level failure, even though two steps (step1, step2) failed.
+      expect(failedTaskCountCalls).toHaveLength(1);
+      expect(taskCount.add).toHaveBeenCalledWith(1, {
+        template: '',
+        result: 'failed',
+      });
+
+      const stepCountIndex = metrics.createCounter.mock.calls.findIndex(
+        ([name]) => name === 'scaffolder.step.count',
+      );
+      const stepCount =
+        metrics.createCounter.mock.results[stepCountIndex].value;
+      const failedStepCountCalls = stepCount.add.mock.calls.filter(
+        (call: [number, { result: string }]) => call[1].result === 'failed',
+      );
+      // One step-level failure per failing step (step1 and step2).
+      expect(failedStepCountCalls).toHaveLength(2);
+      expect(stepCount.add).toHaveBeenCalledWith(1, {
+        template: '',
+        step: 'Failing step',
+        result: 'failed',
+      });
+      expect(stepCount.add).toHaveBeenCalledWith(1, {
+        template: '',
+        step: 'Failing cleanup',
+        result: 'failed',
+      });
     });
 
     it('should log all errors when multiple cleanup steps fail', async () => {

--- a/plugins/scaffolder-backend/src/scaffolder/tasks/NunjucksWorkflowRunner.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/tasks/NunjucksWorkflowRunner.ts
@@ -752,7 +752,6 @@ export class NunjucksWorkflowRunner implements WorkflowRunner {
       return updatedPreparedContext;
     } catch (cause) {
       const err = taskLogger.redactError(cause);
-      await taskTrack.markFailed(step, err);
       await stepTrack.markFailed();
       throw err;
     } finally {
@@ -929,6 +928,11 @@ export class NunjucksWorkflowRunner implements WorkflowRunner {
       }
 
       if (firstError) {
+        // Task-level failure is counted once per task run, regardless of how
+        // many steps failed (e.g. via `if: ${{ always() }}`/`if: ${{ failure() }}`
+        // steps that keep running after the first failure).
+        await taskTrack.markFailed(allErrors[0].step, firstError);
+
         // If there were multiple errors, add context to the first error
         if (allErrors.length > 1) {
           const additionalErrorSummary = allErrors


### PR DESCRIPTION
## Summary

`scaffolder.task.count` (and the deprecated `scaffolder_task_count` Prometheus counter) is recorded once per **successful task run** (`markSuccessful()` is called once, at the end of `execute()`), but is currently recorded once per **failing step** for `result: 'failed'` — because `taskTrack.markFailed(step, err)` is called inside `executeStep()`'s per-step catch block.

For a template whose steps use `if: ${{ always() }}` / `if: ${{ failure() }}` to keep running after the first failure, a single failed task run that fails on more than one step increments `scaffolder.task.count{result:'failed'}` once per failing step, not once per task. That makes the metric's `failed` bucket incomparable to its `ok` bucket (which is strictly one-per-task), and inflates any error-rate computed as `failed / (ok + failed)`.

## Fix

Moves the task-level failure increment out of `executeStep()`'s catch block and into `execute()`, where it now fires exactly once per task run — using the first error encountered, at the same point the existing "Task failed with N errors. First error from step ..." log message is already built. `stepTrack.markFailed()` (the step-level counter) is untouched and continues to fire once per failing step, which is correct today.

## Test plan

- Added a test asserting a single failing step increments both `scaffolder.task.count` and `scaffolder.step.count` by 1 each for `result: 'failed'`.
- Added a test with three steps (two failing `always()`-guarded steps, one succeeding) asserting `scaffolder.task.count{result:'failed'}` fires **exactly once** for the task while `scaffolder.step.count{result:'failed'}` fires once per failing step (twice). This test is red against the pre-fix code.
- Full existing `NunjucksWorkflowRunner.test.ts` suite passes (138/138).