### PR TITLE
frontend-plugin-api: target routes by extension ID

### DIFF
--- a/.changeset/auth-structural-route.md
+++ b/.changeset/auth-structural-route.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-auth': patch
+---
+
+Updated the Auth page route to target its extension ID, allowing the page to be replaced without forwarding its route reference.

--- a/.changeset/auth-structural-route.md
+++ b/.changeset/auth-structural-route.md
@@ -2,4 +2,4 @@
 '@backstage/plugin-auth': patch
 ---
 
-Updated the Auth page route to target its extension ID, allowing the page to be replaced without forwarding its route reference.
+Updated the Auth page route to target its extension ID.

--- a/.changeset/catalog-structural-index-route.md
+++ b/.changeset/catalog-structural-index-route.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog': patch
+---
+
+The Catalog index route now targets `page:catalog`, so replacement pages no longer need to register its route reference. Existing legacy mount points and hybrid page conversion remain supported.

--- a/.changeset/catalog-structural-index-route.md
+++ b/.changeset/catalog-structural-index-route.md
@@ -2,4 +2,4 @@
 '@backstage/plugin-catalog': patch
 ---
 
-The Catalog index route now targets `page:catalog`, so replacement pages no longer need to register its route reference. Existing legacy mount points and hybrid page conversion remain supported.
+The Catalog index route now targets `page:catalog`. Existing legacy mount points and hybrid page conversion remain supported.

--- a/.changeset/frontend-route-compat.md
+++ b/.changeset/frontend-route-compat.md
@@ -1,0 +1,5 @@
+---
+'@backstage/core-compat-api': patch
+---
+
+Preserved legacy route-reference conversion when upgrading to extension-targeted frontend routes. Converted legacy refs retain their explicit page or routing-shim association, and structural refs can still be used as explicit legacy mount points.

--- a/.changeset/frontend-route-resolution.md
+++ b/.changeset/frontend-route-resolution.md
@@ -3,3 +3,5 @@
 ---
 
 Added resolution of route references by installed extension ID, alongside historical page-associated routes. Named module routes follow extension override precedence, and app assembly validates target extensions and parameter contracts. External bindings also support duplicated named refs and preserve explicitly disabled defaults.
+
+Deprecated page registrations provide a fallback for extension-targeted refs when the target extension is absent, preserving hybrid conversion with generated or overridden extension IDs. Installed targets, including disabled ones, take precedence.

--- a/.changeset/frontend-route-resolution.md
+++ b/.changeset/frontend-route-resolution.md
@@ -1,0 +1,5 @@
+---
+'@backstage/frontend-app-api': patch
+---
+
+Added resolution of route references by installed extension ID, alongside historical page-associated routes. Named module routes follow extension override precedence, and app assembly validates target extensions and parameter contracts. External bindings also support duplicated named refs and preserve explicitly disabled defaults.

--- a/.changeset/frontend-route-template.md
+++ b/.changeset/frontend-route-template.md
@@ -1,0 +1,5 @@
+---
+'@backstage/cli-module-new': patch
+---
+
+Updated the frontend plugin template to create route references with an extension ID and define pages without a route reference parameter.

--- a/.changeset/frontend-route-test-mounts.md
+++ b/.changeset/frontend-route-test-mounts.md
@@ -1,0 +1,5 @@
+---
+'@backstage/frontend-test-utils': patch
+---
+
+Updated test app helpers to mount extension-targeted route references at the supplied test paths, including external route targets with parameters.

--- a/.changeset/frontend-structural-routes.md
+++ b/.changeset/frontend-structural-routes.md
@@ -1,0 +1,11 @@
+---
+'@backstage/frontend-plugin-api': minor
+---
+
+**BREAKING** `createRouteRef` now requires an `extensionId` identifying the routable extension. Remove `aliasFor` from source code and use `extensionId` instead. Pages no longer need to receive the reference through the deprecated `PageBlueprint` or `SubPageBlueprint` `routeRef` option.
+
+```ts
+const rootRouteRef = createRouteRef({ extensionId: 'page:example' });
+```
+
+Frontend modules can now add or override named `routes` in their plugin namespace. These overrides affect external defaults and configuration bindings without changing existing structural references. The runtime remains compatible with previously compiled route refs and features.

--- a/.changeset/frontend-structural-routes.md
+++ b/.changeset/frontend-structural-routes.md
@@ -2,7 +2,7 @@
 '@backstage/frontend-plugin-api': minor
 ---
 
-**BREAKING** `createRouteRef` now requires an `extensionId` identifying the routable extension. Remove `aliasFor` from source code and use `extensionId` instead. Pages no longer need to receive the reference through the deprecated `PageBlueprint` or `SubPageBlueprint` `routeRef` option.
+**BREAKING** `createRouteRef` now requires an `extensionId` identifying the routable extension. Remove `aliasFor` from source code and use `extensionId` instead. The `routeRef` options of `PageBlueprint` and `SubPageBlueprint` are deprecated.
 
 ```ts
 const rootRouteRef = createRouteRef({ extensionId: 'page:example' });

--- a/.changeset/home-structural-route.md
+++ b/.changeset/home-structural-route.md
@@ -2,4 +2,4 @@
 '@backstage/plugin-home': patch
 ---
 
-Updated the Home page route to target its extension ID, allowing the page to be replaced without forwarding its route reference.
+Updated the Home page route to target its extension ID.

--- a/.changeset/home-structural-route.md
+++ b/.changeset/home-structural-route.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-home': patch
+---
+
+Updated the Home page route to target its extension ID, allowing the page to be replaced without forwarding its route reference.

--- a/.changeset/visualizer-structural-route.md
+++ b/.changeset/visualizer-structural-route.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-app-visualizer': patch
+---
+
+Exposed the App Visualizer root route and updated its pages to resolve routes through extension IDs.

--- a/docs/features/software-catalog/catalog-customization.md
+++ b/docs/features/software-catalog/catalog-customization.md
@@ -221,9 +221,9 @@ component. In the new frontend system, these customizations are done by
 overriding the `page:catalog` extension.
 
 For example, to customize the catalog index page with custom columns or actions,
-you can override the page extension using a frontend module. The Catalog plugin
-still uses a converted legacy route reference, so the replacement page retains
-that reference:
+you can override the page extension using a frontend module. Catalog route
+references target `page:catalog`, so the replacement page does not need to
+register a route reference:
 
 ```tsx title="packages/app/src/catalog/customCatalogPage.tsx"
 import {
@@ -231,12 +231,9 @@ import {
   createFrontendModule,
 } from '@backstage/frontend-plugin-api';
 
-import catalogPlugin from '@backstage/plugin-catalog/alpha';
-
 const customCatalogPage = PageBlueprint.make({
   params: {
     path: '/catalog',
-    routeRef: catalogPlugin.routes.catalogIndex,
     loader: async () => {
       const { CustomCatalogPage } = await import('./CustomCatalogPage');
       return <CustomCatalogPage />;

--- a/docs/features/software-catalog/catalog-customization.md
+++ b/docs/features/software-catalog/catalog-customization.md
@@ -221,19 +221,22 @@ component. In the new frontend system, these customizations are done by
 overriding the `page:catalog` extension.
 
 For example, to customize the catalog index page with custom columns or actions,
-you can override the page extension using a frontend module:
+you can override the page extension using a frontend module. The Catalog plugin
+still uses a converted legacy route reference, so the replacement page retains
+that reference:
 
 ```tsx title="packages/app/src/catalog/customCatalogPage.tsx"
 import {
   PageBlueprint,
   createFrontendModule,
-  createRouteRef,
 } from '@backstage/frontend-plugin-api';
+
+import catalogPlugin from '@backstage/plugin-catalog/alpha';
 
 const customCatalogPage = PageBlueprint.make({
   params: {
     path: '/catalog',
-    routeRef: createRouteRef({ aliasFor: 'catalog.catalogIndex' }),
+    routeRef: catalogPlugin.routes.catalogIndex,
     loader: async () => {
       const { CustomCatalogPage } = await import('./CustomCatalogPage');
       return <CustomCatalogPage />;

--- a/docs/features/software-catalog/catalog-customization.md
+++ b/docs/features/software-catalog/catalog-customization.md
@@ -221,9 +221,7 @@ component. In the new frontend system, these customizations are done by
 overriding the `page:catalog` extension.
 
 For example, to customize the catalog index page with custom columns or actions,
-you can override the page extension using a frontend module. Catalog route
-references target `page:catalog`, so the replacement page does not need to
-register a route reference:
+you can override the page extension using a frontend module:
 
 ```tsx title="packages/app/src/catalog/customCatalogPage.tsx"
 import {

--- a/docs/frontend-system/architecture/36-routes.md
+++ b/docs/frontend-system/architecture/36-routes.md
@@ -34,7 +34,7 @@ Route refs do not have any behavior themselves. They are an opaque value that re
 
 ### Providing Route References to Plugins
 
-The `extensionId` identifies the routable extension. The page supplies its path and content; it does not need to receive the route reference:
+The `extensionId` identifies the routable extension. The page supplies its path and content:
 
 ```tsx title="plugins/catalog/src/plugin.tsx"
 import {
@@ -492,8 +492,7 @@ Modules for plugins that are not installed are ignored. Modules do not provide
 
 For native extensions, add `extensionId` to each `createRouteRef` call and remove the corresponding
 `PageBlueprint` or `SubPageBlueprint` `routeRef` parameter. Keep `params` unchanged
-and ensure they match the target extension's route path. Sub routes and external
-bindings do not need to change.
+and ensure they match the target extension's route path.
 
 The runtime continues to support plugins built with earlier versions, including
 page-emitted refs and historical aliases. The `aliasFor` creation option is no
@@ -509,11 +508,10 @@ ID.
 For compatibility with hybrid conversion utilities, a structural ref can still
 be registered through an extension's deprecated `routeRef` output. If the target
 extension ID is absent from the app, the runtime uses that explicit mount as a
-fallback, including for equivalent ref copies. The wrapper's ID does not need to
-match the ref's target ID. Multiple fallback mounts for the same target are
+fallback, including for equivalent ref copies. Multiple fallback mounts for the same target are
 ambiguous and are rejected when the fallback is needed.
 
 An installed target always takes precedence over deprecated registrations. If
 that target is disabled or conditionally unavailable, the route remains
 unavailable. Keep the deprecated registration when migrating a shared ref used
-by hybrid wrappers; native replacement pages do not need it.
+by hybrid wrappers.

--- a/docs/frontend-system/architecture/36-routes.md
+++ b/docs/frontend-system/architecture/36-routes.md
@@ -24,8 +24,8 @@ Route references, also known as "absolute" or "regular" routes, are created as f
 ```tsx title="plugins/catalog/src/routes.ts"
 import { createRouteRef } from '@backstage/frontend-plugin-api';
 
-// Creates a route reference, which is not yet associated with any plugin page
-export const indexRouteRef = createRouteRef();
+// Targets the catalog index page extension, regardless of its configured path
+export const indexRouteRef = createRouteRef({ extensionId: 'page:catalog' });
 ```
 
 Note that you often want to create the route references themselves in a different file than the one that creates the plugin instance, for example a top-level `routes.ts`. This is to avoid circular imports when you use the route references from other parts of the same plugin.
@@ -34,21 +34,20 @@ Route refs do not have any behavior themselves. They are an opaque value that re
 
 ### Providing Route References to Plugins
 
-The code snippet in the previous section does not indicate which plugin the route belongs to. To do so, you have to use it in the creation of any kind of routable extension, such as a page extension:
+The `extensionId` identifies the routable extension. The page supplies its path and content; it does not need to receive the route reference:
 
 ```tsx title="plugins/catalog/src/plugin.tsx"
 import {
   createFrontendPlugin,
-  createPageExtension,
+  PageBlueprint,
 } from '@backstage/frontend-plugin-api';
 import { indexRouteRef } from './routes';
 
-const catalogIndexPage = createPageExtension({
-  // The `name` option is omitted because this is an index page
-  path: '/entities',
-  // highlight-next-line
-  routeRef: indexRouteRef,
-  loader: () => import('./components').then(m => <m.IndexPage />),
+const catalogIndexPage = PageBlueprint.make({
+  params: {
+    path: '/entities',
+    loader: () => import('./components').then(m => <m.IndexPage />),
+  },
 });
 
 export default createFrontendPlugin({
@@ -62,9 +61,21 @@ export default createFrontendPlugin({
 });
 ```
 
-In the example above we associated the `indexRouteRef` with the `catalogIndexPage` extension and provided both the route ref and page via the Catalog plugin. So, when this plugin is installed in the app, the index page will become associated with the newly created `RouteRef`, making it possible to use the route ref to navigate the page extension.
+The page above has the ID `page:catalog`: its kind is `page`, its plugin
+namespace is `catalog`, and it has no name. A page named `index` would instead
+have the ID `page:catalog/index`.
 
-It may seem unclear why we configure the `routes` option when creating a plugin as the route has already been passed to the extension. We do that to make it possible for other plugins to route to our page, which is explained in detail in the [binding routes](#binding-external-route-references) section.
+The plugin's `routes` option exposes named targets such as `catalog.index` for
+external defaults and application configuration. It does not establish the
+reference's target. References can be used without being listed in `routes`.
+References listed in a plugin or module must target its plugin namespace,
+including the absolute parent of a sub route. The target extension may be
+provided by a module.
+
+Separate references with the same extension ID and parameters resolve to the
+same route. Conflicting parameter contracts, unknown targets, and targets that
+do not expose a route path are errors. Disabled or conditionally unavailable
+extensions resolve to `undefined`.
 
 ### Defining References with Path Parameters
 
@@ -74,6 +85,7 @@ Route references optionally accept a `params` option, which will require the lis
 import { createRouteRef } from '@backstage/frontend-plugin-api';
 
 export const detailsRouteRef = createRouteRef({
+  extensionId: 'page:catalog/entity',
   // The parameters that must be included in the path of this route reference
   // highlight-next-line
   params: ['kind', 'namespace', 'name'],
@@ -189,15 +201,16 @@ Now the only thing left is to provide the page and external route via a plugin:
 ```tsx title="plugins/catalog/src/plugin.tsx"
 import {
   createFrontendPlugin,
-  createPageExtension,
+  PageBlueprint,
   useRouteRef,
 } from '@backstage/frontend-plugin-api';
 import { indexRouteRef, createComponentExternalRouteRef } from './routes';
 
-const catalogIndexPage = createPageExtension({
-  path: '/entities',
-  routeRef: indexRouteRef,
-  loader: () => import('./components').then(m => <m.IndexPage />),
+const catalogIndexPage = PageBlueprint.make({
+  params: {
+    path: '/entities',
+    loader: () => import('./components').then(m => <m.IndexPage />),
+  },
 });
 
 export default createFrontendPlugin({
@@ -302,7 +315,7 @@ import {
   createSubRouteRef,
 } from '@backstage/frontend-plugin-api';
 
-export const indexRouteRef = createRouteRef();
+export const indexRouteRef = createRouteRef({ extensionId: 'page:catalog' });
 // highlight-start
 export const detailsSubRouteRef = createSubRouteRef({
   parent: indexRouteRef,
@@ -417,14 +430,15 @@ Finally, see how a plugin can provide subroutes:
 ```tsx title="plugins/catalog/src/plugin.tsx"
 import {
   createFrontendPlugin,
-  createPageExtension,
+  PageBlueprint,
 } from '@backstage/frontend-plugin-api';
 import { indexRouteRef, detailsSubRouteRef } from './routes';
 
-const catalogIndexPage = createPageExtension({
-  path: '/entities',
-  routeRef: indexRouteRef,
-  loader: () => import('./components').then(m => <m.IndexPage />),
+const catalogIndexPage = PageBlueprint.make({
+  params: {
+    path: '/entities',
+    loader: () => import('./components').then(m => <m.IndexPage />),
+  },
 });
 
 export default createFrontendPlugin({
@@ -438,41 +452,56 @@ export default createFrontendPlugin({
 });
 ```
 
-## Route Aliases - Overriding Routed Extensions in Modules
+## Overriding routes with modules
 
-It is possible to [override extensions of a plugin using a module](./25-extension-overrides.md#creating-a-frontend-module). In some cases the extension you're overriding may require a route reference. You could import the plugin instance and access the it via the `routes` property, but this creates a direct dependency on the plugin and risks leading to package duplication issues that would also break the route reference.
+A module can [override a page extension](./25-extension-overrides.md#creating-a-frontend-module)
+by providing the same extension ID. References targeting that ID resolve through
+the replacement page automatically.
 
-Instead of accessing the route reference directly, you can create a new route reference that acts as an alias for the original one from the plugin. For example, you can override the catalog index page with a custom one like this:
+Modules can also add or override named routes using `routes`:
 
 ```tsx
-const indexRouteRef = createRouteRef({ aliasFor: 'catalog.catalogIndex' });
+const customIndexRouteRef = createRouteRef({
+  extensionId: 'page:example/custom-index',
+});
 
 export default createFrontendModule({
-  pluginId: 'catalog',
+  pluginId: 'example',
+  routes: { root: customIndexRouteRef },
   extensions: [
     PageBlueprint.make({
+      name: 'custom-index',
       params: {
-        defaultPath: '/catalog',
-        routeRef: indexRouteRef,
+        path: '/custom',
         loader: () =>
-          import('./CustomCatalogIndexPage').then(m => (
-            <m.CustomCatalogIndexPage />
-          )),
+          import('./CustomIndexPage').then(m => <m.CustomIndexPage />),
       },
     }),
   ],
 });
 ```
 
-Aliases are limited to the plugin that they are defined in. These aliases can also be imported and used as usual with for example `useRouteRef`, but they must always be registered in the app via an extension for this to work. For example, the following will not work:
+This changes the named target `example.root` used in external defaults and
+configuration. A reference already targeting `page:example` continues to target
+that extension. Module routes use the same resolved feature order as module
+extensions: modules override the base plugin, and the last module wins.
+Modules for plugins that are not installed are ignored. Modules do not provide
+`externalRoutes`.
 
-```tsx
-function MyInvalidComponent() {
-  // This is NOT valid
-  const link = useRouteRef(
-    createRouteRef({ aliasFor: 'catalog.catalogIndex' }),
-  );
+## Migrating existing references
 
-  // ...
-}
-```
+Add `extensionId` to each `createRouteRef` call and remove the corresponding
+`PageBlueprint` or `SubPageBlueprint` `routeRef` parameter. Keep `params` unchanged
+and ensure they match the target extension's route path. Sub routes and external
+bindings do not need to change.
+
+The runtime continues to support plugins built with earlier versions, including
+page-emitted refs and historical aliases. The `aliasFor` creation option is no
+longer available in TypeScript. When overriding a page that still uses a
+historical ref, keep emitting that ref, obtained from the plugin's `routes`.
+
+Legacy refs converted with `convertLegacyRouteRef` keep their historical page or
+routing-shim association. A structural ref can also be converted for use in the
+old frontend system, provided the plugin explicitly uses that same ref as its
+legacy mount point. The old system cannot infer a mount point from an extension
+ID.

--- a/docs/frontend-system/architecture/36-routes.md
+++ b/docs/frontend-system/architecture/36-routes.md
@@ -490,7 +490,7 @@ Modules for plugins that are not installed are ignored. Modules do not provide
 
 ## Migrating existing references
 
-Add `extensionId` to each `createRouteRef` call and remove the corresponding
+For native extensions, add `extensionId` to each `createRouteRef` call and remove the corresponding
 `PageBlueprint` or `SubPageBlueprint` `routeRef` parameter. Keep `params` unchanged
 and ensure they match the target extension's route path. Sub routes and external
 bindings do not need to change.
@@ -505,3 +505,15 @@ routing-shim association. A structural ref can also be converted for use in the
 old frontend system, provided the plugin explicitly uses that same ref as its
 legacy mount point. The old system cannot infer a mount point from an extension
 ID.
+
+For compatibility with hybrid conversion utilities, a structural ref can still
+be registered through an extension's deprecated `routeRef` output. If the target
+extension ID is absent from the app, the runtime uses that explicit mount as a
+fallback, including for equivalent ref copies. The wrapper's ID does not need to
+match the ref's target ID. Multiple fallback mounts for the same target are
+ambiguous and are rejected when the fallback is needed.
+
+An installed target always takes precedence over deprecated registrations. If
+that target is disabled or conditionally unavailable, the route remains
+unavailable. Keep the deprecated registration when migrating a shared ref used
+by hybrid wrappers; native replacement pages do not need it.

--- a/docs/frontend-system/building-plugins/01-index.md
+++ b/docs/frontend-system/building-plugins/01-index.md
@@ -55,7 +55,7 @@ import { createRouteRef } from '@backstage/frontend-plugin-api';
 
 // This will be the route reference for our example page. If you want to link
 // to the page from somewhere else, you can use this reference to generate the target path.
-export const rootRouteRef = createRouteRef();
+export const rootRouteRef = createRouteRef({ extensionId: 'page:example' });
 ```
 
 ```tsx title="in src/plugin.ts"
@@ -70,8 +70,6 @@ import { rootRouteRef } from './routes';
 // You can export it locally for testing purposes, but don't export it from the plugin package.
 const examplePage = PageBlueprint.make({
   params: {
-    routeRef: rootRouteRef,
-
     // This is the default path of this page, but integrators are free to override it
     path: '/example',
 

--- a/packages/app/src/examples/pagesPlugin.tsx
+++ b/packages/app/src/examples/pagesPlugin.tsx
@@ -31,12 +31,14 @@ import {
 import { useEffect, useState } from 'react';
 import { Route, Routes } from 'react-router-dom';
 
-const indexRouteRef = createRouteRef();
-const page1RouteRef = createRouteRef();
+const indexRouteRef = createRouteRef({ extensionId: 'page:pages/index' });
+const page1RouteRef = createRouteRef({ extensionId: 'page:pages/page1' });
 export const externalPageXRouteRef = createExternalRouteRef({
   defaultTarget: 'pages.pageX',
 });
-export const pageXRouteRef = createRouteRef();
+export const pageXRouteRef = createRouteRef({
+  extensionId: 'page:pages/pageX',
+});
 
 function PluginInfo() {
   const node = useAppNode();
@@ -58,7 +60,7 @@ const IndexPage = PageBlueprint.make({
   name: 'index',
   params: {
     path: '/',
-    routeRef: indexRouteRef,
+
     loader: async () => {
       const Component = () => {
         const page1Link = useRouteRef(page1RouteRef);
@@ -151,7 +153,7 @@ const Page1 = PageBlueprint.make({
   name: 'page1',
   params: {
     path: '/page1',
-    routeRef: page1RouteRef,
+
     loader: async () => {
       const Component = () => {
         const indexLink = useRouteRef(indexRouteRef);
@@ -202,7 +204,7 @@ const ExternalPage = PageBlueprint.make({
   name: 'pageX',
   params: {
     path: '/pageX',
-    routeRef: pageXRouteRef,
+
     loader: async () => {
       const Component = () => {
         const indexLink = useRouteRef(indexRouteRef);

--- a/packages/cli-module-new/templates/frontend-plugin/src/plugin.tsx.hbs
+++ b/packages/cli-module-new/templates/frontend-plugin/src/plugin.tsx.hbs
@@ -8,7 +8,6 @@ import { rootRouteRef } from './routes';
 export const page = PageBlueprint.make({
   params: {
     path: '/{{pluginId}}',
-    routeRef: rootRouteRef,
     loader: () =>
       import('./components/TodoPage').then(m => (
         <m.TodoPage />

--- a/packages/cli-module-new/templates/frontend-plugin/src/routes.ts
+++ b/packages/cli-module-new/templates/frontend-plugin/src/routes.ts
@@ -1,3 +1,0 @@
-import { createRouteRef } from '@backstage/frontend-plugin-api';
-
-export const rootRouteRef = createRouteRef();

--- a/packages/cli-module-new/templates/frontend-plugin/src/routes.ts.hbs
+++ b/packages/cli-module-new/templates/frontend-plugin/src/routes.ts.hbs
@@ -1,0 +1,3 @@
+import { createRouteRef } from '@backstage/frontend-plugin-api';
+
+export const rootRouteRef = createRouteRef({ extensionId: 'page:{{pluginId}}' });

--- a/packages/core-compat-api/src/compatWrapper/compatWrapper.test.tsx
+++ b/packages/core-compat-api/src/compatWrapper/compatWrapper.test.tsx
@@ -158,6 +158,7 @@ describe('ForwardsCompatProvider', () => {
   });
 
   it('should convert the routing context', async () => {
+    // @ts-expect-error Historical refs intentionally omit extensionId
     const routeRef = createNewRouteRef();
 
     function Component() {

--- a/packages/core-compat-api/src/convertLegacyRouteRef.test.ts
+++ b/packages/core-compat-api/src/convertLegacyRouteRef.test.ts
@@ -30,6 +30,8 @@ import {
   createSubRouteRef as createNewSubRouteRef,
   createExternalRouteRef as createNewExternalRouteRef,
 } from '@backstage/frontend-plugin-api';
+// eslint-disable-next-line @backstage/no-relative-monorepo-imports
+import { RouteResolver as LegacyRouteResolver } from '../../core-app-api/src/routing/RouteResolver';
 import { convertLegacyRouteRef } from './convertLegacyRouteRef';
 import {
   OpaqueExternalRouteRef,
@@ -38,6 +40,58 @@ import {
 } from '@internal/frontend';
 
 describe('convertLegacyRouteRef', () => {
+  it('resolves extension-targeted refs through an explicit legacy mount point', () => {
+    const ref = createNewRouteRef({
+      extensionId: 'page:test/item',
+      params: ['id'],
+    });
+    const sub = createNewSubRouteRef({ parent: ref, path: '/edit' });
+    const legacy = convertLegacyRouteRef(ref);
+    const legacySub = convertLegacyRouteRef(sub);
+    const resolver = new LegacyRouteResolver(
+      new Map([[legacy, '/legacy/:id']]),
+      new Map(),
+      [],
+      new Map(),
+      '',
+    );
+    expect(resolver.resolve(legacy, '/')?.({ id: 'one' })).toBe('/legacy/one');
+    expect(resolver.resolve(legacySub, '/')?.({ id: 'one' })).toBe(
+      '/legacy/one/edit',
+    );
+    expect(convertLegacyRouteRef(legacy)).toBe(ref);
+    expect(OpaqueRouteRef.toInternal(ref).getExtensionId?.()).toBe(
+      'page:test/item',
+    );
+    expect(
+      OpaqueRouteRef.toInternal(
+        convertLegacyRouteRef(createOldRouteRef({ id: 'old' })),
+      ).getExtensionId,
+    ).toBeUndefined();
+  });
+
+  it('converts refs from before the dual-system protocol', () => {
+    const old = createOldRouteRef({ id: 'old', params: ['id'] });
+    const external = createOldExternalRouteRef({
+      id: 'external',
+      params: ['id'],
+    });
+    delete (old as { $$type?: string }).$$type;
+    delete (external as { $$type?: string }).$$type;
+    const converted = convertLegacyRouteRef(old);
+    const convertedExternal = convertLegacyRouteRef(external);
+    const internal = OpaqueRouteRef.toInternal(converted);
+    const internalExternal =
+      OpaqueExternalRouteRef.toInternal(convertedExternal);
+    expect(converted).toBe(old);
+    expect(internal.getParams()).toEqual(['id']);
+    expect(internal.getExtensionId).toBeUndefined();
+    expect(internal.version).toBe('v1');
+    internalExternal.setId('test.external');
+    expect(internalExternal.getId?.()).toBe('test.external');
+    expect(internalExternal.getParams()).toEqual(['id']);
+  });
+
   it('converts old to new', () => {
     const ref1 = createOldRouteRef({ id: 'ref1' });
     const ref2 = createOldRouteRef({ id: 'ref2', params: ['p1', 'p2'] });
@@ -121,7 +175,9 @@ describe('convertLegacyRouteRef', () => {
   });
 
   it('converts new to old', () => {
+    // @ts-expect-error Historical refs intentionally omit extensionId
     const ref1 = createNewRouteRef();
+    // @ts-expect-error Historical refs intentionally omit extensionId
     const ref2 = createNewRouteRef({ params: ['p1', 'p2'] });
     const ref1sub1 = createNewSubRouteRef({
       parent: ref1,

--- a/packages/core-compat-api/src/convertLegacyRouteRef.ts
+++ b/packages/core-compat-api/src/convertLegacyRouteRef.ts
@@ -220,6 +220,8 @@ function convertOldToNew(
     const legacyRef = ref as LegacyRouteRef;
     const legacyRefStr = String(legacyRef);
     const newRef = OpaqueRouteRef.toInternal(
+      // Legacy refs deliberately retain the historical page association.
+      // @ts-expect-error Runtime compatibility with creation options before extensionId
       createRouteRef({
         params: legacyRef.params as string[],
       }),
@@ -285,6 +287,9 @@ function convertOldToNew(
       $$type: '@backstage/ExternalRouteRef' as const,
       version: 'v1',
       T: newRef.T,
+      getId() {
+        return newRef.getId?.();
+      },
       getParams() {
         return newRef.getParams();
       },

--- a/packages/frontend-app-api/src/routing/RouteResolver.test.ts
+++ b/packages/frontend-app-api/src/routing/RouteResolver.test.ts
@@ -42,8 +42,11 @@ const rest = {
   plugins: new Set<BackstagePlugin>(),
 };
 
+// @ts-expect-error Historical refs intentionally omit extensionId
 const ref1 = createRouteRef();
+// @ts-expect-error Historical refs intentionally omit extensionId
 const ref2 = createRouteRef({ params: ['x'] });
+// @ts-expect-error Historical refs intentionally omit extensionId
 const ref3 = createRouteRef({ params: ['y'] });
 const subRef1 = createSubRouteRef({ parent: ref1, path: '/foo' });
 const subRef2 = createSubRouteRef({ parent: ref1, path: '/foo/:a' });
@@ -108,6 +111,7 @@ describe('RouteResolver', () => {
   });
 
   it('should resolve nested sub routes directly and as external targets', () => {
+    // @ts-expect-error Historical refs intentionally omit extensionId
     const packagesRouteRef = createRouteRef();
     const revisionRouteRef = createSubRouteRef({
       parent: packagesRouteRef,
@@ -241,6 +245,7 @@ describe('RouteResolver', () => {
 
     expect(r.resolve(ref1, src('/'))?.()).toBe('/my-route');
     expect(
+      // @ts-expect-error Historical refs intentionally omit extensionId
       r.resolve(createRouteRef({ aliasFor: 'test.ref1' }), src('/'))?.(),
     ).toBe('/my-route');
   });
@@ -300,8 +305,10 @@ describe('RouteResolver', () => {
     );
     expect(
       r.resolve(
+        // @ts-expect-error Historical refs intentionally omit extensionId
         createRouteRef({ aliasFor: 'test.param', params: ['x'] }),
         src('/'),
+        // @ts-expect-error Historical refs intentionally omit extensionId
       )?.({ x: '1x' }),
     ).toBe('/my-parent/1x');
   });

--- a/packages/frontend-app-api/src/routing/RouteResolver.ts
+++ b/packages/frontend-app-api/src/routing/RouteResolver.ts
@@ -49,7 +49,8 @@ function resolveTargetRef(
   routePaths: Map<RouteRef, string>,
   routeBindings: Map<AnyRouteRef, AnyRouteRef | undefined>,
   routeRefsById: Map<string, RouteRef | SubRouteRef>,
-  extensionRoutes: Map<string, RouteRef>,
+  extensionRoutes: Map<string, RouteRef | undefined>,
+  fallbackRoutes: Map<string, RouteRef | undefined>,
 ): readonly [RouteRef | undefined, string] {
   // First we figure out which absolute route ref we're dealing with, an if there was an sub route path to append.
   // For sub routes it will be the parent path, while for external routes it will be the bound route.
@@ -94,13 +95,25 @@ function resolveTargetRef(
   const internal = OpaqueRouteRef.toInternal(ref);
   const extensionId = internal.getExtensionId?.();
   if (extensionId !== undefined) {
-    const mountedRef = extensionRoutes.get(extensionId);
+    const hasTarget = extensionRoutes.has(extensionId);
+    if (
+      !hasTarget &&
+      fallbackRoutes.has(extensionId) &&
+      !fallbackRoutes.get(extensionId)
+    ) {
+      throw new Error(`Ambiguous deprecated route mounts for '${extensionId}'`);
+    }
+    const mountedRef = hasTarget
+      ? extensionRoutes.get(extensionId)
+      : fallbackRoutes.get(extensionId);
     if (!mountedRef) {
       return [undefined, ''];
     }
     const expected = [
-      ...OpaqueRouteRef.toInternal(mountedRef).getParams(),
-    ].sort();
+      ...(routePaths.get(mountedRef) ?? '').matchAll(/:([\w-]+)/g),
+    ]
+      .map(match => match[1])
+      .sort();
     const actual = [...internal.getParams()].sort();
     if (JSON.stringify(actual) !== JSON.stringify(expected)) {
       throw new Error(
@@ -197,7 +210,8 @@ function resolveBasePath(
 }
 
 export class RouteResolver implements RouteResolutionApi {
-  private readonly extensionRoutes = new Map<string, RouteRef>();
+  private readonly extensionRoutes = new Map<string, RouteRef | undefined>();
+  private readonly fallbackRoutes = new Map<string, RouteRef | undefined>();
   private readonly routePaths: Map<RouteRef, string>;
   private readonly routeParents: Map<RouteRef, RouteRef | undefined>;
   private readonly routeObjects: BackstageRouteObject[];
@@ -217,7 +231,12 @@ export class RouteResolver implements RouteResolutionApi {
     appBasePath: string, // base path without a trailing slash
     routeAliasResolver: RouteAliasResolver,
     routeRefsById: Map<string, RouteRef | SubRouteRef>,
+    installedExtensionIds: Iterable<string> = [],
   ) {
+    // An installed but unmounted target must not resolve through a fallback.
+    for (const id of installedExtensionIds) {
+      this.extensionRoutes.set(id, undefined);
+    }
     this.routePaths = new Map(routePaths);
     this.routeParents = new Map(routeParents);
     // Canonical refs let extension-ID lookups share the path resolver while
@@ -229,6 +248,19 @@ export class RouteResolver implements RouteResolutionApi {
       objects.map(object => {
         let ref = parent;
         const refs = new Set(object.routeRefs);
+        const mountedIds = new Set<string>();
+        for (const emittedRef of refs) {
+          const id = OpaqueRouteRef.toInternal(emittedRef).getExtensionId?.();
+          if (id !== undefined && !mountedIds.has(id)) {
+            // Deprecated registrations are fallback candidates only. Multiple
+            // copies emitted at the same mount describe the same association.
+            this.fallbackRoutes.set(
+              id,
+              this.fallbackRoutes.has(id) ? undefined : emittedRef,
+            );
+            mountedIds.add(id);
+          }
+        }
         if (object.appNode) {
           const extensionId = object.appNode.spec.id;
           ref = createRouteRef({
@@ -289,13 +321,14 @@ export class RouteResolver implements RouteResolutionApi {
       }
       contracts.set(extensionId, contract);
       const node = tree.nodes.get(extensionId);
-      if (!node) {
+      if (!node && !this.fallbackRoutes.has(extensionId)) {
         throw new Error(
           `Route reference targets unknown extension '${extensionId}'`,
         );
       }
-      const extension = toInternalExtension(node.spec.extension);
+      const extension = node && toInternalExtension(node.spec.extension);
       if (
+        extension &&
         !Object.values(extension.output).some(
           data => data.id === coreExtensionData.routePath.id,
         )
@@ -311,6 +344,7 @@ export class RouteResolver implements RouteResolutionApi {
         this.routeBindings,
         this.routeRefsById,
         this.extensionRoutes,
+        this.fallbackRoutes,
       );
     }
     for (const [externalRef, target] of this.routeBindings) {
@@ -345,6 +379,7 @@ export class RouteResolver implements RouteResolutionApi {
       this.routeBindings,
       this.routeRefsById,
       this.extensionRoutes,
+      this.fallbackRoutes,
     );
     if (!targetRef) {
       return undefined;

--- a/packages/frontend-app-api/src/routing/RouteResolver.ts
+++ b/packages/frontend-app-api/src/routing/RouteResolver.ts
@@ -17,6 +17,9 @@
 import { generatePath, matchRoutes } from 'react-router-dom';
 import {
   RouteRef,
+  createRouteRef,
+  AppTree,
+  coreExtensionData,
   ExternalRouteRef,
   SubRouteRef,
   AnyRouteRefParams,
@@ -31,6 +34,8 @@ import {
   OpaqueSubRouteRef,
 } from '@internal/frontend';
 import { RouteAliasResolver } from './RouteAliasResolver';
+// eslint-disable-next-line @backstage/no-relative-monorepo-imports
+import { toInternalExtension } from '../../../frontend-plugin-api/src/wiring/resolveExtensionDefinition';
 import { joinPaths } from './joinPaths';
 
 /**
@@ -44,6 +49,7 @@ function resolveTargetRef(
   routePaths: Map<RouteRef, string>,
   routeBindings: Map<AnyRouteRef, AnyRouteRef | undefined>,
   routeRefsById: Map<string, RouteRef | SubRouteRef>,
+  extensionRoutes: Map<string, RouteRef>,
 ): readonly [RouteRef | undefined, string] {
   // First we figure out which absolute route ref we're dealing with, an if there was an sub route path to append.
   // For sub routes it will be the parent path, while for external routes it will be the bound route.
@@ -51,8 +57,16 @@ function resolveTargetRef(
   let path = '';
 
   if (OpaqueExternalRouteRef.isType(ref)) {
-    let resolvedRoute = routeBindings.get(ref);
-    if (!resolvedRoute) {
+    const id = OpaqueExternalRouteRef.toInternal(ref).getId?.();
+    const bindingRef = id
+      ? [...routeBindings.keys()].find(
+          candidate =>
+            OpaqueExternalRouteRef.isType(candidate) &&
+            OpaqueExternalRouteRef.toInternal(candidate).getId?.() === id,
+        ) ?? ref
+      : ref;
+    let resolvedRoute = routeBindings.get(bindingRef);
+    if (!routeBindings.has(bindingRef)) {
       const internal = OpaqueExternalRouteRef.toInternal(ref);
       const defaultTarget = internal.getDefaultTarget();
       if (defaultTarget) {
@@ -75,6 +89,25 @@ function resolveTargetRef(
     throw new Error(
       `Unexpectedly resolved ${targetRouteRef} to a non-route ref ${ref}`,
     );
+  }
+
+  const internal = OpaqueRouteRef.toInternal(ref);
+  const extensionId = internal.getExtensionId?.();
+  if (extensionId !== undefined) {
+    const mountedRef = extensionRoutes.get(extensionId);
+    if (!mountedRef) {
+      return [undefined, ''];
+    }
+    const expected = [
+      ...OpaqueRouteRef.toInternal(mountedRef).getParams(),
+    ].sort();
+    const actual = [...internal.getParams()].sort();
+    if (JSON.stringify(actual) !== JSON.stringify(expected)) {
+      throw new Error(
+        `Route reference for '${extensionId}' has parameters [${actual}], but its mounted path requires [${expected}]`,
+      );
+    }
+    ref = mountedRef;
   }
 
   // Find the path that our target route is bound to
@@ -164,10 +197,14 @@ function resolveBasePath(
 }
 
 export class RouteResolver implements RouteResolutionApi {
+  private readonly extensionRoutes = new Map<string, RouteRef>();
   private readonly routePaths: Map<RouteRef, string>;
   private readonly routeParents: Map<RouteRef, RouteRef | undefined>;
   private readonly routeObjects: BackstageRouteObject[];
-  private readonly routeBindings: Map<ExternalRouteRef, RouteRef | SubRouteRef>;
+  private readonly routeBindings: Map<
+    ExternalRouteRef,
+    RouteRef | SubRouteRef | undefined
+  >;
   private readonly appBasePath: string; // base path without a trailing slash
   private readonly routeAliasResolver: RouteAliasResolver;
   private readonly routeRefsById: Map<string, RouteRef | SubRouteRef>;
@@ -176,18 +213,120 @@ export class RouteResolver implements RouteResolutionApi {
     routePaths: Map<RouteRef, string>,
     routeParents: Map<RouteRef, RouteRef | undefined>,
     routeObjects: BackstageRouteObject[],
-    routeBindings: Map<ExternalRouteRef, RouteRef | SubRouteRef>,
+    routeBindings: Map<ExternalRouteRef, RouteRef | SubRouteRef | undefined>,
     appBasePath: string, // base path without a trailing slash
     routeAliasResolver: RouteAliasResolver,
     routeRefsById: Map<string, RouteRef | SubRouteRef>,
   ) {
-    this.routePaths = routePaths;
-    this.routeParents = routeParents;
-    this.routeObjects = routeObjects;
+    this.routePaths = new Map(routePaths);
+    this.routeParents = new Map(routeParents);
+    // Canonical refs let extension-ID lookups share the path resolver while
+    // leaving historical page associations and their parent chains intact.
+    const indexRoutes = (
+      objects: BackstageRouteObject[],
+      parent?: RouteRef,
+    ): BackstageRouteObject[] =>
+      objects.map(object => {
+        let ref = parent;
+        const refs = new Set(object.routeRefs);
+        if (object.appNode) {
+          const extensionId = object.appNode.spec.id;
+          ref = createRouteRef({
+            extensionId,
+            params: [...object.path.matchAll(/:([\w-]+)/g)].map(
+              match => match[1],
+            ),
+          });
+          this.extensionRoutes.set(extensionId, ref);
+          this.routePaths.set(ref, object.path);
+          this.routeParents.set(ref, parent);
+          refs.add(ref);
+        }
+        return {
+          ...object,
+          routeRefs: refs,
+          ...(object.children && {
+            children: indexRoutes(object.children, ref),
+          }),
+        };
+      });
+    this.routeObjects = indexRoutes(routeObjects);
     this.routeBindings = routeBindings;
     this.appBasePath = appBasePath;
     this.routeAliasResolver = routeAliasResolver;
     this.routeRefsById = routeRefsById;
+  }
+
+  validate(tree: AppTree, refs: Iterable<RouteRef | SubRouteRef>) {
+    const contracts = new Map<string, string>();
+    const targets = [...refs, ...this.routeBindings.values()];
+    for (const node of tree.nodes.values()) {
+      const ref = node.instance?.getData(coreExtensionData.routeRef);
+      if (ref) {
+        targets.push(ref);
+      }
+    }
+    for (const ref of targets) {
+      if (!ref) {
+        continue;
+      }
+      const root = OpaqueSubRouteRef.isType(ref)
+        ? OpaqueSubRouteRef.toInternal(ref).getParent()
+        : ref;
+      const internal = OpaqueRouteRef.toInternal(root);
+      const extensionId = internal.getExtensionId?.();
+      if (extensionId === undefined) {
+        continue;
+      }
+      const contract = JSON.stringify([...internal.getParams()].sort());
+      if (
+        contracts.has(extensionId) &&
+        contracts.get(extensionId) !== contract
+      ) {
+        throw new Error(
+          `Conflicting route parameter contracts for extension '${extensionId}'`,
+        );
+      }
+      contracts.set(extensionId, contract);
+      const node = tree.nodes.get(extensionId);
+      if (!node) {
+        throw new Error(
+          `Route reference targets unknown extension '${extensionId}'`,
+        );
+      }
+      const extension = toInternalExtension(node.spec.extension);
+      if (
+        !Object.values(extension.output).some(
+          data => data.id === coreExtensionData.routePath.id,
+        )
+      ) {
+        throw new Error(
+          `Route reference targets non-routable extension '${extensionId}'`,
+        );
+      }
+      // Disabled and conditional targets can be known without having a mounted path.
+      resolveTargetRef(
+        ref,
+        this.routePaths,
+        this.routeBindings,
+        this.routeRefsById,
+        this.extensionRoutes,
+      );
+    }
+    for (const [externalRef, target] of this.routeBindings) {
+      if (!target) {
+        continue;
+      }
+      const params = OpaqueExternalRouteRef.toInternal(externalRef).getParams();
+      const targetParams = OpaqueSubRouteRef.isType(target)
+        ? OpaqueSubRouteRef.toInternal(target).getParams()
+        : OpaqueRouteRef.toInternal(target).getParams();
+      if (targetParams.some(param => !params.includes(param))) {
+        throw new Error(
+          `External route ${externalRef} does not provide the parameters required by ${target}`,
+        );
+      }
+    }
   }
 
   resolve<TParams extends AnyRouteRefParams>(
@@ -205,6 +344,7 @@ export class RouteResolver implements RouteResolutionApi {
       this.routePaths,
       this.routeBindings,
       this.routeRefsById,
+      this.extensionRoutes,
     );
     if (!targetRef) {
       return undefined;

--- a/packages/frontend-app-api/src/routing/RouteTracker.test.tsx
+++ b/packages/frontend-app-api/src/routing/RouteTracker.test.tsx
@@ -30,8 +30,11 @@ import {
 import { MATCH_ALL_ROUTE } from './extractRouteInfoFromAppNode';
 
 describe('RouteTracker', () => {
+  // @ts-expect-error Historical refs intentionally omit extensionId
   const routeRef0 = createRouteRef();
+  // @ts-expect-error Historical refs intentionally omit extensionId
   const routeRef1 = createRouteRef();
+  // @ts-expect-error Historical refs intentionally omit extensionId
   const routeRef2 = createRouteRef();
 
   const routeObjects: BackstageRouteObject[] = [

--- a/packages/frontend-app-api/src/routing/RouteTracker.tsx
+++ b/packages/frontend-app-api/src/routing/RouteTracker.tsx
@@ -35,11 +35,11 @@ const getExtensionContext = (
     // Find matching routes for the given path name.
     const matches = matchRoutes(routes, { pathname });
 
-    // Of the matching routes, get the last (e.g. most specific) instance of
-    // the BackstageRouteObject that contains a routeRef. Filtering by routeRef
-    // ensures subRouteRefs are aligned to their parent routes' context.
+    // Use the most specific mounted extension, including pages without route refs.
     const routeMatch = matches
-      ?.filter(match => match?.route.routeRefs?.size > 0)
+      ?.filter(
+        match => match?.route.appNode || match?.route.routeRefs?.size > 0,
+      )
       .pop();
     const routeObject = routeMatch?.route;
 

--- a/packages/frontend-app-api/src/routing/collectRouteIds.test.ts
+++ b/packages/frontend-app-api/src/routing/collectRouteIds.test.ts
@@ -35,6 +35,7 @@ afterEach(() => {
 
 describe('collectRouteIds', () => {
   it('should assign IDs to routes', () => {
+    // @ts-expect-error Historical refs intentionally omit extensionId
     const ref = createRouteRef();
     const extRef = createExternalRouteRef();
 
@@ -71,6 +72,7 @@ describe('collectRouteIds', () => {
   });
 
   it('should report duplicate route IDs', () => {
+    // @ts-expect-error Historical refs intentionally omit extensionId
     const ref = createRouteRef();
     const extRef = createExternalRouteRef();
 

--- a/packages/frontend-app-api/src/routing/collectRouteIds.ts
+++ b/packages/frontend-app-api/src/routing/collectRouteIds.ts
@@ -26,11 +26,16 @@ import {
   OpaqueExternalRouteRef,
   OpaqueFrontendPlugin,
 } from '@internal/frontend';
+// eslint-disable-next-line @backstage/no-relative-monorepo-imports
+import { isInternalFrontendModule } from '../../../frontend-plugin-api/src/wiring/createFrontendModule';
+// eslint-disable-next-line @backstage/no-relative-monorepo-imports
+import { validateRouteNamespace } from '../../../frontend-plugin-api/src/routing/validateRouteNamespace';
 import { ErrorCollector } from '../wiring/createErrorCollector';
 
 /** @internal */
 export interface RouteRefsById {
   routes: Map<string, RouteRef | SubRouteRef>;
+  allRoutes?: Set<RouteRef | SubRouteRef>;
   externalRoutes: Map<string, ExternalRouteRef>;
 }
 
@@ -39,6 +44,7 @@ export function collectRouteIds(
   features: FrontendFeature[],
   collector: ErrorCollector,
 ): RouteRefsById {
+  const allRoutes = new Set<RouteRef | SubRouteRef>();
   const routesById = new Map<string, RouteRef | SubRouteRef>();
   const externalRoutesById = new Map<string, ExternalRouteRef>();
 
@@ -47,8 +53,10 @@ export function collectRouteIds(
       continue;
     }
 
+    validateRouteNamespace(feature.id, feature.routes);
     for (const [name, ref] of Object.entries(feature.routes)) {
       const refId = `${feature.id}.${name}`;
+      allRoutes.add(ref);
       if (routesById.has(refId)) {
         collector.report({
           code: 'ROUTE_DUPLICATE',
@@ -60,7 +68,9 @@ export function collectRouteIds(
 
       if (OpaqueRouteRef.isType(ref)) {
         const internalRef = OpaqueRouteRef.toInternal(ref);
-        internalRef.setId(refId);
+        if (!internalRef.getExtensionId) {
+          internalRef.setId(refId);
+        }
         routesById.set(refId, ref);
       } else {
         const internalRef = OpaqueSubRouteRef.toInternal(ref);
@@ -84,5 +94,28 @@ export function collectRouteIds(
     }
   }
 
-  return { routes: routesById, externalRoutes: externalRoutesById };
+  // This is the same resolved feature order used by resolveAppNodeSpecs:
+  // plugins first, then modules, with the last module winning.
+  const pluginIds = new Set(
+    features.filter(OpaqueFrontendPlugin.isType).map(p => p.id),
+  );
+  for (const module of features.filter(isInternalFrontendModule)) {
+    if (!pluginIds.has(module.pluginId)) {
+      continue;
+    }
+    validateRouteNamespace(module.pluginId, module.routes ?? {});
+    for (const [name, ref] of Object.entries(module.routes ?? {})) {
+      const refId = `${module.pluginId}.${name}`;
+      allRoutes.add(ref);
+      if (OpaqueRouteRef.isType(ref)) {
+        const internal = OpaqueRouteRef.toInternal(ref);
+        if (!internal.getExtensionId) {
+          internal.setId(refId);
+        }
+      }
+      routesById.set(refId, ref);
+    }
+  }
+
+  return { routes: routesById, externalRoutes: externalRoutesById, allRoutes };
 }

--- a/packages/frontend-app-api/src/routing/extensionRoutes.test.tsx
+++ b/packages/frontend-app-api/src/routing/extensionRoutes.test.tsx
@@ -280,11 +280,63 @@ it('validates ownership and complete installed targets without rejecting disable
   expect(() => createSpecializedApp({ features: [app, mismatch] })).toThrow(
     'parameters',
   );
-  const wrongEmission = createFrontendPlugin({
-    pluginId: 'test',
-    extensions: [page('wrong', '/', { ref })],
+});
+
+it('uses deprecated mounts only when the structural target is absent', () => {
+  const ref = createRouteRef({
+    extensionId: 'page:test/target',
+    params: ['id'],
   });
+  const copy = createRouteRef({
+    extensionId: 'page:test/target',
+    params: ['id'],
+  });
+  const sub = createSubRouteRef({ parent: copy, path: '/edit' });
+  const external = createExternalRouteRef({
+    params: ['id'],
+    defaultTarget: 'test.sub',
+  });
+  const fallback = page('converted', '/legacy/:id', { ref });
+  const plugin = createFrontendPlugin({
+    pluginId: 'test',
+    routes: { ref, copy, sub },
+    externalRoutes: { external },
+    extensions: [fallback],
+  });
+  const routes = createSpecializedApp({ features: [app, plugin] }).apis.get(
+    routeResolutionApiRef,
+  )!;
+  expect(routes.resolve(copy)?.({ id: 'one' })).toBe('/legacy/one');
+  expect(routes.resolve(external)?.({ id: 'one' })).toBe('/legacy/one/edit');
+
+  const withTarget = (target: ReturnType<typeof page>) =>
+    createSpecializedApp({
+      features: [app, plugin.withOverrides({ extensions: [target] })],
+    }).apis.get(routeResolutionApiRef)!;
+  expect(
+    withTarget(page('target', '/native/:id')).resolve(copy)?.({ id: 'one' }),
+  ).toBe('/native/one');
+  expect(
+    withTarget(page('target', '/native/:id', { disabled: true })).resolve(copy),
+  ).toBeUndefined();
+  expect(
+    withTarget(page('target', '/native/:id', { if: false })).resolve(copy),
+  ).toBeUndefined();
+
+  const duplicates = plugin.withOverrides({
+    extensions: [page('second', '/other/:id', { ref: copy })],
+  });
+  expect(() => createSpecializedApp({ features: [app, duplicates] })).toThrow(
+    'Ambiguous deprecated route mounts',
+  );
   expect(() =>
-    createSpecializedApp({ features: [app, wrongEmission] }),
-  ).toThrow("targets 'page:test/root'");
+    createSpecializedApp({
+      features: [
+        app,
+        duplicates.withOverrides({
+          extensions: [page('target', '/native/:id')],
+        }),
+      ],
+    }),
+  ).not.toThrow();
 });

--- a/packages/frontend-app-api/src/routing/extensionRoutes.test.tsx
+++ b/packages/frontend-app-api/src/routing/extensionRoutes.test.tsx
@@ -1,0 +1,290 @@
+/*
+ * Copyright 2026 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+  coreExtensionData,
+  createExtension,
+  createExtensionInput,
+  createFrontendPlugin,
+  createFrontendModule,
+  createRouteRef,
+  createSubRouteRef,
+  createExternalRouteRef,
+  routeResolutionApiRef,
+  RouteRef,
+} from '@backstage/frontend-plugin-api';
+import { OpaqueRouteRef } from '@internal/frontend';
+import { ConfigReader } from '@backstage/config';
+import { createSpecializedApp } from '../wiring/createSpecializedApp';
+
+const app = createFrontendPlugin({
+  pluginId: 'app',
+  extensions: [
+    createExtension({
+      attachTo: { id: 'root', input: 'app' },
+      inputs: {
+        children: createExtensionInput([coreExtensionData.reactElement]),
+      },
+      output: [coreExtensionData.reactElement],
+      factory: () => [coreExtensionData.reactElement(<div />)],
+    }),
+    createExtension({
+      name: 'root',
+      attachTo: { id: 'app', input: 'children' },
+      inputs: {
+        children: createExtensionInput([coreExtensionData.reactElement]),
+      },
+      output: [coreExtensionData.reactElement],
+      factory: () => [coreExtensionData.reactElement(<div />)],
+    }),
+  ],
+});
+
+function page(
+  name: string,
+  path: string,
+  options?: {
+    parent?: string;
+    ref?: RouteRef;
+    disabled?: boolean;
+    if?: false;
+  },
+) {
+  return createExtension({
+    kind: 'page',
+    name,
+    disabled: options?.disabled,
+    if: options?.if,
+    attachTo: { id: options?.parent ?? 'app/root', input: 'children' },
+    inputs: {
+      children: createExtensionInput([coreExtensionData.reactElement]),
+    },
+    output: [
+      coreExtensionData.reactElement,
+      coreExtensionData.routePath,
+      coreExtensionData.routeRef.optional(),
+    ],
+    *factory() {
+      yield coreExtensionData.reactElement(<div />);
+      yield coreExtensionData.routePath(path);
+      if (options?.ref) {
+        yield coreExtensionData.routeRef(options.ref);
+      }
+    },
+  });
+}
+
+it('resolves structural copies and sub routes alongside historical page refs', () => {
+  const root = createRouteRef({ extensionId: 'page:test/root' });
+  const detail = createRouteRef({
+    extensionId: 'page:test/detail',
+    params: ['id'],
+  });
+  const copy = { ...detail };
+  const child = createRouteRef({ extensionId: 'page:test/child' });
+  const sub = createSubRouteRef({ parent: copy, path: '/edit/:tab' });
+  // @ts-expect-error Simulate a plugin compiled before extensionId was required
+  const historical = createRouteRef();
+  const plugin = createFrontendPlugin({
+    pluginId: 'test',
+    routes: { root, detail, sub, historical, child },
+    extensions: [
+      page('root', '/test'),
+      page('detail', ':id', { parent: 'page:test/root', ref: detail }),
+      page('old', '/old', { ref: historical }),
+      page('child', 'child', { parent: 'page:test/detail' }),
+    ],
+  });
+  const result = createSpecializedApp({ features: [app, plugin] });
+  const routes = result.apis.get(routeResolutionApiRef)!;
+  expect(routes.resolve(root)?.()).toBe('/test');
+  expect(routes.resolve(copy)?.({ id: 'one' })).toBe('/test/one');
+  expect(routes.resolve(sub)?.({ id: 'one', tab: 'two' })).toBe(
+    '/test/one/edit/two',
+  );
+  expect(routes.resolve(historical)?.()).toBe('/old');
+  expect(routes.resolve(child, { sourcePath: '/test/one' })?.()).toBe(
+    '/test/one/child',
+  );
+  expect(() => routes.resolve(child)).toThrow('has parameters');
+  expect(
+    routes.resolve(createRouteRef({ extensionId: 'page:test/root' }))?.(),
+  ).toBe('/test');
+  expect(() =>
+    routes.resolve(createRouteRef({ extensionId: 'page:test/detail' })),
+  ).toThrow('parameters');
+});
+
+it('shares module precedence with extensions while keeping structural targets stable', () => {
+  const root = createRouteRef({ extensionId: 'page:test/root' });
+  const replacement = createRouteRef({ extensionId: 'page:test/replacement' });
+  const external = createExternalRouteRef({ defaultTarget: 'test.root' });
+  const plugin = createFrontendPlugin({
+    pluginId: 'test',
+    routes: { root },
+    externalRoutes: { home: external },
+    extensions: [page('root', '/base')],
+  });
+  const low = createFrontendModule({
+    pluginId: 'test',
+    routes: { root },
+    extensions: [page('replacement', '/low')],
+  });
+  const high = createFrontendModule({
+    pluginId: 'test',
+    routes: { root: replacement },
+    extensions: [page('replacement', '/high')],
+  });
+  const oldModule = { ...createFrontendModule({ pluginId: 'test' }) };
+  delete (oldModule as { routes?: unknown }).routes;
+  const result = createSpecializedApp({
+    features: [app, high, plugin, low, oldModule, high],
+  });
+  const routes = result.apis.get(routeResolutionApiRef)!;
+  // The repeated module object is deduplicated before both route and extension ordering.
+  expect(routes.resolve(external)?.()).toBe('/base');
+  expect(routes.resolve(replacement)?.()).toBe('/low');
+  expect(routes.resolve(root)?.()).toBe('/base');
+  const winning = createSpecializedApp({
+    features: [app, plugin, low, high],
+  }).apis.get(routeResolutionApiRef)!;
+  expect(winning.resolve(external)?.()).toBe('/high');
+  expect(winning.resolve(root)?.()).toBe('/base');
+  expect(OpaqueRouteRef.toInternal(root).getExtensionId?.()).toBe(
+    'page:test/root',
+  );
+});
+
+it('binds duplicated external refs through named IDs, including disabled defaults and sub routes', () => {
+  const root = createRouteRef({ extensionId: 'page:test/root' });
+  const sub = createSubRouteRef({ parent: root, path: '/:id' });
+  const external = createExternalRouteRef({
+    params: ['id'],
+    defaultTarget: 'test.sub',
+  });
+  const copy = createExternalRouteRef({
+    params: ['id'],
+    defaultTarget: 'test.sub',
+  });
+  createFrontendPlugin({
+    pluginId: 'consumer',
+    externalRoutes: { item: copy },
+  });
+  const consumer = createFrontendPlugin({
+    pluginId: 'consumer',
+    externalRoutes: { item: external },
+  });
+  const plugin = createFrontendPlugin({
+    pluginId: 'test',
+    routes: { root, sub },
+    extensions: [page('root', '/items')],
+  });
+  const features = [app, plugin, consumer];
+  const config = new ConfigReader({
+    app: { routes: { bindings: { 'consumer.item': 'test.sub' } } },
+  });
+  const routes = createSpecializedApp({ features, config }).apis.get(
+    routeResolutionApiRef,
+  )!;
+  expect(routes.resolve(copy)?.({ id: 'abc' })).toBe('/items/abc');
+  const disabled = createSpecializedApp({
+    features,
+    config,
+    bindRoutes({ bind }) {
+      bind({ item: copy }, { item: false });
+    },
+  }).apis.get(routeResolutionApiRef)!;
+  expect(disabled.resolve(external)).toBeUndefined();
+  expect(disabled.resolve(copy)).toBeUndefined();
+});
+
+it('validates ownership and complete installed targets without rejecting disabled or module-provided pages', () => {
+  const ref = createRouteRef({ extensionId: 'page:test/root' });
+  const sub = createSubRouteRef({ parent: ref, path: '/sub' });
+  expect(() =>
+    createFrontendPlugin({ pluginId: 'other', routes: { sub } }),
+  ).toThrow('namespace');
+  expect(() =>
+    createFrontendModule({ pluginId: 'other', routes: { sub } }),
+  ).toThrow('namespace');
+  const plugin = createFrontendPlugin({
+    pluginId: 'test',
+    routes: { root: ref },
+  });
+  expect(() => createSpecializedApp({ features: [app, plugin] })).toThrow(
+    'unknown extension',
+  );
+  const module = createFrontendModule({
+    pluginId: 'test',
+    extensions: [page('root', '/test', { disabled: true })],
+  });
+  expect(
+    createSpecializedApp({ features: [app, plugin, module] })
+      .apis.get(routeResolutionApiRef)!
+      .resolve(ref),
+  ).toBeUndefined();
+  const conditional = createFrontendModule({
+    pluginId: 'test',
+    extensions: [page('root', '/test', { if: false })],
+  });
+  expect(
+    createSpecializedApp({ features: [app, plugin, conditional] })
+      .apis.get(routeResolutionApiRef)!
+      .resolve(ref),
+  ).toBeUndefined();
+  const nonRoutable = createFrontendModule({
+    pluginId: 'test',
+    extensions: [
+      createExtension({
+        kind: 'page',
+        name: 'root',
+        attachTo: { id: 'app/root', input: 'children' },
+        output: [coreExtensionData.reactElement],
+        factory: () => [coreExtensionData.reactElement(<div />)],
+      }),
+    ],
+  });
+  expect(() =>
+    createSpecializedApp({ features: [app, plugin, nonRoutable] }),
+  ).toThrow('non-routable');
+  const conflict = createRouteRef({
+    extensionId: 'page:test/root',
+    params: ['id'],
+  });
+  const conflictingPlugin = createFrontendPlugin({
+    pluginId: 'test',
+    routes: { ref, conflict },
+    extensions: [page('root', '/test')],
+  });
+  expect(() =>
+    createSpecializedApp({ features: [app, conflictingPlugin] }),
+  ).toThrow('Conflicting route parameter contracts');
+  const mismatch = createFrontendPlugin({
+    pluginId: 'test',
+    routes: { ref },
+    extensions: [page('root', '/:id')],
+  });
+  expect(() => createSpecializedApp({ features: [app, mismatch] })).toThrow(
+    'parameters',
+  );
+  const wrongEmission = createFrontendPlugin({
+    pluginId: 'test',
+    extensions: [page('wrong', '/', { ref })],
+  });
+  expect(() =>
+    createSpecializedApp({ features: [app, wrongEmission] }),
+  ).toThrow("targets 'page:test/root'");
+});

--- a/packages/frontend-app-api/src/routing/extractRouteInfoFromAppNode.test.ts
+++ b/packages/frontend-app-api/src/routing/extractRouteInfoFromAppNode.test.ts
@@ -51,10 +51,15 @@ afterEach(() => {
   }
 });
 
+// @ts-expect-error Historical refs intentionally omit extensionId
 const ref1 = createRouteRef();
+// @ts-expect-error Historical refs intentionally omit extensionId
 const ref2 = createRouteRef();
+// @ts-expect-error Historical refs intentionally omit extensionId
 const ref3 = createRouteRef();
+// @ts-expect-error Historical refs intentionally omit extensionId
 const ref4 = createRouteRef();
+// @ts-expect-error Historical refs intentionally omit extensionId
 const ref5 = createRouteRef();
 const refOrder: RouteRef<AnyRouteRefParams>[] = [ref1, ref2, ref3, ref4, ref5];
 
@@ -581,8 +586,11 @@ describe('discovery', () => {
 
   describe('route aliases', () => {
     it('should resolve route aliases', () => {
+      // @ts-expect-error Historical refs intentionally omit extensionId
       const r1 = createRouteRef();
+      // @ts-expect-error Historical refs intentionally omit extensionId
       const r2 = createRouteRef({ aliasFor: 'test.r3' });
+      // @ts-expect-error Historical refs intentionally omit extensionId
       const r3 = createRouteRef();
 
       const info = routeInfoFromExtensions(
@@ -590,11 +598,13 @@ describe('discovery', () => {
           createTestExtension({
             name: 'page1',
             path: 'foo',
+            // @ts-expect-error Historical refs intentionally omit extensionId
             routeRef: createRouteRef({ aliasFor: 'test.r1' }),
           }),
           createTestExtension({
             name: 'page3',
             path: 'bar',
+            // @ts-expect-error Historical refs intentionally omit extensionId
             routeRef: createRouteRef({ aliasFor: 'test.r2' }),
           }),
         ],
@@ -627,11 +637,13 @@ describe('discovery', () => {
             createTestExtension({
               name: 'page1',
               path: 'page1',
+              // @ts-expect-error Historical refs intentionally omit extensionId
               routeRef: createRouteRef({ aliasFor: 'other.root' }),
             }),
           ],
 
           {
+            // @ts-expect-error Historical refs intentionally omit extensionId
             'other.root': createRouteRef(),
           },
         ),
@@ -641,8 +653,11 @@ describe('discovery', () => {
     });
 
     it('should bail on infinite route alias loops', () => {
+      // @ts-expect-error Historical refs intentionally omit extensionId
       const loop1 = createRouteRef({ aliasFor: 'test.loop2' });
+      // @ts-expect-error Historical refs intentionally omit extensionId
       const loop2 = createRouteRef({ aliasFor: 'test.loop3' });
+      // @ts-expect-error Historical refs intentionally omit extensionId
       const loop3 = createRouteRef({ aliasFor: 'test.loop1' });
 
       expect(() =>
@@ -651,6 +666,7 @@ describe('discovery', () => {
             createTestExtension({
               name: 'page1',
               path: 'page1',
+              // @ts-expect-error Historical refs intentionally omit extensionId
               routeRef: createRouteRef({ aliasFor: 'test.loop1' }),
             }),
           ],

--- a/packages/frontend-app-api/src/routing/extractRouteInfoFromAppNode.ts
+++ b/packages/frontend-app-api/src/routing/extractRouteInfoFromAppNode.ts
@@ -21,6 +21,7 @@ import {
   createExactRouteAliasResolver,
   RouteAliasResolver,
 } from './RouteAliasResolver';
+import { OpaqueRouteRef } from '@internal/frontend';
 import { joinPaths } from './joinPaths';
 
 /** @internal */
@@ -71,8 +72,23 @@ export function extractRouteInfoFromAppNode(
       ?.replace(/^\//, '');
 
     const foundRouteRef = current.instance?.getData(coreExtensionData.routeRef);
-    const routeRef = routeAliasResolver(foundRouteRef, current.spec.plugin?.id);
-    if (foundRouteRef && routeRef !== foundRouteRef) {
+    const extensionId =
+      foundRouteRef &&
+      OpaqueRouteRef.toInternal(foundRouteRef).getExtensionId?.();
+    if (extensionId !== undefined && extensionId !== current.spec.id) {
+      throw new Error(
+        `Route reference emitted by '${current.spec.id}' targets '${extensionId}'`,
+      );
+    }
+    const routeRef =
+      extensionId === undefined
+        ? routeAliasResolver(foundRouteRef, current.spec.plugin?.id)
+        : undefined;
+    if (
+      foundRouteRef &&
+      extensionId === undefined &&
+      routeRef !== foundRouteRef
+    ) {
       routeAliases.set(foundRouteRef, routeRef);
     }
 

--- a/packages/frontend-app-api/src/routing/extractRouteInfoFromAppNode.ts
+++ b/packages/frontend-app-api/src/routing/extractRouteInfoFromAppNode.ts
@@ -21,7 +21,6 @@ import {
   createExactRouteAliasResolver,
   RouteAliasResolver,
 } from './RouteAliasResolver';
-import { OpaqueRouteRef } from '@internal/frontend';
 import { joinPaths } from './joinPaths';
 
 /** @internal */
@@ -72,23 +71,8 @@ export function extractRouteInfoFromAppNode(
       ?.replace(/^\//, '');
 
     const foundRouteRef = current.instance?.getData(coreExtensionData.routeRef);
-    const extensionId =
-      foundRouteRef &&
-      OpaqueRouteRef.toInternal(foundRouteRef).getExtensionId?.();
-    if (extensionId !== undefined && extensionId !== current.spec.id) {
-      throw new Error(
-        `Route reference emitted by '${current.spec.id}' targets '${extensionId}'`,
-      );
-    }
-    const routeRef =
-      extensionId === undefined
-        ? routeAliasResolver(foundRouteRef, current.spec.plugin?.id)
-        : undefined;
-    if (
-      foundRouteRef &&
-      extensionId === undefined &&
-      routeRef !== foundRouteRef
-    ) {
+    const routeRef = routeAliasResolver(foundRouteRef, current.spec.plugin?.id);
+    if (foundRouteRef && routeRef !== foundRouteRef) {
       routeAliases.set(foundRouteRef, routeRef);
     }
 

--- a/packages/frontend-app-api/src/routing/resolveRouteBindings.test.ts
+++ b/packages/frontend-app-api/src/routing/resolveRouteBindings.test.ts
@@ -38,6 +38,7 @@ const emptyIds = { routes: new Map(), externalRoutes: new Map() };
 describe('resolveRouteBindings', () => {
   it('runs happy path', () => {
     const external = { myRoute: createExternalRouteRef() };
+    // @ts-expect-error Historical refs intentionally omit extensionId
     const ref = createRouteRef();
     const result = resolveRouteBindings(
       ({ bind }) => {
@@ -53,6 +54,7 @@ describe('resolveRouteBindings', () => {
 
   it('reports error on unknown keys', () => {
     const external = { myRoute: createExternalRouteRef() };
+    // @ts-expect-error Historical refs intentionally omit extensionId
     const ref = createRouteRef();
     resolveRouteBindings(
       ({ bind }) => {
@@ -73,6 +75,7 @@ describe('resolveRouteBindings', () => {
 
   it('reads bindings from config', () => {
     const mySource = createExternalRouteRef();
+    // @ts-expect-error Historical refs intentionally omit extensionId
     const myTarget = createRouteRef();
     const result = resolveRouteBindings(
       () => {},
@@ -91,6 +94,7 @@ describe('resolveRouteBindings', () => {
 
   it('prioritizes callback routes over config', () => {
     const mySource = createExternalRouteRef();
+    // @ts-expect-error Historical refs intentionally omit extensionId
     const myTarget = createRouteRef();
 
     expect(
@@ -193,7 +197,9 @@ describe('resolveRouteBindings', () => {
 
   it('can have default targets, but at the lowest priority', () => {
     const source = createExternalRouteRef({ defaultTarget: 'target1' });
+    // @ts-expect-error Historical refs intentionally omit extensionId
     const target1 = createRouteRef();
+    // @ts-expect-error Historical refs intentionally omit extensionId
     const target2 = createRouteRef();
     const routesById = {
       routes: new Map([
@@ -240,6 +246,7 @@ describe('resolveRouteBindings', () => {
 
   it('can disable external routes that have defaults', () => {
     const source = createExternalRouteRef({ defaultTarget: 'target1' });
+    // @ts-expect-error Historical refs intentionally omit extensionId
     const target1 = createRouteRef();
     const routesById = {
       routes: new Map([['target1', target1]]),

--- a/packages/frontend-app-api/src/routing/resolveRouteBindings.ts
+++ b/packages/frontend-app-api/src/routing/resolveRouteBindings.ts
@@ -81,8 +81,11 @@ export function resolveRouteBindings(
   config: Config,
   routesById: RouteRefsById,
   collector: ErrorCollector,
-): Map<ExternalRouteRef, RouteRef | SubRouteRef> {
-  const result = new Map<ExternalRouteRef, RouteRef | SubRouteRef>();
+): Map<ExternalRouteRef, RouteRef | SubRouteRef | undefined> {
+  const result = new Map<
+    ExternalRouteRef,
+    RouteRef | SubRouteRef | undefined
+  >();
   const disabledExternalRefs = new Set<ExternalRouteRef>();
 
   // Perform callback bindings first with highest priority
@@ -92,7 +95,12 @@ export function resolveRouteBindings(
       targetRoutes: { [name: string]: RouteRef | SubRouteRef },
     ) => {
       for (const [key, value] of Object.entries(targetRoutes)) {
-        const externalRoute = externalRoutes[key];
+        const providedRoute = externalRoutes[key];
+        const id =
+          providedRoute &&
+          OpaqueExternalRouteRef.toInternal(providedRoute).getId?.();
+        const externalRoute =
+          (id && routesById.externalRoutes.get(id)) || providedRoute;
         if (!externalRoute) {
           collector.report({
             code: 'ROUTE_NOT_FOUND',
@@ -175,6 +183,9 @@ export function resolveRouteBindings(
     }
   }
 
+  for (const ref of disabledExternalRefs) {
+    result.set(ref, undefined);
+  }
   return result;
 }
 

--- a/packages/frontend-app-api/src/wiring/createSpecializedApp.test.tsx
+++ b/packages/frontend-app-api/src/wiring/createSpecializedApp.test.tsx
@@ -668,6 +668,7 @@ describe('createSpecializedApp', () => {
   });
 
   it('should support route bindings', async () => {
+    // @ts-expect-error Historical refs intentionally omit extensionId
     const routeRef = createRouteRef();
     const extRouteRef = createExternalRouteRef();
 

--- a/packages/frontend-app-api/src/wiring/phaseApis.tsx
+++ b/packages/frontend-app-api/src/wiring/phaseApis.tsx
@@ -111,14 +111,17 @@ export class AppTreeApiProxy implements AppTreeApi {
 
 // Helps delay callers from reaching out to the API before the app tree has been materialized
 export class RouteResolutionApiProxy implements RouteResolutionApi {
-  #delegate: RouteResolutionApi | undefined;
+  #delegate: RouteResolver | undefined;
   #routeObjects: BackstageRouteObject[] | undefined;
 
-  private readonly routeBindings: Map<ExternalRouteRef, RouteRef | SubRouteRef>;
+  private readonly routeBindings: Map<
+    ExternalRouteRef,
+    RouteRef | SubRouteRef | undefined
+  >;
   private readonly appBasePath: string;
 
   constructor(
-    routeBindings: Map<ExternalRouteRef, RouteRef | SubRouteRef>,
+    routeBindings: Map<ExternalRouteRef, RouteRef | SubRouteRef | undefined>,
     appBasePath: string,
   ) {
     this.routeBindings = routeBindings;
@@ -144,6 +147,7 @@ export class RouteResolutionApiProxy implements RouteResolutionApi {
   initialize(
     routeInfo: RouteInfo,
     routeRefsById: Map<string, RouteRef | SubRouteRef>,
+    validation?: { tree: AppTree; refs: Iterable<RouteRef | SubRouteRef> },
   ) {
     this.#delegate = new RouteResolver(
       routeInfo.routePaths,
@@ -154,6 +158,9 @@ export class RouteResolutionApiProxy implements RouteResolutionApi {
       routeInfo.routeAliasResolver,
       routeRefsById,
     );
+    if (validation) {
+      this.#delegate.validate(validation.tree, validation.refs);
+    }
     this.#routeObjects = routeInfo.routeObjects;
 
     return routeInfo;
@@ -204,7 +211,7 @@ export function createPhaseApis(options: {
   fallbackApis?: ApiHolder;
   includeConfigApi: boolean;
   appBasePath: string;
-  routeBindings: Map<ExternalRouteRef, RouteRef | SubRouteRef>;
+  routeBindings: Map<ExternalRouteRef, RouteRef | SubRouteRef | undefined>;
   staticFactories: AnyApiFactory[];
 }) {
   const appTreeApi = new AppTreeApiProxy(options.tree, options.appBasePath);
@@ -274,6 +281,14 @@ export function instantiateAndInitializePhaseTree(options: {
   options.routeResolutionApi.initialize(
     routeInfo,
     options.routeRefsById.routes,
+    options.stopAtAttachment
+      ? undefined
+      : {
+          tree: options.tree,
+          refs:
+            options.routeRefsById.allRoutes ??
+            options.routeRefsById.routes.values(),
+        },
   );
   options.appTreeApi.initialize(routeInfo);
 }

--- a/packages/frontend-app-api/src/wiring/phaseApis.tsx
+++ b/packages/frontend-app-api/src/wiring/phaseApis.tsx
@@ -147,7 +147,7 @@ export class RouteResolutionApiProxy implements RouteResolutionApi {
   initialize(
     routeInfo: RouteInfo,
     routeRefsById: Map<string, RouteRef | SubRouteRef>,
-    validation?: { tree: AppTree; refs: Iterable<RouteRef | SubRouteRef> },
+    validation?: { tree: AppTree; refs?: Iterable<RouteRef | SubRouteRef> },
   ) {
     this.#delegate = new RouteResolver(
       routeInfo.routePaths,
@@ -157,8 +157,9 @@ export class RouteResolutionApiProxy implements RouteResolutionApi {
       this.appBasePath,
       routeInfo.routeAliasResolver,
       routeRefsById,
+      validation?.tree.nodes.keys(),
     );
-    if (validation) {
+    if (validation?.refs) {
       this.#delegate.validate(validation.tree, validation.refs);
     }
     this.#routeObjects = routeInfo.routeObjects;
@@ -281,14 +282,13 @@ export function instantiateAndInitializePhaseTree(options: {
   options.routeResolutionApi.initialize(
     routeInfo,
     options.routeRefsById.routes,
-    options.stopAtAttachment
-      ? undefined
-      : {
-          tree: options.tree,
-          refs:
-            options.routeRefsById.allRoutes ??
-            options.routeRefsById.routes.values(),
-        },
+    {
+      tree: options.tree,
+      refs: options.stopAtAttachment
+        ? undefined
+        : options.routeRefsById.allRoutes ??
+          options.routeRefsById.routes.values(),
+    },
   );
   options.appTreeApi.initialize(routeInfo);
 }

--- a/packages/frontend-internal/src/routing/OpaqueExternalRouteRef.ts
+++ b/packages/frontend-internal/src/routing/OpaqueExternalRouteRef.ts
@@ -22,6 +22,7 @@ export const OpaqueExternalRouteRef = OpaqueType.create<{
   versions: {
     readonly version: 'v1';
 
+    getId?(): string | undefined;
     getParams(): string[];
     getDescription(): string;
     getDefaultTarget(): string | undefined;

--- a/packages/frontend-internal/src/routing/OpaqueRouteRef.ts
+++ b/packages/frontend-internal/src/routing/OpaqueRouteRef.ts
@@ -22,6 +22,7 @@ export const OpaqueRouteRef = OpaqueType.create<{
   versions: {
     readonly version: 'v1';
 
+    getExtensionId?(): string;
     getParams(): string[];
     getDescription(): string;
 

--- a/packages/frontend-plugin-api/report.api.md
+++ b/packages/frontend-plugin-api/report.api.md
@@ -790,6 +790,7 @@ export interface CreateFrontendModuleOptions<
   if?: FilterPredicate;
   // (undocumented)
   pluginId: TPluginId;
+  routes?: Record<string, RouteRef | SubRouteRef>;
 }
 
 // @public
@@ -845,9 +846,9 @@ export interface CreateFrontendPluginOptions<
 }
 
 // @public
-export function createRouteRef<TParamKey extends string = never>(config?: {
+export function createRouteRef<TParamKey extends string = never>(config: {
   readonly params?: TParamKey[];
-  aliasFor?: string;
+  readonly extensionId: string;
 }): RouteRef<
   [TParamKey] extends [never]
     ? undefined

--- a/packages/frontend-plugin-api/src/blueprints/PageBlueprint.test.tsx
+++ b/packages/frontend-plugin-api/src/blueprints/PageBlueprint.test.tsx
@@ -27,6 +27,7 @@ import {
 import { waitFor } from '@testing-library/react';
 
 describe('PageBlueprint', () => {
+  // @ts-expect-error Historical refs intentionally omit extensionId
   const mockRouteRef = createRouteRef();
 
   it('should return an extension when calling make with sensible defaults', () => {

--- a/packages/frontend-plugin-api/src/blueprints/PageBlueprint.tsx
+++ b/packages/frontend-plugin-api/src/blueprints/PageBlueprint.tsx
@@ -80,6 +80,7 @@ export const PageBlueprint = createExtensionBlueprint({
       title?: string;
       icon?: IconElement;
       loader?: () => Promise<JSX.Element>;
+      /** @deprecated Set extensionId when creating the route reference instead. */
       routeRef?: RouteRef;
       /**
        * Hide the default plugin page header, making the page fill up all available space.

--- a/packages/frontend-plugin-api/src/blueprints/SubPageBlueprint.tsx
+++ b/packages/frontend-plugin-api/src/blueprints/SubPageBlueprint.tsx
@@ -27,7 +27,7 @@ import { optionalStringSchema } from '../schema/optionalStringSchema';
  * @public
  * @example
  * ```tsx
- * const overviewRouteRef = createRouteRef();
+ * const overviewRouteRef = createRouteRef({ extensionId: 'sub-page:my-plugin/overview' });
  *
  * const mySubPage = SubPageBlueprint.make({
  *   attachTo: { id: 'page:my-plugin', input: 'pages' },
@@ -35,7 +35,6 @@ import { optionalStringSchema } from '../schema/optionalStringSchema';
  *   params: {
  *     path: 'overview',
  *     title: 'Overview',
- *     routeRef: overviewRouteRef,
  *     loader: () => import('./components/Overview').then(m => <m.Overview />),
  *   },
  * });
@@ -77,7 +76,7 @@ export const SubPageBlueprint = createExtensionBlueprint({
        */
       loader: () => Promise<JSX.Element>;
       /**
-       * Optional route reference for this sub-page.
+       * @deprecated Set extensionId when creating the route reference instead.
        */
       routeRef?: RouteRef;
     },

--- a/packages/frontend-plugin-api/src/components/ExtensionBoundary.test.tsx
+++ b/packages/frontend-plugin-api/src/components/ExtensionBoundary.test.tsx
@@ -33,6 +33,7 @@ import {
 import { useAppNode } from '@backstage/frontend-plugin-api';
 
 const wrapInBoundaryExtension = (element?: JSX.Element) => {
+  // @ts-expect-error Historical refs intentionally omit extensionId
   const routeRef = createRouteRef();
   return createExtension({
     name: 'test',

--- a/packages/frontend-plugin-api/src/routing/ExternalRouteRef.ts
+++ b/packages/frontend-plugin-api/src/routing/ExternalRouteRef.ts
@@ -100,6 +100,9 @@ export function createExternalRouteRef<
 
   return OpaqueExternalRouteRef.createInstance('v1', {
     T: undefined as unknown as TParams,
+    getId() {
+      return id;
+    },
     getParams() {
       return params;
     },

--- a/packages/frontend-plugin-api/src/routing/RouteRef.test.ts
+++ b/packages/frontend-plugin-api/src/routing/RouteRef.test.ts
@@ -20,10 +20,12 @@ import { OpaqueRouteRef } from '@internal/frontend';
 
 describe('RouteRef', () => {
   it('should be created and have a mutable ID', () => {
+    // @ts-expect-error Historical refs intentionally omit extensionId
     const routeRef: RouteRef<undefined> = createRouteRef();
     const internal = OpaqueRouteRef.toInternal(routeRef);
     expect(internal.T).toBe(undefined);
     expect(internal.getParams()).toEqual([]);
+    expect(internal.getExtensionId).toBeUndefined();
     expect(internal.getDescription()).toMatch(/RouteRef\.test\.ts/);
 
     expect(String(internal)).toMatch(
@@ -49,12 +51,12 @@ describe('RouteRef', () => {
     const routeRef: RouteRef<{
       x: string;
       y: string;
-    }> = createRouteRef({
-      params: ['x', 'y'],
-    });
+    }> = createRouteRef({ extensionId: 'page:test', params: ['x', 'y'] });
     const internal = OpaqueRouteRef.toInternal(routeRef);
     expect(internal.getParams()).toEqual(['x', 'y']);
-    expect(internal.getDescription()).toMatch(/RouteRef\.test\.ts/);
+    expect(internal.getExtensionId?.()).toBe('page:test');
+    expect(internal.version).toBe('v1');
+    expect(internal.getDescription()).toBe('page:test');
   });
 
   it('should properly infer and validate parameter types and assignments', () => {
@@ -63,14 +65,14 @@ describe('RouteRef', () => {
       _params: T extends undefined ? undefined : T,
     ) {}
 
-    const _1 = createRouteRef({ params: ['x'] });
+    const _1 = createRouteRef({ extensionId: 'page:test', params: ['x'] });
     checkRouteRef(_1, { x: '' });
     // @ts-expect-error
     checkRouteRef(_1, { y: '' });
     // @ts-expect-error
     checkRouteRef(_1, undefined);
 
-    const _2 = createRouteRef({ params: ['x', 'y'] });
+    const _2 = createRouteRef({ extensionId: 'page:test', params: ['x', 'y'] });
     checkRouteRef(_2, { x: '', y: '' });
     // @ts-expect-error
     checkRouteRef(_2, { x: '' });
@@ -81,12 +83,12 @@ describe('RouteRef', () => {
     // @ts-expect-error
     checkRouteRef(_2, { x: '', y: '', z: '' });
 
-    const _3 = createRouteRef({ params: [] });
+    const _3 = createRouteRef({ extensionId: 'page:test', params: [] });
     checkRouteRef(_3, undefined);
     // @ts-expect-error
     checkRouteRef(_3, { x: '' });
 
-    const _4 = createRouteRef();
+    const _4 = createRouteRef({ extensionId: 'page:test' });
     checkRouteRef(_4, undefined);
     // @ts-expect-error
     checkRouteRef(_4, { x: '' });

--- a/packages/frontend-plugin-api/src/routing/RouteRef.ts
+++ b/packages/frontend-plugin-api/src/routing/RouteRef.ts
@@ -44,31 +44,47 @@ export function createRouteRef<
   // ParamKey is narrowed to the literal union of param name strings.
   // Defaulting to never means we get undefined params when the array is empty or omitted.
   TParamKey extends string = never,
->(config?: {
+>(config: {
   /** A list of parameter names that the path that this route ref is bound to must contain */
   readonly params?: TParamKey[];
 
-  aliasFor?: string;
+  /** The ID of the routable extension that this reference resolves through. */
+  readonly extensionId: string;
 }): RouteRef<
   [TParamKey] extends [never] ? undefined : { [param in TParamKey]: string }
 > {
   const params = (config?.params ?? []) as string[];
+  const extensionId = config?.extensionId;
+  if (
+    extensionId !== undefined &&
+    (typeof extensionId !== 'string' || !extensionId)
+  ) {
+    throw new Error('RouteRef extensionId must be a non-empty string');
+  }
   const creationSite = describeParentCallSite();
 
   let id: string | undefined = undefined;
 
   return OpaqueRouteRef.createInstance('v1', {
     T: undefined as any,
+    ...(extensionId === undefined ? {} : { getExtensionId: () => extensionId }),
     getParams() {
       return params;
     },
     getDescription() {
+      if (extensionId) {
+        return extensionId;
+      }
       if (id) {
         return id;
       }
       return `created at '${creationSite}'`;
     },
-    alias: config?.aliasFor,
+    // Older compiled callers may still supply aliases.
+    alias:
+      extensionId === undefined
+        ? (config as { aliasFor?: string } | undefined)?.aliasFor
+        : undefined,
     setId(newId: string) {
       if (!newId) {
         throw new Error(`RouteRef id must be a non-empty string`);

--- a/packages/frontend-plugin-api/src/routing/SubRouteRef.test.ts
+++ b/packages/frontend-plugin-api/src/routing/SubRouteRef.test.ts
@@ -19,11 +19,14 @@ import { SubRouteRef, createSubRouteRef } from './SubRouteRef';
 import { createRouteRef } from './RouteRef';
 import { OpaqueRouteRef, OpaqueSubRouteRef } from '@internal/frontend';
 
+// @ts-expect-error Historical refs intentionally omit extensionId
 const parent = createRouteRef();
+// @ts-expect-error Historical refs intentionally omit extensionId
 const parentX = createRouteRef({ params: ['x'] });
 
 describe('SubRouteRef', () => {
   it('should be created', () => {
+    // @ts-expect-error Historical refs intentionally omit extensionId
     const internalParent = OpaqueRouteRef.toInternal(createRouteRef());
     const routeRef: SubRouteRef = createSubRouteRef({
       parent: internalParent,

--- a/packages/frontend-plugin-api/src/routing/useRouteRef.test.tsx
+++ b/packages/frontend-plugin-api/src/routing/useRouteRef.test.tsx
@@ -33,6 +33,7 @@ describe('v1 consumer', () => {
   });
 
   it('should infer all nested sub-route parameters', () => {
+    // @ts-expect-error Historical refs intentionally omit extensionId
     const rootRouteRef = createRouteRef();
     const revisionRouteRef = createSubRouteRef({
       parent: rootRouteRef,
@@ -59,6 +60,7 @@ describe('v1 consumer', () => {
   it('should resolve routes', () => {
     const resolve = jest.fn(() => () => '/hello');
 
+    // @ts-expect-error Historical refs intentionally omit extensionId
     const routeRef = createRouteRef();
 
     const renderedHook = renderHook(() => useRouteRef(routeRef), {
@@ -80,6 +82,7 @@ describe('v1 consumer', () => {
   });
 
   it('should ignore missing routes', () => {
+    // @ts-expect-error Historical refs intentionally omit extensionId
     const routeRef = createRouteRef();
 
     const renderedHook = renderHook(() => useRouteRef(routeRef), {
@@ -99,6 +102,7 @@ describe('v1 consumer', () => {
   it('re-resolves the routeFunc when the search parameters change', () => {
     const resolve = jest.fn(() => () => '/hello');
 
+    // @ts-expect-error Historical refs intentionally omit extensionId
     const routeRef = createRouteRef();
     const history = createBrowserHistory();
     history.push('/my-page');
@@ -127,6 +131,7 @@ describe('v1 consumer', () => {
     const resolve = jest.fn(() => () => '/hello');
     const api = { resolve };
 
+    // @ts-expect-error Historical refs intentionally omit extensionId
     const routeRef = createRouteRef();
     const history = createBrowserHistory();
     history.push('/my-page');
@@ -155,6 +160,7 @@ describe('v1 consumer', () => {
     const resolve = jest.fn(() => () => '/hello');
     const api = { resolve };
 
+    // @ts-expect-error Historical refs intentionally omit extensionId
     const routeRef = createRouteRef();
     const history = createBrowserHistory();
     history.push('/my-page');
@@ -183,6 +189,7 @@ describe('v1 consumer', () => {
     const resolve = jest.fn(() => () => '/hello');
     const api = { resolve };
 
+    // @ts-expect-error Historical refs intentionally omit extensionId
     const routeRef = createRouteRef();
     const history = createBrowserHistory();
     history.push('/my-page');

--- a/packages/frontend-plugin-api/src/routing/useRouteRefParams.test.tsx
+++ b/packages/frontend-plugin-api/src/routing/useRouteRefParams.test.tsx
@@ -21,6 +21,7 @@ import { createRouteRef } from './RouteRef';
 
 describe('useRouteRefParams', () => {
   it('should provide types params', () => {
+    // @ts-expect-error Historical refs intentionally omit extensionId
     const routeRef = createRouteRef({
       params: ['a', 'b'],
     });

--- a/packages/frontend-plugin-api/src/routing/validateRouteNamespace.ts
+++ b/packages/frontend-plugin-api/src/routing/validateRouteNamespace.ts
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2026 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { OpaqueRouteRef, OpaqueSubRouteRef } from '@internal/frontend';
+import { RouteRef } from './RouteRef';
+import { SubRouteRef } from './SubRouteRef';
+
+export function validateRouteNamespace(
+  pluginId: string,
+  routes: Record<string, RouteRef | SubRouteRef>,
+) {
+  for (const [name, ref] of Object.entries(routes)) {
+    const root = OpaqueSubRouteRef.isType(ref)
+      ? OpaqueSubRouteRef.toInternal(ref).getParent()
+      : ref;
+    const extensionId = OpaqueRouteRef.toInternal(root).getExtensionId?.();
+    if (
+      extensionId !== undefined &&
+      extensionId.replace(/^[^/:]+:/, '').split('/')[0] !== pluginId
+    ) {
+      throw new Error(
+        `Route '${pluginId}.${name}' targets extension '${extensionId}' outside the '${pluginId}' plugin namespace`,
+      );
+    }
+  }
+}

--- a/packages/frontend-plugin-api/src/wiring/createFrontendModule.test.ts
+++ b/packages/frontend-plugin-api/src/wiring/createFrontendModule.test.ts
@@ -56,6 +56,7 @@ describe('createFrontendModule', () => {
         "featureFlags": [],
         "if": undefined,
         "pluginId": "test",
+        "routes": {},
         "toString": [Function],
         "version": "v1",
       }

--- a/packages/frontend-plugin-api/src/wiring/createFrontendModule.ts
+++ b/packages/frontend-plugin-api/src/wiring/createFrontendModule.ts
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+import { RouteRef, SubRouteRef } from '../routing';
+import { validateRouteNamespace } from '../routing/validateRouteNamespace';
 import { ExtensionDefinition } from './createExtension';
 import {
   Extension,
@@ -29,6 +31,8 @@ export interface CreateFrontendModuleOptions<
 > {
   pluginId: TPluginId;
   extensions?: TExtensions;
+  /** Named routes to add or override in the owning plugin. Later modules take precedence. */
+  routes?: Record<string, RouteRef | SubRouteRef>;
   featureFlags?: FeatureFlagConfig[];
   if?: FilterPredicate;
 }
@@ -42,6 +46,7 @@ export interface FrontendModule {
 /** @internal */
 export interface InternalFrontendModule extends FrontendModule {
   readonly version: 'v1';
+  readonly routes?: Record<string, RouteRef | SubRouteRef>;
   readonly extensions: Extension<unknown>[];
   readonly featureFlags: FeatureFlagConfig[];
   readonly if?: FilterPredicate;
@@ -91,6 +96,7 @@ export function createFrontendModule<
   TExtensions extends readonly ExtensionDefinition[],
 >(options: CreateFrontendModuleOptions<TId, TExtensions>): FrontendModule {
   const { pluginId } = options;
+  validateRouteNamespace(pluginId, options.routes ?? {});
 
   const { extensions } = resolveExtensionDefinitions(options.extensions ?? [], {
     namespace: pluginId,
@@ -104,6 +110,7 @@ export function createFrontendModule<
     featureFlags: options.featureFlags ?? [],
     if: options.if,
     extensions,
+    routes: options.routes ?? {},
     toString() {
       return `Module{pluginId=${pluginId}}`;
     },

--- a/packages/frontend-plugin-api/src/wiring/createFrontendPlugin.ts
+++ b/packages/frontend-plugin-api/src/wiring/createFrontendPlugin.ts
@@ -14,7 +14,10 @@
  * limitations under the License.
  */
 
-import { OpaqueFrontendPlugin } from '@internal/frontend';
+import {
+  OpaqueFrontendPlugin,
+  OpaqueExternalRouteRef,
+} from '@internal/frontend';
 import {
   ExtensionDefinition,
   OverridableExtensionDefinition,
@@ -29,6 +32,7 @@ import { MakeSortedExtensionsMap } from './MakeSortedExtensionsMap';
 import { JsonObject } from '@backstage/types';
 import { IconElement } from '../icons/types';
 import { RouteRef, SubRouteRef, ExternalRouteRef } from '../routing';
+import { validateRouteNamespace } from '../routing/validateRouteNamespace';
 import { ID_PATTERN } from './constants';
 import { FilterPredicate } from '@backstage/filter-predicates';
 
@@ -267,6 +271,10 @@ export function createFrontendPlugin<
   MakeSortedExtensionsMap<TExtensions[number], TId>
 > {
   const pluginId = options.pluginId;
+  validateRouteNamespace(pluginId, options.routes ?? {});
+  for (const [name, ref] of Object.entries(options.externalRoutes ?? {})) {
+    OpaqueExternalRouteRef.toInternal(ref).setId(`${pluginId}.${name}`);
+  }
 
   if (!ID_PATTERN.test(pluginId)) {
     // eslint-disable-next-line no-console

--- a/packages/frontend-test-utils/src/app/renderInTestApp.test.tsx
+++ b/packages/frontend-test-utils/src/app/renderInTestApp.test.tsx
@@ -117,6 +117,7 @@ describe('renderInTestApp', () => {
   });
 
   it('should allow mounting route refs', () => {
+    // @ts-expect-error Historical refs intentionally omit extensionId
     const testRouteRef = createRouteRef({
       params: ['name'],
     });

--- a/packages/frontend-test-utils/src/app/renderInTestApp.tsx
+++ b/packages/frontend-test-utils/src/app/renderInTestApp.tsx
@@ -42,7 +42,7 @@ import type { CreateSpecializedAppInternalOptions } from '../../../frontend-app-
 // eslint-disable-next-line @backstage/no-relative-monorepo-imports
 import { getBasePath } from '../../../frontend-app-api/src/routing/getBasePath';
 import { TestApiPairs } from '../apis/TestApiProvider';
-import { OpaqueExternalRouteRef } from '@internal/frontend';
+import { OpaqueExternalRouteRef, OpaqueRouteRef } from '@internal/frontend';
 
 const DEFAULT_MOCK_CONFIG = {
   app: { baseUrl: 'http://localhost:3000' },
@@ -180,16 +180,30 @@ export function renderInTestApp<const TApiPairs extends any[] = any[]>(
 
       if (OpaqueExternalRouteRef.isType(optionRef)) {
         // Create an actual route ref for the external route, then bind the external ref to it
-        routeRef = createRouteRef();
+        routeRef = createRouteRef({
+          extensionId: `test-route:test/${encodeURIComponent(path)}`,
+          params: OpaqueExternalRouteRef.toInternal(optionRef).getParams(),
+        });
         externalBindings.set(optionRef, routeRef);
       } else {
         routeRef = optionRef;
       }
 
+      const extensionId =
+        OpaqueRouteRef.toInternal(routeRef).getExtensionId?.();
+      const kind = extensionId?.match(/^([^/:]+):/)?.[1];
+      const scopedName = extensionId?.replace(/^[^/:]+:/, '');
+      const [namespace, ...name] = scopedName?.split('/') ?? [];
+
       extensions.push(
         createExtension({
           kind: 'test-route',
           name: path,
+          ...(extensionId && {
+            kind,
+            namespace,
+            name: name.join('/') || undefined,
+          }),
           attachTo: { id: 'app/root', input: 'elements' },
           output: [
             coreExtensionData.reactElement,

--- a/packages/frontend-test-utils/src/app/renderTestApp.tsx
+++ b/packages/frontend-test-utils/src/app/renderTestApp.tsx
@@ -42,7 +42,7 @@ import type { CreateSpecializedAppInternalOptions } from '../../../frontend-app-
 // eslint-disable-next-line @backstage/no-relative-monorepo-imports
 import { getBasePath } from '../../../frontend-app-api/src/routing/getBasePath';
 import { TestApiPairs } from '../apis/TestApiProvider';
-import { OpaqueExternalRouteRef } from '@internal/frontend';
+import { OpaqueExternalRouteRef, OpaqueRouteRef } from '@internal/frontend';
 
 const DEFAULT_MOCK_CONFIG = {
   app: { baseUrl: 'http://localhost:3000' },
@@ -135,16 +135,30 @@ export function renderTestApp<const TApiPairs extends any[] = any[]>(
 
       if (OpaqueExternalRouteRef.isType(optionRef)) {
         // Create an actual route ref for the external route, then bind the external ref to it
-        routeRef = createRouteRef();
+        routeRef = createRouteRef({
+          extensionId: `test-route:test/${encodeURIComponent(path)}`,
+          params: OpaqueExternalRouteRef.toInternal(optionRef).getParams(),
+        });
         externalBindings.set(optionRef, routeRef);
       } else {
         routeRef = optionRef;
       }
 
+      const extensionId =
+        OpaqueRouteRef.toInternal(routeRef).getExtensionId?.();
+      const kind = extensionId?.match(/^([^/:]+):/)?.[1];
+      const scopedName = extensionId?.replace(/^[^/:]+:/, '');
+      const [namespace, ...name] = scopedName?.split('/') ?? [];
+
       extensions.push(
         createExtension({
           kind: 'test-route',
           name: path,
+          ...(extensionId && {
+            kind,
+            namespace,
+            name: name.join('/') || undefined,
+          }),
           attachTo: { id: 'app/routes', input: 'routes' },
           output: [
             coreExtensionData.reactElement,

--- a/plugins/app-react/src/blueprints/NavContentBlueprint.test.tsx
+++ b/plugins/app-react/src/blueprints/NavContentBlueprint.test.tsx
@@ -31,6 +31,7 @@ import {
 import { withLogCollector } from '@backstage/test-utils';
 import { render, screen } from '@testing-library/react';
 
+// @ts-expect-error Historical refs intentionally omit extensionId
 const routeRef = createRouteRef();
 
 function mockNode(id: string): AppNode {

--- a/plugins/app-visualizer/report.api.md
+++ b/plugins/app-visualizer/report.api.md
@@ -15,7 +15,9 @@ import { RouteRef } from '@backstage/frontend-plugin-api';
 
 // @public (undocumented)
 const visualizerPlugin: OverridableFrontendPlugin<
-  {},
+  {
+    root: RouteRef<undefined>;
+  },
   {},
   {
     'page:app-visualizer': OverridableExtensionDefinition<{

--- a/plugins/app-visualizer/src/plugin.tsx
+++ b/plugins/app-visualizer/src/plugin.tsx
@@ -23,26 +23,22 @@ import {
 } from '@backstage/frontend-plugin-api';
 import { RiEyeLine } from '@remixicon/react';
 
-const rootRouteRef = createRouteRef();
+const rootRouteRef = createRouteRef({ extensionId: 'page:app-visualizer' });
 
 const appVisualizerPage = PageBlueprint.make({
   params: {
     path: '/visualizer',
-    routeRef: rootRouteRef,
+
     title: 'Visualizer',
     icon: <RiEyeLine />,
   },
 });
 
-const treeRouteRef = createRouteRef();
-const detailedRouteRef = createRouteRef();
-const textRouteRef = createRouteRef();
-
 const appVisualizerTreePage = SubPageBlueprint.make({
   name: 'tree',
   params: {
     path: 'tree',
-    routeRef: treeRouteRef,
+
     title: 'Tree',
     loader: () =>
       import('./components/AppVisualizerPage/TreeVisualizer').then(m => (
@@ -54,7 +50,7 @@ const appVisualizerDetailedPage = SubPageBlueprint.make({
   name: 'details',
   params: {
     path: 'details',
-    routeRef: detailedRouteRef,
+
     title: 'Detailed',
     loader: () =>
       import('./components/AppVisualizerPage/DetailedVisualizer').then(m => (
@@ -66,7 +62,7 @@ const appVisualizerTextPage = SubPageBlueprint.make({
   name: 'text',
   params: {
     path: 'text',
-    routeRef: textRouteRef,
+
     title: 'Text',
     loader: () =>
       import('./components/AppVisualizerPage/TextVisualizer').then(m => (
@@ -85,6 +81,7 @@ const copyTreeAsJson = PluginHeaderActionBlueprint.make({
 /** @public */
 export const visualizerPlugin = createFrontendPlugin({
   pluginId: 'app-visualizer',
+  routes: { root: rootRouteRef },
   title: 'App Visualizer',
   icon: <RiEyeLine />,
   info: { packageJson: () => import('../package.json') },

--- a/plugins/app/src/extensions/AppNav.test.tsx
+++ b/plugins/app/src/extensions/AppNav.test.tsx
@@ -28,6 +28,7 @@ const DEFAULT_CONFIG = {
   backend: { baseUrl: 'http://localhost:7007' },
 };
 
+// @ts-expect-error Historical refs intentionally omit extensionId
 const mockRouteRef = createRouteRef();
 
 const mockPage = PageBlueprint.make({

--- a/plugins/auth/src/plugin.tsx
+++ b/plugins/auth/src/plugin.tsx
@@ -22,7 +22,6 @@ import { rootRouteRef } from './routes';
 export const AuthPage = PageBlueprint.make({
   params: {
     path: '/oauth2',
-    routeRef: rootRouteRef,
     loader: () => import('./components/Router').then(m => <m.Router />),
   },
 });

--- a/plugins/auth/src/routes.ts
+++ b/plugins/auth/src/routes.ts
@@ -15,4 +15,4 @@
  */
 import { createRouteRef } from '@backstage/frontend-plugin-api';
 
-export const rootRouteRef = createRouteRef();
+export const rootRouteRef = createRouteRef({ extensionId: 'page:auth' });

--- a/plugins/catalog-react/src/alpha/blueprints/EntityContentBlueprint.test.tsx
+++ b/plugins/catalog-react/src/alpha/blueprints/EntityContentBlueprint.test.tsx
@@ -115,6 +115,7 @@ describe('EntityContentBlueprint', () => {
   });
 
   it('should emit the correct defaults', () => {
+    // @ts-expect-error Historical refs intentionally omit extensionId
     const mockRouteRef = createRouteRef();
     const extension = EntityContentBlueprint.make({
       name: 'test',

--- a/plugins/catalog/src/routes.test.tsx
+++ b/plugins/catalog/src/routes.test.tsx
@@ -1,0 +1,117 @@
+/*
+ * Copyright 2026 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { screen } from '@testing-library/react';
+import { Route } from 'react-router-dom';
+import { FlatRoutes } from '@backstage/core-app-api';
+import { getComponentData } from '@backstage/core-plugin-api';
+import { convertLegacyPageExtension } from '@backstage/core-compat-api';
+import {
+  createFrontendPlugin,
+  createRouteRef,
+  PageBlueprint,
+  useRouteRef,
+} from '@backstage/frontend-plugin-api';
+import { renderTestApp } from '@backstage/frontend-test-utils';
+// eslint-disable-next-line @backstage/no-relative-monorepo-imports
+import { RouteResolver as LegacyRouteResolver } from '../../../packages/core-app-api/src/routing/RouteResolver';
+// eslint-disable-next-line @backstage/no-relative-monorepo-imports
+import { collectLegacyRoutes } from '../../../packages/core-compat-api/src/collectLegacyRoutes';
+import { CatalogIndexPage, catalogPlugin } from './plugin';
+import { rootRouteRef } from './routes';
+
+function Probe() {
+  const shared = useRouteRef(rootRouteRef);
+  const copy = useRouteRef(createRouteRef({ extensionId: 'page:catalog' }));
+  return (
+    <div>
+      Shared: {shared?.()} Copy: {copy?.()}
+    </div>
+  );
+}
+
+const probe = PageBlueprint.make({
+  name: 'probe',
+  params: { path: '/probe', loader: async () => <Probe /> },
+});
+
+it('preserves the legacy Catalog mount and resolves a native replacement without registration', async () => {
+  expect(catalogPlugin.routes.catalogIndex).toBe(rootRouteRef);
+  expect(getComponentData(<CatalogIndexPage />, 'core.mountPoint')).toBe(
+    rootRouteRef,
+  );
+  const legacy = new LegacyRouteResolver(
+    new Map([[rootRouteRef, '/old-catalog']]),
+    new Map(),
+    [],
+    new Map(),
+    '',
+  );
+  expect(legacy.resolve(rootRouteRef, '/')?.()).toBe('/old-catalog');
+  renderTestApp({
+    initialRouteEntries: ['/probe'],
+    extensions: [probe],
+    features: [
+      createFrontendPlugin({
+        pluginId: 'catalog',
+        routes: { catalogIndex: rootRouteRef },
+        extensions: [
+          PageBlueprint.make({
+            params: { path: '/custom-catalog', loader: async () => <div /> },
+          }),
+        ],
+      }),
+    ],
+  });
+  expect(
+    await screen.findByText('Shared: /custom-catalog Copy: /custom-catalog'),
+  ).toBeInTheDocument();
+});
+
+it.each(['named wrapper', 'flat routes'])(
+  'resolves Catalog through hybrid conversion: %s',
+  async mode => {
+    const features =
+      mode === 'named wrapper'
+        ? [
+            createFrontendPlugin({
+              pluginId: 'catalog',
+              routes: { catalogIndex: rootRouteRef },
+              extensions: [
+                convertLegacyPageExtension(CatalogIndexPage, {
+                  name: 'renamed',
+                  path: '/converted-catalog',
+                }),
+              ],
+            }),
+          ]
+        : collectLegacyRoutes(
+            <FlatRoutes>
+              <Route path="/converted-catalog" element={<CatalogIndexPage />} />
+            </FlatRoutes>,
+          );
+    renderTestApp({
+      initialRouteEntries: ['/probe'],
+      extensions: [probe],
+      features,
+    });
+    expect(
+      await screen.findByText(
+        'Shared: /converted-catalog Copy: /converted-catalog',
+      ),
+    ).toBeInTheDocument();
+  },
+);

--- a/plugins/catalog/src/routes.ts
+++ b/plugins/catalog/src/routes.ts
@@ -14,10 +14,9 @@
  * limitations under the License.
  */
 
-import {
-  createExternalRouteRef,
-  createRouteRef,
-} from '@backstage/core-plugin-api';
+import { createExternalRouteRef } from '@backstage/core-plugin-api';
+import { createRouteRef } from '@backstage/frontend-plugin-api';
+import { convertLegacyRouteRef } from '@backstage/core-compat-api';
 
 export const createComponentRouteRef = createExternalRouteRef({
   id: 'create-component',
@@ -44,6 +43,6 @@ export const unregisterRedirectRouteRef = createExternalRouteRef({
   optional: true,
 });
 
-export const rootRouteRef = createRouteRef({
-  id: 'catalog',
-});
+export const rootRouteRef = convertLegacyRouteRef(
+  createRouteRef({ extensionId: 'page:catalog' }),
+);

--- a/plugins/home/src/alpha.tsx
+++ b/plugins/home/src/alpha.tsx
@@ -51,7 +51,7 @@ import {
   type HomePageLayoutProps,
 } from '@backstage/plugin-home-react/alpha';
 
-const rootRouteRef = createRouteRef();
+const rootRouteRef = createRouteRef({ extensionId: 'page:home' });
 
 const VisitListener = reactLazy(() =>
   import('./components/VisitListener').then(m => ({
@@ -86,7 +86,7 @@ const homePage = PageBlueprint.makeWithOverrides({
     return originalFactory({
       path: '/home',
       noHeader: true,
-      routeRef: rootRouteRef,
+
       title: 'Home',
       icon: <HomeIcon fontSize="inherit" />,
       loader: async () => {


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

This changes new frontend route refs to target routable extension IDs. `createRouteRef` now requires `extensionId` in TypeScript; the v1 runtime still accepts historical refs, aliases, and converted legacy mount points.

Modules can override named routes with the same precedence as extensions. Named bindings follow those overrides while existing structural refs retain their targets. Deprecated emitted mounts remain a fallback when the target extension is absent, preserving hybrid wrappers. The Catalog index now uses a structural ref while retaining its legacy registration. This also updates the native examples, plugin template, migration docs, and compatibility bridge.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))


