### PR TITLE
test(cli): exercise packed common packages in native Node

### DIFF
--- a/packages/cli-module-build/src/tests/packageConsumption/README.md
+++ b/packages/cli-module-build/src/tests/packageConsumption/README.md
@@ -1,0 +1,100 @@
+# Published package consumption tests
+
+This suite exercises the boundary between building a Backstage package and
+consuming its archive through native Node.js package resolution. It is a first
+slice of the [module compatibility requirements investigation](https://github.com/backstage/backstage/issues/35604),
+not the full acceptance matrix or a proposed replacement build system.
+
+Read this document and the [common-library scenario](./__fixtures__/common/README.md)
+before changing fixtures. Import syntax, dependency export shapes, directory
+placement, and manifest fields can be essential to coverage. Treat a change to
+those characteristics as a change to the experiment, even if the tests stay green.
+
+## Execution and isolation
+
+The checked-in fixtures are miniature packages, outside the repository's workspace
+globs. They are not released. The dependency fixtures live in `__fixtures__/node_modules`
+so editors can resolve their declarations, following the neighboring transform
+tests' convention. These are deliberately checked-in files, not installed dependencies.
+
+Each suite run:
+
+1. Copies the source package into a fresh operating-system temporary directory.
+1. Uses `getOutputsForRole` and `buildPackage` to build the role's JavaScript
+   outputs once. It omits the declaration output, which needs separate coverage.
+1. Uses `productionPack` with a separate target directory to rewrite the manifest
+   and select publication files. The test does not manufacture conditional exports.
+1. Runs the repository's checked-in Yarn release to create an archive of that
+   directory. Network access is disabled and no dependency installation runs.
+1. Extracts the archive into an independent consumer's `node_modules` and copies
+   the two dependency fixtures there. Deletes the producer and staging directories.
+1. Runs `.cjs` and `.mjs` consumers with the test runner's Node executable, clearing
+   `NODE_OPTIONS` and `NODE_PATH`. Jest never imports the built package itself.
+1. Checks results, verifies resolved entries belong to the extracted package, and
+   verifies the two consumers exercised distinct outputs. Removes temporary files
+   even after a test failure.
+
+The consumer imports by package name, including `/alpha`. A direct import of a
+`dist` filename would bypass the publication contract. Neither source links nor
+Backstage loaders are available in the consumer. The harness also checks that the
+extracted package is not a symlink and has no `src` directory.
+
+## Coverage and limits
+
+| Surface                                                           | Coverage in this suite                                                       |
+| ----------------------------------------------------------------- | ---------------------------------------------------------------------------- |
+| Common-library JavaScript output                                  | Real role-based build; CJS and ESM consumption                               |
+| Publication entry rewriting                                       | Real `productionPack`, including root and `/alpha`                           |
+| Archive contents                                                  | Real Yarn packing of the prepared directory and extraction                   |
+| CJS interoperability                                              | Default import from a dependency with dynamically assigned exports           |
+| ESM interoperability                                              | Dynamic import of an ESM dependency with top-level await                     |
+| Node versions                                                     | The executing Node version; normal repository CI supplies its version matrix |
+| Declarations and TypeScript consumer resolution                   | Not covered; fixture dependency declarations only support authoring          |
+| CLI prepack/postpack command dispatch and restoration             | Not covered; publication preparation is called directly                      |
+| Package-manager installation and workspace protocols              | Not covered; dependencies are copied into an installed layout                |
+| Source development, Jest consumers, browser bundles, tree shaking | Not covered; Jest is only the orchestrator here                              |
+| Other roles, assets, source maps, Storybook, module federation    | Not covered                                                                  |
+
+The source manifest's `types` field is retained to resemble normal authoring, but
+without declaration generation this is deliberately a runtime-only artifact.
+Do not describe a passing result as validating all aspects of a publishable package.
+
+## Running and measuring
+
+After `yarn install` in the repository root:
+
+```shell
+CI=1 yarn test packages/cli-module-build/src/tests/packageConsumption --runInBand
+```
+
+To print separate timings for the build, publication rewrite, Yarn packing,
+consumer setup, and each Node process:
+
+```shell
+BACKSTAGE_COMPAT_TIMINGS=1 CI=1 yarn test packages/cli-module-build/src/tests/packageConsumption --runInBand
+```
+
+Jest's total duration additionally includes test module loading and orchestration.
+Compare standalone runs with runs alongside the neighboring transform tests and
+with CI measurements. There is no timing assertion: timeouts bound hung operations,
+not an accepted performance budget. The producer is built and packed once for both
+consumers; adding consumer assertions should not require another build or install.
+
+## Maintaining coverage
+
+For each added scenario, document its adopter-visible guarantee, sensitive fixture
+characteristics, expected failure, and exclusions beside its source. Link historical
+regressions where available. Keep expected values independent of the implementation
+under test, and avoid snapshots of complete manifests or generated JavaScript.
+
+Before claiming a regression is covered, deliberately reintroduce it and confirm
+the consumer fails at the expected boundary. The scenario README describes the
+negative controls for this slice. Restore the defect and rerun the tests before
+committing. A setup error, missing tool, or unrelated type error does not establish
+that the intended regression was detected.
+
+The exact filenames and tool APIs used by the harness are replaceable. The
+source-to-archive boundary, native consumer isolation, dependency characteristics,
+and public entry points are the coverage to preserve. If a design deliberately
+changes a characteristic such as dual output, update the experiment and explain
+which replacement tests exercise the newly intended contract.

--- a/packages/cli-module-build/src/tests/packageConsumption/__fixtures__/common/README.md
+++ b/packages/cli-module-build/src/tests/packageConsumption/__fixtures__/common/README.md
@@ -1,0 +1,62 @@
+# Common-library root and alpha scenario
+
+An adopter must be able to call the same public functions through native
+`require` and `import` of a packaged common library, including an `/alpha` subpath.
+The functions exercise an external CommonJS (CJS) dependency and asynchronous
+loading of an ECMAScript module (ESM) dependency.
+
+This scenario contributes runtime coverage toward MOD03 (module interoperability)
+and PUB03 (subpath exports) in the
+[requirements investigation](https://github.com/backstage/backstage/issues/35604).
+It is motivated in part by the
+[CJS import correction](https://github.com/backstage/backstage/pull/35598).
+It reproduces the relevant dependency shape; it does not test `lodash` itself or
+the corrected source of any production Backstage package.
+
+## Details that carry coverage
+
+| Detail                                               | Why it matters                                                                                 |
+| ---------------------------------------------------- | ---------------------------------------------------------------------------------------------- |
+| `backstage.role: common-library`                     | Exercises the real role's JavaScript outputs together                                          |
+| Source paths in `main` and `exports`                 | Makes publication rewriting necessary; existing dist paths would bypass it                     |
+| No package `type` field                              | Represents the existing common-library authoring convention; adding one changes the experiment |
+| `files: ["dist"]`                                    | Requires consumers to work without the TypeScript source tree                                  |
+| Distinct `/alpha` function                           | Makes accidentally pointing the subpath at the root observable                                 |
+| `./index` without an extension in `alpha.ts`         | Exercises rewriting an internal source import into a runnable output reference                 |
+| Default import of `compat-cjs-dependency`            | Retrieves a dynamically populated CJS export object from both outputs                          |
+| Dependency uses `Object.assign(module.exports, ...)` | Native Node cannot infer its `value` named export from an `exports.value` assignment           |
+| Bare external dependency imports                     | Leaves interoperability work for the consumer runtime, rather than bundling it away            |
+| Dynamic `import()` of `compat-esm-dependency`        | Exercises native asynchronous loading from the CJS output as well as the ESM output            |
+| Top-level await in the ESM dependency                | Prevents newer Node `require(esm)` support from masking an import rewritten into require       |
+| `.cjs` and `.mjs` consumers                          | Fixes each consumer's native module interpretation independently of package heuristics         |
+| Resolution checks in the harness                     | Prevents a passing test from silently consuming CJS output twice                               |
+
+Both consumers must return `42` from the root, `43` from `/alpha`, and `44` from
+the asynchronous function. These literals are independently chosen expectations,
+not results calculated using the builder's implementation.
+
+The dependency names, function names, and numeric values are incidental. The
+export shapes, import mechanisms, distinct entry behavior, and runtime isolation
+are essential. The `.d.ts` files alongside dependencies describe fixture APIs for
+the editor; they are not generated declarations or evidence of consumer type
+compatibility. See the [suite coverage limits](../../README.md).
+
+## Negative controls
+
+These are temporary verification edits, not additional supported fixture variants:
+
+- Replace the default dependency import in `src/index.ts` with
+  `import { value } from 'compat-cjs-dependency'` and call `value()`. The native
+  ESM consumer should fail to import that named CJS export, even though the CJS
+  consumer works. This demonstrates the class of failure behind that dependency import regression.
+- Replace the asynchronous `import('compat-esm-dependency')` with
+  `require('compat-esm-dependency')`. The CJS consumer should reject loading the
+  asynchronous ESM module. A transformer making the equivalent mistake should
+  be caught at the same boundary.
+- Remove `./alpha` from the prepared package's `exports` before packing. The
+  consumer should fail with a package-subpath resolution error.
+
+Run the suite after each edit, inspect the failure, and restore the fixture or
+harness before rerunning successfully. Do not fix a failure by adding a loader,
+using a direct dist path, bundling the dependency, or making both consumers select
+the same output: those changes remove the boundary this scenario exercises.

--- a/packages/cli-module-build/src/tests/packageConsumption/__fixtures__/common/package.json
+++ b/packages/cli-module-build/src/tests/packageConsumption/__fixtures__/common/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "@backstage-test/compat-common",
+  "version": "0.0.0",
+  "backstage": {
+    "role": "common-library"
+  },
+  "exports": {
+    ".": "./src/index.ts",
+    "./alpha": "./src/alpha.ts"
+  },
+  "main": "src/index.ts",
+  "types": "src/index.ts",
+  "files": [
+    "dist"
+  ],
+  "dependencies": {
+    "compat-cjs-dependency": "0.0.0",
+    "compat-esm-dependency": "0.0.0"
+  }
+}

--- a/packages/cli-module-build/src/tests/packageConsumption/__fixtures__/common/src/alpha.ts
+++ b/packages/cli-module-build/src/tests/packageConsumption/__fixtures__/common/src/alpha.ts
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2026 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { readValue } from './index';
+
+export function readAlphaValue(): number {
+  return readValue() + 1;
+}

--- a/packages/cli-module-build/src/tests/packageConsumption/__fixtures__/common/src/index.ts
+++ b/packages/cli-module-build/src/tests/packageConsumption/__fixtures__/common/src/index.ts
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2026 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import dependency from 'compat-cjs-dependency';
+
+// The default import is intentional; see ../README.md before changing its form.
+export function readValue(): number {
+  return dependency.value();
+}
+
+export async function readAsyncValue(): Promise<number> {
+  const { value } = await import('compat-esm-dependency');
+  return value();
+}

--- a/packages/cli-module-build/src/tests/packageConsumption/__fixtures__/consumers/import.mjs
+++ b/packages/cli-module-build/src/tests/packageConsumption/__fixtures__/consumers/import.mjs
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2026 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { readValue, readAsyncValue } from '@backstage-test/compat-common';
+import { readAlphaValue } from '@backstage-test/compat-common/alpha';
+
+console.log(
+  JSON.stringify({
+    value: readValue(),
+    alphaValue: readAlphaValue(),
+    asyncValue: await readAsyncValue(),
+    entries: [
+      '@backstage-test/compat-common',
+      '@backstage-test/compat-common/alpha',
+    ].map(name => import.meta.resolve(name)),
+  }),
+);

--- a/packages/cli-module-build/src/tests/packageConsumption/__fixtures__/consumers/require.cjs
+++ b/packages/cli-module-build/src/tests/packageConsumption/__fixtures__/consumers/require.cjs
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2026 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+const { pathToFileURL } = require('node:url');
+const { readValue, readAsyncValue } = require('@backstage-test/compat-common');
+const { readAlphaValue } = require('@backstage-test/compat-common/alpha');
+
+async function main() {
+  console.log(
+    JSON.stringify({
+      value: readValue(),
+      alphaValue: readAlphaValue(),
+      asyncValue: await readAsyncValue(),
+      entries: [
+        '@backstage-test/compat-common',
+        '@backstage-test/compat-common/alpha',
+      ].map(name => pathToFileURL(require.resolve(name)).href),
+    }),
+  );
+}
+
+main().catch(error => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/packages/cli-module-build/src/tests/packageConsumption/__fixtures__/node_modules/compat-cjs-dependency/index.cjs
+++ b/packages/cli-module-build/src/tests/packageConsumption/__fixtures__/node_modules/compat-cjs-dependency/index.cjs
@@ -1,0 +1,18 @@
+/*
+ * Copyright 2026 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Do not replace with exports.value: that changes native ESM named-export detection.
+Object.assign(module.exports, { value: () => 42 });

--- a/packages/cli-module-build/src/tests/packageConsumption/__fixtures__/node_modules/compat-cjs-dependency/index.d.ts
+++ b/packages/cli-module-build/src/tests/packageConsumption/__fixtures__/node_modules/compat-cjs-dependency/index.d.ts
@@ -1,0 +1,18 @@
+/*
+ * Copyright 2026 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+declare const dependency: { value(): number };
+export default dependency;

--- a/packages/cli-module-build/src/tests/packageConsumption/__fixtures__/node_modules/compat-cjs-dependency/package.json
+++ b/packages/cli-module-build/src/tests/packageConsumption/__fixtures__/node_modules/compat-cjs-dependency/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "compat-cjs-dependency",
+  "version": "0.0.0",
+  "main": "index.cjs",
+  "types": "index.d.ts"
+}

--- a/packages/cli-module-build/src/tests/packageConsumption/__fixtures__/node_modules/compat-esm-dependency/index.d.ts
+++ b/packages/cli-module-build/src/tests/packageConsumption/__fixtures__/node_modules/compat-esm-dependency/index.d.ts
@@ -1,0 +1,17 @@
+/*
+ * Copyright 2026 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export declare function value(): number;

--- a/packages/cli-module-build/src/tests/packageConsumption/__fixtures__/node_modules/compat-esm-dependency/index.js
+++ b/packages/cli-module-build/src/tests/packageConsumption/__fixtures__/node_modules/compat-esm-dependency/index.js
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2026 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Top-level await prevents require(esm) support from hiding a rewritten import().
+await Promise.resolve();
+
+export function value() {
+  return 44;
+}

--- a/packages/cli-module-build/src/tests/packageConsumption/__fixtures__/node_modules/compat-esm-dependency/package.json
+++ b/packages/cli-module-build/src/tests/packageConsumption/__fixtures__/node_modules/compat-esm-dependency/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "compat-esm-dependency",
+  "version": "0.0.0",
+  "type": "module",
+  "main": "index.js",
+  "types": "index.d.ts"
+}

--- a/packages/cli-module-build/src/tests/packageConsumption/packageConsumption.test.ts
+++ b/packages/cli-module-build/src/tests/packageConsumption/packageConsumption.test.ts
@@ -1,0 +1,158 @@
+/*
+ * Copyright 2026 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { execFile } from 'node:child_process';
+import { tmpdir } from 'node:os';
+import { resolve } from 'node:path';
+import { performance } from 'node:perf_hooks';
+import { promisify } from 'node:util';
+import { pathToFileURL } from 'node:url';
+import fs from 'fs-extra';
+import * as tar from 'tar';
+import { targetPaths } from '@backstage/cli-common';
+import { buildPackage, getOutputsForRole, Output } from '../../lib/builder';
+import { productionPack } from '../../lib/packager/productionPack';
+
+const execFileAsync = promisify(execFile);
+const fixtures = resolve(__dirname, '__fixtures__');
+
+// Jest orchestrates the experiment. It must never load the published package.
+const nativeEnv = { ...process.env, NODE_OPTIONS: '', NODE_PATH: '' };
+
+async function timed<T>(label: string, action: () => Promise<T>): Promise<T> {
+  const start = performance.now();
+  try {
+    return await action();
+  } finally {
+    if (process.env.BACKSTAGE_COMPAT_TIMINGS) {
+      console.log(
+        `package consumption: ${label} ${(performance.now() - start).toFixed(
+          0,
+        )} ms`,
+      );
+    }
+  }
+}
+
+describe('published common-library consumption', () => {
+  let directory: string;
+  let consumer: string;
+  let installed: string;
+
+  beforeAll(async () => {
+    directory = await fs.realpath(
+      await fs.mkdtemp(resolve(tmpdir(), 'backstage-package-consumption-')),
+    );
+    const producer = resolve(directory, 'producer');
+    const staged = resolve(directory, 'staged');
+    const archive = resolve(directory, 'common.tgz');
+    consumer = resolve(directory, 'consumer');
+    installed = resolve(consumer, 'node_modules/@backstage-test/compat-common');
+
+    await fs.copy(resolve(fixtures, 'common'), producer);
+    const pkg = await fs.readJson(resolve(producer, 'package.json'));
+    const outputs = getOutputsForRole(pkg.backstage.role);
+    // This first slice covers runtime output, not declaration generation. See README.md.
+    outputs.delete(Output.types);
+    await timed('build', () =>
+      buildPackage({
+        targetDir: producer,
+        outputs,
+        workspacePackages: [],
+      }),
+    );
+    await timed('publication rewrite', () =>
+      productionPack({
+        packageDir: producer,
+        targetDir: staged,
+      }),
+    );
+
+    // This repository keeps its pinned Yarn release on disk. Avoid Corepack and installs.
+    const { packageManager } = await fs.readJson(
+      targetPaths.resolveRoot('package.json'),
+    );
+    const yarnPath = targetPaths.resolveRoot(
+      '.yarn/releases',
+      `${packageManager.replace('@', '-')}.cjs`,
+    );
+    await fs.writeFile(resolve(staged, 'yarn.lock'), '');
+    await timed('yarn pack', () =>
+      execFileAsync(process.execPath, [yarnPath, 'pack', '--out', archive], {
+        cwd: staged,
+        env: {
+          ...nativeEnv,
+          YARN_ENABLE_NETWORK: '0',
+          YARN_ENABLE_TELEMETRY: '0',
+          YARN_IGNORE_PATH: '1',
+        },
+        timeout: 30_000,
+      }),
+    );
+
+    await timed('consumer setup', async () => {
+      await fs.copy(resolve(fixtures, 'consumers'), consumer);
+      await fs.copy(
+        resolve(fixtures, 'node_modules'),
+        resolve(consumer, 'node_modules'),
+      );
+      await fs.ensureDir(installed);
+      await tar.x({ file: archive, cwd: installed, strip: 1 });
+      // No original source or staging tree remains available to rescue a broken archive.
+      await fs.remove(producer);
+      await fs.remove(staged);
+    });
+  }, 60_000);
+
+  afterAll(async () => {
+    if (directory) {
+      await fs.remove(directory);
+    }
+  });
+
+  it('loads root and alpha through native require and import, including external dependencies', async () => {
+    expect(await fs.pathExists(resolve(installed, 'src'))).toBe(false);
+    expect((await fs.lstat(installed)).isSymbolicLink()).toBe(false);
+    const consumerDir = consumer;
+    const results = [];
+    for (const entry of ['require.cjs', 'import.mjs']) {
+      const { stdout } = await timed(entry, () =>
+        execFileAsync(process.execPath, [entry], {
+          cwd: consumerDir,
+          env: nativeEnv,
+          timeout: 10_000,
+        }),
+      );
+      const result = JSON.parse(stdout);
+      expect(result).toEqual({
+        value: 42,
+        alphaValue: 43,
+        asyncValue: 44,
+        entries: [expect.any(String), expect.any(String)],
+      });
+      for (const resolved of result.entries) {
+        expect(resolved.startsWith(`${pathToFileURL(installed).href}/`)).toBe(
+          true,
+        );
+      }
+      results.push(result);
+    }
+    // Selecting CJS for both consumers could conceal a broken ESM artifact.
+    // This guards the experiment's coverage, not the spelling of output filenames.
+    expect(results[0].entries[0]).not.toBe(results[1].entries[0]);
+    expect(results[0].entries[1]).not.toBe(results[1].entries[1]);
+  }, 30_000);
+});


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Add a documented first slice of the compatibility test suite discussed in #35604. The existing transform tests load explicit build paths; these tests build a common-library fixture, apply publication rewriting, create a real Yarn archive, and consume its root and `/alpha` entries by package name in isolated native Node CJS and ESM processes.

The fixture exercises dynamically assigned CJS exports and dynamic loading of an ESM dependency with top-level await. Suite/scenario READMEs document coverage-sensitive details, negative controls, and exclusions. This is runtime-only coverage: declarations, CLI pack-hook dispatch, source development, Jest consumers, and browser targets remain follow-ups.

Validation: tests passed on Node 22.22.2 and 24.16.0, alongside the existing transform suite (10 tests). All three deliberate negative controls failed at their intended boundary. `yarn lint --fix`, formatting/documentation checks, and `yarn build:api-reports` passed; no API report changes. An initial standalone local sample took about 300 ms for fixture stages and one second including Jest; optional phase timings are included for CI evaluation.

Tests/docs only; no changeset needed. The local pre-commit catalog-staging command rejected the intentionally tracked `node_modules` fixture paths, so that hook was bypassed after running its applicable checks separately.


#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
