### PR TITLE
fix(integration): url-encode the branch ref in GitLab file fetch URLs

### DIFF
--- a/.changeset/gitlab-branch-ref-encoding.md
+++ b/.changeset/gitlab-branch-ref-encoding.md
@@ -1,0 +1,5 @@
+---
+'@backstage/integration': patch
+---
+
+Fixed an issue where reading files from GitLab could fail when the branch name contained special characters such as an ampersand or a plus sign. The branch name is now correctly encoded in the request URL.

--- a/packages/integration/src/gitlab/core.test.ts
+++ b/packages/integration/src/gitlab/core.test.ts
@@ -170,6 +170,48 @@ describe('gitlab core', () => {
         ).resolves.toBe(fetchUrl);
       });
     });
+
+    describe('when the branch name contains special characters', () => {
+      it('encodes a branch containing an ampersand so it is not split into another query parameter', async () => {
+        const target =
+          'https://gitlab.com/group/project/-/blob/foo&bar/folder/file.yaml';
+        const fetchUrl =
+          'https://gitlab.com/api/v4/projects/group%2Fproject/repository/files/folder%2Ffile.yaml/raw?ref=foo%26bar';
+        await expect(
+          getGitLabFileFetchUrl(target, configWithNoToken),
+        ).resolves.toBe(fetchUrl);
+      });
+
+      it('encodes a branch containing a plus sign so it is not decoded as a space', async () => {
+        const target =
+          'https://gitlab.com/group/project/-/blob/foo+bar/folder/file.yaml';
+        const fetchUrl =
+          'https://gitlab.com/api/v4/projects/group%2Fproject/repository/files/folder%2Ffile.yaml/raw?ref=foo%2Bbar';
+        await expect(
+          getGitLabFileFetchUrl(target, configWithNoToken),
+        ).resolves.toBe(fetchUrl);
+      });
+
+      it('encodes a branch containing a space', async () => {
+        const target =
+          'https://gitlab.com/group/project/-/blob/my branch/folder/file.yaml';
+        const fetchUrl =
+          'https://gitlab.com/api/v4/projects/group%2Fproject/repository/files/folder%2Ffile.yaml/raw?ref=my%20branch';
+        await expect(
+          getGitLabFileFetchUrl(target, configWithNoToken),
+        ).resolves.toBe(fetchUrl);
+      });
+
+      it('leaves an already-encoded branch name intact', async () => {
+        const target =
+          'https://gitlab.com/group/project/-/blob/release%2Fv1/folder/file.yaml';
+        const fetchUrl =
+          'https://gitlab.com/api/v4/projects/group%2Fproject/repository/files/folder%2Ffile.yaml/raw?ref=release%2Fv1';
+        await expect(
+          getGitLabFileFetchUrl(target, configWithNoToken),
+        ).resolves.toBe(fetchUrl);
+      });
+    });
   });
 
   describe('extractProjectPath', () => {

--- a/packages/integration/src/gitlab/core.ts
+++ b/packages/integration/src/gitlab/core.ts
@@ -101,7 +101,7 @@ function buildProjectUrl(
       'raw',
     ].join('/');
 
-    url.search = `?ref=${branch}`;
+    url.search = `?ref=${encodeURIComponent(decodeURIComponent(branch))}`;
 
     return url;
   } catch (e) {


### PR DESCRIPTION
Fixes a URL-encoding bug in `@backstage/integration` when reading files from GitLab.

`getGitLabFileFetchUrl` already encodes the project path and file path, but the branch/ref was interpolated into the query string unencoded. A branch name containing a URL-reserved character produced a malformed request:

- `foo&bar` → `?ref=foo&bar`, where `&bar` becomes a stray query parameter and the ref silently truncates to `foo`
- `foo+bar` → the server decodes `+` as a space, so GitLab sees `foo bar`

The branch is now normalized with the same decode-then-encode round-trip already used for the file path, so already-encoded and raw branch names both resolve correctly. Ordinary branch names are unaffected, and there is no public API change.

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
