### PR TITLE
chore: use GitHub App client IDs

### DIFF
--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -20,7 +20,7 @@ jobs:
         id: dependency-merger-token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
-          app-id: ${{ vars.BACKSTAGE_DEPENDENCY_MERGER_APP_ID }}
+          client-id: ${{ vars.BACKSTAGE_DEPENDENCY_MERGER_CLIENT_ID }}
           private-key: ${{ secrets.BACKSTAGE_DEPENDENCY_MERGER_PRIVATE_KEY }}
           permission-contents: write
           permission-pull-requests: write

--- a/.github/workflows/sync_pull-requests-scheduled.yml
+++ b/.github/workflows/sync_pull-requests-scheduled.yml
@@ -27,7 +27,7 @@ jobs:
         id: token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
-          app-id: ${{ secrets.BACKSTAGE_GOALIE_APPLICATION_ID }}
+          client-id: ${{ vars.BACKSTAGE_GOALIE_CLIENT_ID }}
           private-key: ${{ secrets.BACKSTAGE_GOALIE_PRIVATE_KEY }}
 
       - name: Determine PR batch


### PR DESCRIPTION
## Summary

- use the recommended `client-id` input for the dependency-merger token
- use the recommended `client-id` input for the scheduled Goalie token
- remove the `actions/create-github-app-token@v3` deprecation warnings

The corresponding public client IDs have been added as repository variables. Private keys and requested installation-token permissions are unchanged.

## Verification

- both client IDs verified against the public GitHub App metadata
- `git diff --check`
- commit includes the required DCO sign-off