### PR TITLE
chore: configure Dependabot versioning strategy

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,13 @@
+version: 2
+updates:
+  - package-ecosystem: 'npm'
+    directories:
+      - '/'
+      - '/docs-ui'
+      - '/microsite'
+    schedule:
+      interval: 'weekly'
+    # Disable version updates since we use Renovate for those.
+    open-pull-requests-limit: 0
+    # Leave package ranges unchanged when they already include the patched version.
+    versioning-strategy: 'increase-if-necessary'


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Configure Dependabot security updates to leave package ranges unchanged when the patched version is already in range. This follows the [operator responsibility described in the threat model](https://backstage.io/docs/overview/threat-model/#operator-responsibilities) and keeps regular dependency version updates with Renovate.

The configuration covers the root workspace, `docs-ui`, and `microsite`. Setting the version-update limit to zero does not disable security updates.

#### :heavy_check_mark: Checklist

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))

Generated with [Codex](https://openai.com/codex/).
