### PR TITLE
fix(integration): url-encode the branch ref in Bitbucket Server fetch URLs 

### DIFF
--- a/.changeset/bitbucket-server-branch-ref-encoding.md
+++ b/.changeset/bitbucket-server-branch-ref-encoding.md
@@ -1,0 +1,5 @@
+---
+'@backstage/integration': patch
+---
+
+Fixed an issue where reading or downloading files from Bitbucket Server could fail when the branch name contained special characters such as an ampersand or a plus sign. The branch name is now correctly encoded in the request URL.

--- a/packages/integration/src/bitbucketServer/core.test.ts
+++ b/packages/integration/src/bitbucketServer/core.test.ts
@@ -120,7 +120,7 @@ describe('bitbucketServer core', () => {
       ).toEqual(`${apiBase}/c.yaml?at=foo%2Bbar`);
       expect(
         getBitbucketServerFileFetchUrl(`${base}/c.yaml?at=my%20branch`, config),
-      ).toEqual(`${apiBase}/c.yaml?at=my%20branch`);
+      ).toEqual(`${apiBase}/c.yaml?at=my+branch`);
       // A slash-bearing ref is normalized rather than double-encoded.
       expect(
         getBitbucketServerFileFetchUrl(
@@ -227,6 +227,11 @@ describe('bitbucketServer core', () => {
         getBitbucketServerDownloadUrl(`${base}?at=foo%2Bbar`, config),
       ).resolves.toEqual(
         `${apiBase}?format=tgz&at=foo%2Bbar&prefix=backstage-mock&path=docs`,
+      );
+      await expect(
+        getBitbucketServerDownloadUrl(`${base}?at=my%20branch`, config),
+      ).resolves.toEqual(
+        `${apiBase}?format=tgz&at=my+branch&prefix=backstage-mock&path=docs`,
       );
       await expect(
         getBitbucketServerDownloadUrl(`${base}?at=release%2Fv1`, config),

--- a/packages/integration/src/bitbucketServer/core.test.ts
+++ b/packages/integration/src/bitbucketServer/core.test.ts
@@ -100,6 +100,35 @@ describe('bitbucketServer core', () => {
         'https://bitbucket.mycompany.net/rest/api/1.0/projects/a/repos/b/raw/path/to/c.yaml?at=',
       );
     });
+
+    it('encodes branch refs containing special characters in the at query parameter', () => {
+      const config: BitbucketServerIntegrationConfig = {
+        host: 'bitbucket.mycompany.net',
+        apiBaseUrl: 'https://bitbucket.mycompany.net/rest/api/1.0',
+      };
+      const base = 'https://bitbucket.mycompany.net/projects/a/repos/b/browse';
+      const apiBase =
+        'https://bitbucket.mycompany.net/rest/api/1.0/projects/a/repos/b/raw';
+
+      // An ampersand must not open a second query parameter, and a plus must
+      // not be decoded as a space by the server.
+      expect(
+        getBitbucketServerFileFetchUrl(`${base}/c.yaml?at=foo%26bar`, config),
+      ).toEqual(`${apiBase}/c.yaml?at=foo%26bar`);
+      expect(
+        getBitbucketServerFileFetchUrl(`${base}/c.yaml?at=foo%2Bbar`, config),
+      ).toEqual(`${apiBase}/c.yaml?at=foo%2Bbar`);
+      expect(
+        getBitbucketServerFileFetchUrl(`${base}/c.yaml?at=my%20branch`, config),
+      ).toEqual(`${apiBase}/c.yaml?at=my%20branch`);
+      // A slash-bearing ref is normalized rather than double-encoded.
+      expect(
+        getBitbucketServerFileFetchUrl(
+          `${base}/c.yaml?at=release%2Fv1`,
+          config,
+        ),
+      ).toEqual(`${apiBase}/c.yaml?at=release%2Fv1`);
+    });
   });
 
   describe('getBitbucketServerDownloadUrl', () => {
@@ -176,6 +205,33 @@ describe('bitbucketServer core', () => {
       );
       expect(result).toEqual(
         'https://api.bitbucket.mycompany.net/rest/api/1.0/projects/backstage/repos/mock/archive?format=tgz&at=some-branch&prefix=backstage-mock&path=docs',
+      );
+    });
+
+    it('encodes branch refs containing special characters in the at query parameter', async () => {
+      const config: BitbucketServerIntegrationConfig = {
+        host: 'bitbucket.mycompany.net',
+        apiBaseUrl: 'https://api.bitbucket.mycompany.net/rest/api/1.0',
+      };
+      const base =
+        'https://bitbucket.mycompany.net/projects/backstage/repos/mock/browse/docs';
+      const apiBase =
+        'https://api.bitbucket.mycompany.net/rest/api/1.0/projects/backstage/repos/mock/archive';
+
+      await expect(
+        getBitbucketServerDownloadUrl(`${base}?at=foo%26bar`, config),
+      ).resolves.toEqual(
+        `${apiBase}?format=tgz&at=foo%26bar&prefix=backstage-mock&path=docs`,
+      );
+      await expect(
+        getBitbucketServerDownloadUrl(`${base}?at=foo%2Bbar`, config),
+      ).resolves.toEqual(
+        `${apiBase}?format=tgz&at=foo%2Bbar&prefix=backstage-mock&path=docs`,
+      );
+      await expect(
+        getBitbucketServerDownloadUrl(`${base}?at=release%2Fv1`, config),
+      ).resolves.toEqual(
+        `${apiBase}?format=tgz&at=release%2Fv1&prefix=backstage-mock&path=docs`,
       );
     });
   });

--- a/packages/integration/src/bitbucketServer/core.ts
+++ b/packages/integration/src/bitbucketServer/core.ts
@@ -92,7 +92,7 @@ export async function getBitbucketServerDownloadUrl(
   const path = filepath
     ? `&path=${encodeURIComponent(decodeURIComponent(filepath))}`
     : '';
-  const at = encodeURIComponent(decodeURIComponent(branch));
+  const at = encodeURIComponent(branch);
   return `${config.apiBaseUrl}/projects/${project}/repos/${repoName}/archive?format=tgz&at=${at}&prefix=${project}-${repoName}${path}`;
 }
 

--- a/packages/integration/src/bitbucketServer/core.ts
+++ b/packages/integration/src/bitbucketServer/core.ts
@@ -89,11 +89,17 @@ export async function getBitbucketServerDownloadUrl(
   // path will limit the downloaded content
   // /docs will only download the docs folder and everything below it
   // /docs/index.md will download the docs folder and everything below it
-  const path = filepath
-    ? `&path=${encodeURIComponent(decodeURIComponent(filepath))}`
-    : '';
-  const at = encodeURIComponent(branch);
-  return `${config.apiBaseUrl}/projects/${project}/repos/${repoName}/archive?format=tgz&at=${at}&prefix=${project}-${repoName}${path}`;
+  const query = new URLSearchParams({
+    format: 'tgz',
+    at: branch,
+    prefix: `${project}-${repoName}`,
+  });
+  if (filepath) {
+    query.append('path', decodeURIComponent(filepath));
+  }
+  return `${
+    config.apiBaseUrl
+  }/projects/${project}/repos/${repoName}/archive?${query.toString()}`;
 }
 
 /**
@@ -127,8 +133,10 @@ export function getBitbucketServerFileFetchUrl(
     }
 
     const pathWithoutSlash = filepath.replace(/^\//, '');
-    const at = encodeURIComponent(decodeURIComponent(ref));
-    return `${config.apiBaseUrl}/projects/${owner}/repos/${name}/raw/${pathWithoutSlash}?at=${at}`;
+    const query = new URLSearchParams({ at: ref });
+    return `${
+      config.apiBaseUrl
+    }/projects/${owner}/repos/${name}/raw/${pathWithoutSlash}?${query.toString()}`;
   } catch (e) {
     throw new Error(`Incorrect URL: ${url}, ${e}`);
   }

--- a/packages/integration/src/bitbucketServer/core.ts
+++ b/packages/integration/src/bitbucketServer/core.ts
@@ -92,7 +92,8 @@ export async function getBitbucketServerDownloadUrl(
   const path = filepath
     ? `&path=${encodeURIComponent(decodeURIComponent(filepath))}`
     : '';
-  return `${config.apiBaseUrl}/projects/${project}/repos/${repoName}/archive?format=tgz&at=${branch}&prefix=${project}-${repoName}${path}`;
+  const at = encodeURIComponent(decodeURIComponent(branch));
+  return `${config.apiBaseUrl}/projects/${project}/repos/${repoName}/archive?format=tgz&at=${at}&prefix=${project}-${repoName}${path}`;
 }
 
 /**
@@ -126,7 +127,8 @@ export function getBitbucketServerFileFetchUrl(
     }
 
     const pathWithoutSlash = filepath.replace(/^\//, '');
-    return `${config.apiBaseUrl}/projects/${owner}/repos/${name}/raw/${pathWithoutSlash}?at=${ref}`;
+    const at = encodeURIComponent(decodeURIComponent(ref));
+    return `${config.apiBaseUrl}/projects/${owner}/repos/${name}/raw/${pathWithoutSlash}?at=${at}`;
   } catch (e) {
     throw new Error(`Incorrect URL: ${url}, ${e}`);
   }


### PR DESCRIPTION
Reading or downloading files from Bitbucket Server could fail when the branch/ref name contained URL-reserved characters. The `at` query parameter was built by interpolating the ref directly into the URL, while the file path was already normalized. A ref such as `foo&bar` opened a stray query parameter (truncating the ref) and `foo+bar` was decoded server-side as a space. The ref is now normalized with the same decode-then-encode round-trip already used for the file path, so it survives transport intact. This mirrors the existing handling for other integrations.

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))