### PR TITLE
fix: use dedicated app for dependency merges

### DIFF
--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -19,4 +19,3 @@ jobs:
           app-id: ${{ secrets.BACKSTAGE_GOALIE_APPLICATION_ID }}
           private-key: ${{ secrets.BACKSTAGE_GOALIE_PRIVATE_KEY }}
           installation-id: ${{ secrets.BACKSTAGE_GOALIE_INSTALLATION_ID }}
-          merge-token: ${{ secrets.GH_DEPENDENCY_MERGE_TOKEN }}

--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -4,6 +4,8 @@ on:
   schedule:
     - cron: '*/5 * * * *'
 
+permissions: {}
+
 jobs:
   cron:
     runs-on: ubuntu-latest
@@ -14,8 +16,19 @@ jobs:
         with:
           egress-policy: audit
 
+      - name: Generate dependency merger token
+        id: dependency-merger-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          app-id: ${{ vars.BACKSTAGE_DEPENDENCY_MERGER_APP_ID }}
+          private-key: ${{ secrets.BACKSTAGE_DEPENDENCY_MERGER_PRIVATE_KEY }}
+          permission-contents: write
+          permission-pull-requests: write
+          permission-workflows: write
+
       - uses: backstage/actions/cron@7da58d8d1e914892549d73ae9b291acb640b61f9 # v0.7.12
         with:
           app-id: ${{ secrets.BACKSTAGE_GOALIE_APPLICATION_ID }}
           private-key: ${{ secrets.BACKSTAGE_GOALIE_PRIVATE_KEY }}
           installation-id: ${{ secrets.BACKSTAGE_GOALIE_INSTALLATION_ID }}
+          merge-token: ${{ steps.dependency-merger-token.outputs.token }}


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Uses the dedicated Backstage Dependency Merger GitHub App for dependency merges from the Cron workflow.

The workflow now:

- disables all permissions on the ordinary `GITHUB_TOKEN`
- creates an installation token that defaults to the current repository only
- requests only `contents: write`, `pull_requests: write`, and `workflows: write` for that token
- passes the narrowly scoped token to `backstage/actions/cron` as `merge-token`

This replaces the temporary personal `GH_DEPENDENCY_MERGE_TOKEN` without giving Backstage Goalie workflow-write access across its organization-wide installation.

Verification:

- Confirmed the pinned `actions/create-github-app-token` action supports each requested permission input and defaults to the current repository when `owner` and `repositories` are omitted
- Parsed `.github/workflows/cron.yml` successfully
- Ran `git diff --check`
- Verified every commit in the PR has a `Signed-off-by` trailer

#### :heavy_check_mark: Checklist

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
