### PR TITLE
fix: improve plugin route isolation

### DIFF
--- a/.changeset/calm-routes-rest.md
+++ b/.changeset/calm-routes-rest.md
@@ -1,0 +1,6 @@
+---
+'@backstage/backend-defaults': patch
+---
+
+Plugin route registration now rejects paths that differ only by letter casing,
+and HTTP credentials are resolved independently for each plugin service instance.

--- a/docs/backend-system/core-services/root-http-router.md
+++ b/docs/backend-system/core-services/root-http-router.md
@@ -9,6 +9,8 @@ The root HTTP router is a service that allows you to register routes on the root
 
 The `/api/:pluginId/` path prefix is reserved for use by plugins to register their own routes via the [HttpRouter](./http-router.md) service.
 
+Each registered root path must be distinct. Registration fails if a path overlaps an existing path; comparisons are case-insensitive and treat trailing slashes as equivalent.
+
 ## Using the service
 
 The following example shows how to get the root HTTP router service in your `example` backend plugin to register a health check route.

--- a/packages/backend-defaults/src/entrypoints/httpAuth/DefaultHttpAuthService.test.ts
+++ b/packages/backend-defaults/src/entrypoints/httpAuth/DefaultHttpAuthService.test.ts
@@ -15,7 +15,7 @@
  */
 
 import { DefaultHttpAuthService } from './httpAuthServiceFactory';
-import { mockServices } from '@backstage/backend-test-utils';
+import { mockCredentials, mockServices } from '@backstage/backend-test-utils';
 import { createRequest } from 'node-mocks-http';
 
 describe('DefaultHttpAuthService', () => {
@@ -38,5 +38,34 @@ describe('DefaultHttpAuthService', () => {
       createRequest({ headers: { test: 'mock-user-token' } }),
     );
     expect(auth.authenticate).toHaveBeenCalledWith('mock-user-token');
+  });
+
+  it('keeps credentials scoped to each service instance', async () => {
+    const request = createRequest({
+      headers: {
+        authorization: mockCredentials.service.header({
+          onBehalfOf: mockCredentials.service('external:test'),
+          targetPluginId: 'Catalog',
+        }),
+      },
+    });
+    const firstService = DefaultHttpAuthService.create({
+      discovery: mockServices.discovery(),
+      auth: mockServices.auth({ pluginId: 'Catalog' }),
+      pluginId: 'Catalog',
+    });
+    const secondAuth = mockServices.auth({ pluginId: 'catalog' });
+    const secondAuthenticate = jest.spyOn(secondAuth, 'authenticate');
+    const secondService = DefaultHttpAuthService.create({
+      discovery: mockServices.discovery(),
+      auth: secondAuth,
+      pluginId: 'catalog',
+    });
+
+    await expect(firstService.credentials(request)).resolves.toEqual(
+      mockCredentials.service('external:test'),
+    );
+    await expect(secondService.credentials(request)).rejects.toThrow();
+    expect(secondAuthenticate).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/backend-defaults/src/entrypoints/httpAuth/httpAuthServiceFactory.ts
+++ b/packages/backend-defaults/src/entrypoints/httpAuth/httpAuthServiceFactory.ts
@@ -60,14 +60,6 @@ function willExpireSoon(expiresAt: Date) {
   return Date.now() + FIVE_MINUTES_MS > expiresAt.getTime();
 }
 
-const credentialsSymbol = Symbol('backstage-credentials');
-const limitedCredentialsSymbol = Symbol('backstage-limited-credentials');
-
-type RequestWithCredentials = Request & {
-  [credentialsSymbol]?: Promise<BackstageCredentials>;
-  [limitedCredentialsSymbol]?: Promise<BackstageCredentials>;
-};
-
 /**
  * @public
  * Options for creating a DefaultHttpAuthService.
@@ -87,6 +79,14 @@ export interface DefaultHttpAuthServiceOptions {
  * DefaultHttpAuthService is the default implementation of the HttpAuthService
  */
 export class DefaultHttpAuthService implements HttpAuthService {
+  readonly #credentialsCache = new WeakMap<
+    Request,
+    Promise<BackstageCredentials>
+  >();
+  readonly #limitedCredentialsCache = new WeakMap<
+    Request,
+    Promise<BackstageCredentials>
+  >();
   readonly #auth: AuthService;
   readonly #discovery: DiscoveryService;
   readonly #pluginId: string;
@@ -142,14 +142,22 @@ export class DefaultHttpAuthService implements HttpAuthService {
     return await this.#auth.getNoneCredentials();
   }
 
-  async #getCredentials(req: RequestWithCredentials) {
-    return (req[credentialsSymbol] ??=
-      this.#extractCredentialsFromRequest(req));
+  async #getCredentials(req: Request) {
+    let credentials = this.#credentialsCache.get(req);
+    if (!credentials) {
+      credentials = this.#extractCredentialsFromRequest(req);
+      this.#credentialsCache.set(req, credentials);
+    }
+    return credentials;
   }
 
-  async #getLimitedCredentials(req: RequestWithCredentials) {
-    return (req[limitedCredentialsSymbol] ??=
-      this.#extractLimitedCredentialsFromRequest(req));
+  async #getLimitedCredentials(req: Request) {
+    let credentials = this.#limitedCredentialsCache.get(req);
+    if (!credentials) {
+      credentials = this.#extractLimitedCredentialsFromRequest(req);
+      this.#limitedCredentialsCache.set(req, credentials);
+    }
+    return credentials;
   }
 
   async credentials<TAllowed extends keyof BackstagePrincipalTypes = 'unknown'>(

--- a/packages/backend-defaults/src/entrypoints/rootHttpRouter/DefaultRootHttpRouter.test.ts
+++ b/packages/backend-defaults/src/entrypoints/rootHttpRouter/DefaultRootHttpRouter.test.ts
@@ -38,6 +38,7 @@ describe('DefaultRootHttpRouter', () => {
     [['/a'], '/a', '/a'],
     [['/a'], '/a/b', '/a'],
     [['/a/b'], '/a', '/a/b'],
+    [['/api/Catalog'], '/api/catalog', '/api/Catalog'],
   ])(
     `find conflict when existing paths %s, adds %s`,
     (existing, added, conflict) => {

--- a/packages/backend-defaults/src/entrypoints/rootHttpRouter/DefaultRootHttpRouter.ts
+++ b/packages/backend-defaults/src/entrypoints/rootHttpRouter/DefaultRootHttpRouter.ts
@@ -19,7 +19,7 @@ import { Handler, Router } from 'express';
 import trimEnd from 'lodash/trimEnd';
 
 function normalizePath(path: string): string {
-  return `${trimEnd(path, '/')}/`;
+  return `${trimEnd(path, '/')}/`.toLowerCase();
 }
 
 /**


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Improves consistency between backend plugin route registration and request handling by rejecting case-insensitive route conflicts and keeping credential resolution scoped to each HTTP auth service instance.

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (not applicable; no UI changes)
- [x] All commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))