### PR TITLE
fix: use dedicated token for dependency merges

### DIFF
--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -19,4 +19,4 @@ jobs:
           app-id: ${{ secrets.BACKSTAGE_GOALIE_APPLICATION_ID }}
           private-key: ${{ secrets.BACKSTAGE_GOALIE_PRIVATE_KEY }}
           installation-id: ${{ secrets.BACKSTAGE_GOALIE_INSTALLATION_ID }}
-          merge-token: ${{ secrets.GH_SERVICE_ACCOUNT_TOKEN }}
+          merge-token: ${{ secrets.GH_DEPENDENCY_MERGE_TOKEN }}


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Switches the Cron action's dependency merge client to the dedicated `GH_DEPENDENCY_MERGE_TOKEN` organization secret.

The previous shared service-account token reached the merge endpoint but failed repeatedly because it lacked workflow-write permission. The new token is narrowly scoped for dependency merges and includes that permission.

Verification:

- Parsed the Cron workflow successfully
- Ran `git diff --check`
- Confirmed the diff only changes the merge-token secret reference

#### :heavy_check_mark: Checklist

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
