### PR TITLE
Avoid lookahead in filter predicate key pattern

### DIFF
--- a/.changeset/filter-predicates-re2-safe-key-pattern.md
+++ b/.changeset/filter-predicates-re2-safe-key-pattern.md
@@ -1,0 +1,5 @@
+---
+'@backstage/filter-predicates': patch
+---
+
+The JSON Schema exported for filter predicates can now be compiled by validators built on RE2 (for example Go's `regexp`, used by Amazon Bedrock AgentCore Gateway), which previously rejected the predicate key pattern and failed every call to tools such as `query-catalog-entities`. Accepted keys are unchanged, except that a key whose first character is U+2028 or U+2029 is no longer rejected.

--- a/packages/filter-predicates/src/predicates/schema.test.ts
+++ b/packages/filter-predicates/src/predicates/schema.test.ts
@@ -15,8 +15,10 @@
  */
 
 import { z } from 'zod/v3';
+import { z as zodV4 } from 'zod/v4';
 import {
   createZodV3FilterPredicateSchema,
+  createZodV4FilterPredicateSchema,
   parseFilterPredicate,
 } from './schema';
 import { FilterPredicate } from './types';
@@ -108,6 +110,8 @@ describe('createZodV3FilterPredicateSchema', () => {
       { $not: { $all: [{ x: { $unknown: true } }] } },
       { $unknown: 'foo' },
       { 'metadata.tags': ['foo', 'bar'] },
+      { '\nkind': 'component' },
+      { 'kind\n': 'component' },
       { kind: 'API', $not: { 'spec.type': 'dataset' } },
       { kind: 'API', $all: [{ 'spec.type': 'service' }] },
       { kind: 'API', $any: [{ 'spec.type': 'service' }] },
@@ -117,6 +121,37 @@ describe('createZodV3FilterPredicateSchema', () => {
       const result = schema.safeParse(predicate);
       expect(result.success).toBe(false);
     });
+  });
+});
+
+describe('createZodV4FilterPredicateSchema', () => {
+  const schema = createZodV4FilterPredicateSchema();
+
+  it.each([
+    { kind: 'component', 'spec.type': 'service' },
+    { 'metadata.tags': { $in: ['java'] } },
+    { $not: { 'spec.type': 'service' } },
+  ])('should accept valid predicate %j', predicate => {
+    expect(schema.safeParse(predicate).success).toBe(true);
+  });
+
+  it.each([
+    { '\nkind': 'component' },
+    { 'kind\n': 'component' },
+    { '\rkind': 'component' },
+    { $unknown: 'foo' },
+    { kind: { $unknown: 'foo' } },
+  ])('should reject invalid predicate %j', predicate => {
+    expect(schema.safeParse(predicate).success).toBe(false);
+  });
+
+  it('should export a JSON Schema without lookahead patterns', () => {
+    // RE2-based validators (e.g. Go's regexp) reject lookahead, and the
+    // exported schema is what MCP clients validate arguments against.
+    const jsonSchema = JSON.stringify(
+      zodV4.toJSONSchema(createZodV4FilterPredicateSchema()),
+    );
+    expect(jsonSchema).not.toMatch(/\(\?[=!<]/);
   });
 });
 
@@ -210,6 +245,8 @@ describe('parseFilterPredicate', () => {
       { $unknown: 'foo' },
       { kind: { $hasPrefix: 1 } },
       { 'metadata.tags': ['foo', 'bar'] },
+      { '\nkind': 'component' },
+      { 'kind\n': 'component' },
       { kind: 'API', $not: { 'spec.type': 'dataset' } },
       { kind: 'API', $all: [{ 'spec.type': 'service' }] },
       { kind: 'API', $any: [{ 'spec.type': 'service' }] },

--- a/packages/filter-predicates/src/predicates/schema.ts
+++ b/packages/filter-predicates/src/predicates/schema.ts
@@ -44,7 +44,7 @@ export function createZodV3FilterPredicateSchema(
 
   const expressionSchema = z.lazy(() =>
     z.union([
-      z.record(z.string().regex(/^(?!\$).*$/), valuePredicateSchema),
+      z.record(z.string().regex(/^(?:[^$\n\r].*)?$/), valuePredicateSchema),
       z.record(z.string().regex(/^\$/), z.never()),
     ]),
   ) as zodV3.ZodType<FilterPredicateExpression>;
@@ -93,7 +93,10 @@ export function createZodV4FilterPredicateSchema(): zodV4.ZodType<
 
   const expressionSchema = zodV4.lazy(() =>
     zodV4.union([
-      zodV4.record(zodV4.string().regex(/^(?!\$).*$/), valuePredicateSchema),
+      zodV4.record(
+        zodV4.string().regex(/^(?:[^$\n\r].*)?$/),
+        valuePredicateSchema,
+      ),
       zodV4.record(zodV4.string().regex(/^\$/), zodV4.never()),
     ]),
   ) as zodV4.ZodType<FilterPredicateExpression, FilterPredicateExpression>;


### PR DESCRIPTION
The predicate key schema uses `/^(?!\$).*$/`. Once exported as JSON Schema (the MCP actions endpoint does this for `query-catalog-entities`), RE2-based validators can't compile the lookahead. Amazon Bedrock AgentCore Gateway rejects every call to the tool with `Unsupported regex pattern in schema: error parsing regexp: invalid or unsupported Perl syntax: (?!`.

`/^(?:[^$\n\r].*)?$/` accepts the same keys without lookahead, in both the zod v3 and v4 builders. The one residual difference is a key whose first character is U+2028 or U+2029, which is no longer rejected: excluding those needs a `\u` escape in the exported pattern, which RE2 doesn't parse either. Tests cover the line-terminator rejection and that the exported JSON Schema has no lookahead.

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages.
- [x] Tests for new functionality and regression tests for bug fixes
- [x] All commits have a `Signed-off-by` line.
