### PR TITLE
fix(api-docs): remove duplicate zod import

### DIFF
--- a/plugins/api-docs/src/alpha.tsx
+++ b/plugins/api-docs/src/alpha.tsx
@@ -33,7 +33,6 @@ import { defaultDefinitionWidgets } from './components/ApiDefinitionCard';
 import { rootRoute, registerComponentRouteRef } from './routes';
 import { apiDocsConfigRef } from './config';
 import { AppIcon } from '@backstage/core-components';
-import { z } from 'zod';
 
 import {
   EntityCardBlueprint,


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Removes the stale `zod` import left behind by #34738. The file already imports `z` from `zod/v4`, so the additional import redeclared the binding and caused package lint to fail.

The existing changeset from #34738 already covers this unreleased change.

#### :heavy_check_mark: Checklist

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))

Generated with [Codex](https://openai.com/codex/).
