### PR TITLE
chore: prioritize yarn lockfile code owners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -5,8 +5,6 @@
 # https://help.github.com/articles/about-codeowners/
 
 *                                                 @backstage/maintainers
-yarn.lock                                         @backstage/maintainers @backstage-service
-*/yarn.lock                                       @backstage/maintainers @backstage-service
 /.changeset                                       @backstage/operations-maintainers
 /.changeset/*.md
 /.github                                          @backstage/operations-maintainers
@@ -92,3 +90,6 @@ yarn.lock                                         @backstage/maintainers @backst
 /packages/backend-defaults/src/entrypoints/auditor                        @backstage/maintainers @backstage/auditor-maintainers
 /packages/backend-defaults/report-auditor.api.md                          @backstage/maintainers @backstage/auditor-maintainers
 /docs/backend-system/core-services/auditor.md                             @backstage/maintainers @backstage/auditor-maintainers @backstage/documentation-maintainers
+
+# Keep this rule last so that directory-specific ownership does not override it.
+**/yarn.lock                                      @backstage/maintainers @backstage-service


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Makes the existing `yarn.lock` ownership rule recursive and places it last in `CODEOWNERS`, where it takes precedence over directory-specific ownership.

This allows `backstage-service` approvals to satisfy the code-owner review requirement for lockfile-only dependency updates such as `microsite/yarn.lock`. Other changes under `microsite` continue to request review from `@backstage/documentation-maintainers`.

Policy note: lockfile-only changes under `microsite` will no longer require a documentation-maintainer review. Please confirm that this is acceptable before merging.

Verification:

- Confirmed `**/yarn.lock` matches root, one-level, and deeply nested lockfiles
- Confirmed the rule is the last matching rule in `CODEOWNERS`
- Confirmed GitHub reports no CODEOWNERS syntax errors for the branch
- Ran `git diff --check`

#### :heavy_check_mark: Checklist

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
